### PR TITLE
feat: amortized MLP encoder for link community model

### DIFF
--- a/pinto/src/edge_profiles.rs
+++ b/pinto/src/edge_profiles.rs
@@ -248,6 +248,33 @@ pub fn build_edge_profiles(
     Ok(LinkProfileStore::new(profiles, n_edges, m))
 }
 
+/// Map fine edges to canonical super-edges defined by cell cluster labels.
+///
+/// Each edge (i, j) is mapped to (min(label[i], label[j]), max(...)).
+/// Returns (super_edges list, fine_to_super mapping).
+pub fn build_super_edges(
+    edges: &[(usize, usize)],
+    cell_labels: &[usize],
+) -> (Vec<(usize, usize)>, Vec<usize>) {
+    let mut key_to_super: HashMap<(usize, usize), usize> = HashMap::new();
+    let mut super_edges: Vec<(usize, usize)> = Vec::new();
+    let mut fine_to_super = Vec::with_capacity(edges.len());
+
+    for &(i, j) in edges {
+        let li = cell_labels[i];
+        let lj = cell_labels[j];
+        let key = (li.min(lj), li.max(lj));
+        let se = *key_to_super.entry(key).or_insert_with(|| {
+            let s = super_edges.len();
+            super_edges.push(key);
+            s
+        });
+        fine_to_super.push(se);
+    }
+
+    (super_edges, fine_to_super)
+}
+
 /// Coarsen link profiles by cell-level cluster labels.
 ///
 /// Each edge (i, j) maps to a super-edge key (min(label[i], label[j]), max(...)).
@@ -262,24 +289,8 @@ pub fn coarsen_edge_profiles(
     let m = profiles.m;
     let n_edges = edges.len();
 
-    // Map each edge to a canonical super-edge key
-    let mut key_to_super: HashMap<(usize, usize), usize> = HashMap::new();
-    let mut next_super = 0usize;
-    let mut fine_to_super = Vec::with_capacity(n_edges);
-
-    for &(i, j) in edges {
-        let li = cell_labels[i];
-        let lj = cell_labels[j];
-        let key = (li.min(lj), li.max(lj));
-        let se = *key_to_super.entry(key).or_insert_with(|| {
-            let s = next_super;
-            next_super += 1;
-            s
-        });
-        fine_to_super.push(se);
-    }
-
-    let n_super = next_super;
+    let (super_edges, fine_to_super) = build_super_edges(edges, cell_labels);
+    let n_super = super_edges.len();
     let mut super_profiles = vec![0.0f32; n_super * m];
 
     // Accumulate fine link profiles into super-link profiles

--- a/pinto/src/fit_srt_gene_pair_link_community.rs
+++ b/pinto/src/fit_srt_gene_pair_link_community.rs
@@ -10,8 +10,9 @@ use crate::edge_profiles::*;
 use crate::fit_srt_link_community::{
     link_community_histogram, write_link_communities, write_score_trace,
 };
+use crate::link_community_encoder::LinkCommunityEncoder;
 use crate::link_community_gibbs::{ComponentGibbsArgs, LinkGibbsSampler};
-use crate::link_community_model::{LinkCommunityStats, LinkProfileStore};
+use crate::link_community_model::{LinkCommunityClassifier, LinkCommunityStats, LinkProfileStore};
 use crate::srt_cell_pairs::*;
 use crate::srt_common::*;
 use crate::srt_estimate_batch_effects::{estimate_and_write_batch_effects, EstimateBatchArgs};
@@ -42,9 +43,9 @@ pub struct SrtGenePairLinkCommunityArgs {
     #[arg(
         long,
         default_value_t = 100,
-        help = "Gibbs sampling sweeps per coarsening level"
+        help = "Gibbs iterations at the coarsest level"
     )]
-    num_sweeps: usize,
+    num_gibbs: usize,
 
     #[arg(
         long,
@@ -52,6 +53,25 @@ pub struct SrtGenePairLinkCommunityArgs {
         help = "Max greedy refinement sweeps after Gibbs"
     )]
     num_greedy: usize,
+
+    #[arg(
+        long,
+        help = "EM Gibbs sweeps on full edge set after encoder prediction (0 = skip)"
+    )]
+    num_em: Option<usize>,
+
+    #[arg(
+        long,
+        default_value_t = 100,
+        help = "Encoder training epochs at coarsest level"
+    )]
+    encoder_epochs: usize,
+
+    #[arg(long, default_value_t = 0.01, help = "Encoder learning rate")]
+    encoder_lr: f64,
+
+    #[arg(long, help = "Encoder hidden layer dimension (default = same as M)")]
+    encoder_hidden: Option<usize>,
 
     #[arg(
         long,
@@ -332,23 +352,7 @@ pub fn fit_srt_gene_pair_link_community(args: &SrtGenePairLinkCommunityArgs) -> 
     info!("Building COARSE gene-pair profiles at coarsest level...");
     let coarsest_labels = &ml.all_cell_labels[0];
 
-    // Build super-edges at coarsest level
-    let mut super_edge_map: HashMap<(usize, usize), usize> = HashMap::new();
-    let mut super_edges: Vec<(usize, usize)> = Vec::new();
-    let mut fine_to_super = Vec::with_capacity(n_edges);
-
-    for &(i, j) in edges {
-        let li = coarsest_labels[i];
-        let lj = coarsest_labels[j];
-        let key = (li.min(lj), li.max(lj));
-        let se = *super_edge_map.entry(key).or_insert_with(|| {
-            let s = super_edges.len();
-            super_edges.push(key);
-            s
-        });
-        fine_to_super.push(se);
-    }
-
+    let (super_edges, fine_to_super) = build_super_edges(edges, coarsest_labels);
     let n_super = super_edges.len();
     info!(
         "Coarsest level: {} super-edges from {} fine edges",
@@ -433,13 +437,11 @@ pub fn fit_srt_gene_pair_link_community(args: &SrtGenePairLinkCommunityArgs) -> 
     // 12. Gibbs on coarsest level
     let mut sampler = LinkGibbsSampler::new(SmallRng::seed_from_u64(c.seed));
 
-    // Random initial labels for coarsest
     let init_labels: Vec<usize> = (0..coarse_profiles.n_edges).map(|e| e % k).collect();
-
     let mut coarse_stats = LinkCommunityStats::from_profiles(&coarse_profiles, k, &init_labels);
 
-    info!("Gibbs on coarsest ({} sweeps)...", args.num_sweeps);
-    let moves = sampler.run_parallel(&mut coarse_stats, &coarse_profiles, a0, b0, args.num_sweeps);
+    info!("Gibbs on coarsest ({} sweeps)...", args.num_gibbs);
+    let moves = sampler.run_parallel(&mut coarse_stats, &coarse_profiles, a0, b0, args.num_gibbs);
     info!(
         "Coarsest Gibbs: {} total moves, score={:.2}",
         moves,
@@ -447,19 +449,95 @@ pub fn fit_srt_gene_pair_link_community(args: &SrtGenePairLinkCommunityArgs) -> 
     );
     score_trace.push(coarse_stats.total_score(a0, b0));
 
-    // Transfer to fine level
-    let mut current_labels = transfer_labels(&fine_to_super, &coarse_stats.membership);
+    // 12b. Progressive Gibbs + encoder training across all coarsening levels
+    let m_dim = coarse_profiles.m;
+    let num_levels = ml.all_cell_labels.len();
+    let hidden_dim = args.encoder_hidden.unwrap_or(m_dim);
+    let gibbs_per_level = (args.num_gibbs / 5).max(10);
 
-    // 13. Refinement on fine edges with full profile building
-    let num_fine_sweeps = (args.num_sweeps / 2).max(10);
-    info!("EM Gibbs on full edge set ({} sweeps)...", num_fine_sweeps);
+    let classifier = LinkCommunityClassifier::from_stats(&coarse_stats, a0, b0);
+    let mut encoder = LinkCommunityEncoder::from_classifier(&classifier, hidden_dim)?;
+    info!(
+        "Encoder: input={}, hidden={}, output={} ({} params)",
+        m_dim,
+        hidden_dim,
+        k,
+        m_dim * hidden_dim + hidden_dim + hidden_dim * k + k,
+    );
 
-    // Create profile builder closure
+    let loss = encoder.train(
+        &coarse_profiles,
+        &coarse_stats.membership,
+        args.encoder_epochs,
+        args.encoder_lr,
+    );
+    info!(
+        "Level 0: {} super-edges, encoder loss={:.4}",
+        coarse_profiles.n_edges, loss
+    );
+
+    // Profile builder for gene-pair profiles at any super-edge set
     let data_ref = &data_vec;
     let gene_adj_ref = &gene_adj;
     let gene_means_ref = &gene_means;
-    let edges_ref = edges;
     let n_gene_pairs_ref = final_n_gene_pairs;
+
+    let build_profiles_for_super_edges =
+        |super_edges: &[(usize, usize)]| -> anyhow::Result<LinkProfileStore> {
+            let mut store = build_edge_profiles_by_gene_pairs(
+                data_ref,
+                super_edges,
+                gene_adj_ref,
+                gene_means_ref,
+                n_gene_pairs_ref,
+                c.block_size,
+            )?;
+
+            if let Some(ref assignments) = module_collapse {
+                store = store.collapse_modules(assignments);
+            }
+
+            Ok(store)
+        };
+
+    for level in 1..num_levels {
+        let level_labels = &ml.all_cell_labels[level];
+        let (level_super_edges, _) = build_super_edges(edges, level_labels);
+        let n_level_super = level_super_edges.len();
+
+        let level_profiles = build_profiles_for_super_edges(&level_super_edges)?;
+
+        let level_membership = encoder.predict_labels(&level_profiles);
+        let mut level_stats =
+            LinkCommunityStats::from_profiles(&level_profiles, k, &level_membership);
+
+        let level_moves =
+            sampler.run_parallel(&mut level_stats, &level_profiles, a0, b0, gibbs_per_level);
+
+        let level_score = level_stats.total_score(a0, b0);
+        score_trace.push(level_score);
+
+        let level_lr = args.encoder_lr * (0.5_f64).powi(level as i32);
+        let level_epochs = (args.encoder_epochs / (level + 1)).max(10);
+
+        let level_classifier = LinkCommunityClassifier::from_stats(&level_stats, a0, b0);
+        encoder = LinkCommunityEncoder::from_classifier(&level_classifier, hidden_dim)?;
+
+        let level_loss = encoder.train(
+            &level_profiles,
+            &level_stats.membership,
+            level_epochs,
+            level_lr,
+        );
+
+        info!(
+            "Level {}: {} super-edges, {} Gibbs moves, score={:.2}, encoder({} epochs, lr={:.4}): loss={:.4}",
+            level, n_level_super, level_moves, level_score, level_epochs, level_lr, level_loss,
+        );
+    }
+
+    // 13. Build full fine profiles and predict with trained encoder
+    let edges_ref = edges;
 
     let profile_builder = |edge_indices: &[usize]| -> LinkProfileStore {
         let mut store = build_gene_pair_profiles_for_edges(
@@ -472,33 +550,13 @@ pub fn fit_srt_gene_pair_link_community(args: &SrtGenePairLinkCommunityArgs) -> 
         )
         .expect("profile build failed");
 
-        // Apply module collapse if needed
         if let Some(ref assignments) = module_collapse {
-            let n_edges = store.n_edges;
-            let n_modules = *assignments.iter().max().unwrap_or(&0) + 1;
-            let mut new_profiles = vec![0.0f32; n_edges * n_modules];
-            for e in 0..n_edges {
-                let profile = store.profile(e);
-                let base = e * n_modules;
-                for (p, &module) in assignments.iter().enumerate() {
-                    new_profiles[base + module] += profile[p];
-                }
-            }
-            store = LinkProfileStore::new(new_profiles, n_edges, n_modules);
+            store = store.collapse_modules(assignments);
         }
 
         store
     };
 
-    let comp_args = ComponentGibbsArgs {
-        graph: &srt_cell_pairs.graph,
-        edges,
-        k,
-        a0,
-        b0,
-    };
-
-    // Build all profiles upfront
     info!("Building full edge profiles...");
     let full_profiles = profile_builder(&(0..n_edges).collect::<Vec<_>>());
 
@@ -509,13 +567,42 @@ pub fn fit_srt_gene_pair_link_community(args: &SrtGenePairLinkCommunityArgs) -> 
         (full_profiles.profiles.len() * std::mem::size_of::<f32>()) as f64 / 1_048_576.0
     );
 
-    let moves = sampler.run_components_em(
-        &mut current_labels,
-        &full_profiles,
-        &comp_args,
-        num_fine_sweeps,
+    let mut current_labels = encoder.predict_labels(&full_profiles);
+
+    let transfer_labels_vec = transfer_labels(&fine_to_super, &coarse_stats.membership);
+    let n_differ = current_labels
+        .iter()
+        .zip(transfer_labels_vec.iter())
+        .filter(|(&a, &b)| a != b)
+        .count();
+    info!(
+        "Encoder vs transfer: {} / {} edges differ ({:.1}%)",
+        n_differ,
+        n_edges,
+        100.0 * n_differ as f64 / n_edges as f64,
     );
-    info!("EM Gibbs: {} moves", moves);
+
+    let comp_args = ComponentGibbsArgs {
+        graph: &srt_cell_pairs.graph,
+        edges,
+        k,
+        a0,
+        b0,
+    };
+
+    let num_fine_sweeps = args.num_em.unwrap_or((args.num_gibbs / 4).max(5));
+    if num_fine_sweeps > 0 {
+        info!("EM Gibbs on full edge set ({} sweeps)...", num_fine_sweeps);
+        let moves = sampler.run_components_em(
+            &mut current_labels,
+            &full_profiles,
+            &comp_args,
+            num_fine_sweeps,
+        );
+        info!("EM Gibbs: {} moves", moves);
+    } else {
+        info!("Skipping EM Gibbs (--num-em 0)");
+    }
 
     // Greedy finalization
     info!("Greedy finalization ({} max sweeps)...", args.num_greedy);

--- a/pinto/src/fit_srt_link_community.rs
+++ b/pinto/src/fit_srt_link_community.rs
@@ -5,8 +5,9 @@
 //! collapsed Gibbs sampling on gene-projected edge profiles.
 
 use crate::edge_profiles::*;
+use crate::link_community_encoder::LinkCommunityEncoder;
 use crate::link_community_gibbs::{ComponentGibbsArgs, LinkGibbsSampler};
-use crate::link_community_model::{LinkCommunityStats, LinkProfileStore};
+use crate::link_community_model::{LinkCommunityClassifier, LinkCommunityStats, LinkProfileStore};
 use crate::srt_cell_pairs::*;
 use crate::srt_common::*;
 use crate::srt_estimate_batch_effects::{estimate_and_write_batch_effects, EstimateBatchArgs};
@@ -61,12 +62,12 @@ pub struct SrtLinkCommunityArgs {
     #[arg(
         long,
         default_value_t = 100,
-        help = "Gibbs sampling sweeps per coarsening level",
-        long_help = "Number of Gibbs sweeps at each multi-level coarsening level.\n\
-                       The finest level uses num_sweeps/2 (minimum 10).\n\
-                       More sweeps improve convergence but take longer."
+        help = "Gibbs iterations at the coarsest level",
+        long_help = "Number of Gibbs iterations at the coarsest coarsening level.\n\
+                       The finest coarsening level uses num_gibbs/5 (minimum 10).\n\
+                       Full-resolution EM iterations are controlled by --num-em."
     )]
-    num_sweeps: usize,
+    num_gibbs: usize,
 
     #[arg(
         long,
@@ -77,6 +78,43 @@ pub struct SrtLinkCommunityArgs {
                        Stops early if no edges move. Typically converges in 2-5 sweeps."
     )]
     num_greedy: usize,
+
+    #[arg(
+        long,
+        help = "EM Gibbs sweeps on full edge set after encoder prediction",
+        long_help = "Number of EM Gibbs sweeps on full-resolution edges after\n\
+                       encoder initialization. Set to 0 to skip EM entirely and\n\
+                       use only greedy refinement (fastest). If omitted, defaults\n\
+                       to num_gibbs/4 (minimum 5)."
+    )]
+    num_em: Option<usize>,
+
+    #[arg(
+        long,
+        default_value_t = 100,
+        help = "Encoder training epochs at coarsest level",
+        long_help = "Number of AdamW epochs to train the MLP encoder at the coarsest\n\
+                       coarsening level. Decays as epochs/(level+1) at deeper levels."
+    )]
+    encoder_epochs: usize,
+
+    #[arg(
+        long,
+        default_value_t = 0.01,
+        help = "Encoder learning rate",
+        long_help = "AdamW learning rate for encoder training. The coarsest level\n\
+                       uses this value; decays as lr*0.5^level at deeper levels."
+    )]
+    encoder_lr: f64,
+
+    #[arg(
+        long,
+        help = "Encoder hidden layer dimension (default = same as M)",
+        long_help = "Hidden dimension of the MLP encoder. If omitted, uses M\n\
+                       (number of gene modules). Larger values increase capacity\n\
+                       but may overfit on small coarsening levels."
+    )]
+    encoder_hidden: Option<usize>,
 
     #[arg(
         long,
@@ -254,22 +292,7 @@ pub fn fit_srt_link_community(args: &SrtLinkCommunityArgs) -> anyhow::Result<()>
 
     // Build super-edges at coarsest level
     let coarsest_labels = &ml.all_cell_labels[0];
-    let mut super_edge_map: HashMap<(usize, usize), usize> = HashMap::new();
-    let mut super_edges: Vec<(usize, usize)> = Vec::new();
-    let mut fine_to_super = Vec::with_capacity(n_edges);
-
-    for &(i, j) in edges {
-        let li = coarsest_labels[i];
-        let lj = coarsest_labels[j];
-        let key = (li.min(lj), li.max(lj));
-        let se = *super_edge_map.entry(key).or_insert_with(|| {
-            let s = super_edges.len();
-            super_edges.push(key);
-            s
-        });
-        fine_to_super.push(se);
-    }
-
+    let (super_edges, fine_to_super) = build_super_edges(edges, coarsest_labels);
     let n_super = super_edges.len();
     info!(
         "Coarsest level: {} super-edges from {} fine edges",
@@ -339,14 +362,13 @@ pub fn fit_srt_link_community(args: &SrtLinkCommunityArgs) -> anyhow::Result<()>
 
     // 7. Gibbs on coarsest level
     let mut sampler = LinkGibbsSampler::new(SmallRng::seed_from_u64(c.seed));
-
     // Random initial labels for coarsest
     let init_labels: Vec<usize> = (0..coarse_profiles.n_edges).map(|e| e % k).collect();
 
     let mut coarse_stats = LinkCommunityStats::from_profiles(&coarse_profiles, k, &init_labels);
 
-    info!("Gibbs on coarsest ({} sweeps)...", args.num_sweeps);
-    let moves = sampler.run_parallel(&mut coarse_stats, &coarse_profiles, a0, b0, args.num_sweeps);
+    info!("Gibbs on coarsest ({} sweeps)...", args.num_gibbs);
+    let moves = sampler.run_parallel(&mut coarse_stats, &coarse_profiles, a0, b0, args.num_gibbs);
     info!(
         "Coarsest Gibbs: {} total moves, score={:.2}",
         moves,
@@ -354,21 +376,89 @@ pub fn fit_srt_link_community(args: &SrtLinkCommunityArgs) -> anyhow::Result<()>
     );
     score_trace.push(coarse_stats.total_score(a0, b0));
 
-    // Transfer to fine level
-    let mut current_labels = transfer_labels(&fine_to_super, &coarse_stats.membership);
+    // 7b. Progressive Gibbs + encoder training across all coarsening levels
+    let m_dim = coarse_profiles.m;
+    let num_levels = ml.all_cell_labels.len();
+    let hidden_dim = args.encoder_hidden.unwrap_or(m_dim);
+    let gibbs_per_level = (args.num_gibbs / 5).max(10);
 
-    // 8. Refinement on fine edges with full profile building
-    let num_fine_sweeps = (args.num_sweeps / 2).max(10);
-    info!("EM Gibbs on full edge set ({} sweeps)...", num_fine_sweeps);
+    // Initialize encoder from coarsest-level analytic classifier
+    let classifier = LinkCommunityClassifier::from_stats(&coarse_stats, a0, b0);
+    let mut encoder = LinkCommunityEncoder::from_classifier(&classifier, hidden_dim)?;
+    info!(
+        "Encoder: input={}, hidden={}, output={} ({} params)",
+        m_dim,
+        hidden_dim,
+        k,
+        m_dim * hidden_dim + hidden_dim + hidden_dim * k + k,
+    );
 
-    // Create profile builder closure
+    // Train encoder on coarsest Gibbs output
+    let loss = encoder.train(
+        &coarse_profiles,
+        &coarse_stats.membership,
+        args.encoder_epochs,
+        args.encoder_lr,
+    );
+    info!(
+        "Level 0: {} super-edges, encoder loss={:.4}",
+        coarse_profiles.n_edges, loss,
+    );
+
+    // Iterate through all remaining coarsening levels (1 .. num_levels-1)
+    for level in 1..num_levels {
+        let level_labels = &ml.all_cell_labels[level];
+        let (level_super_edges, _) = build_super_edges(edges, level_labels);
+        let n_level_super = level_super_edges.len();
+
+        // Build profiles
+        let level_profiles = if let Some(ref g2m) = gene_to_module {
+            build_edge_profiles_by_module(&data_vec, &level_super_edges, g2m, m_dim, c.block_size)?
+        } else {
+            let basis_ref = proj_basis.as_ref().expect("basis missing");
+            build_edge_profiles(&data_vec, &level_super_edges, basis_ref, None, c.block_size)?
+        };
+
+        // Predict labels using current encoder
+        let level_membership = encoder.predict_labels(&level_profiles);
+
+        // Corrective Gibbs
+        let mut level_stats =
+            LinkCommunityStats::from_profiles(&level_profiles, k, &level_membership);
+
+        let level_moves =
+            sampler.run_parallel(&mut level_stats, &level_profiles, a0, b0, gibbs_per_level);
+
+        let level_score = level_stats.total_score(a0, b0);
+        score_trace.push(level_score);
+
+        // Re-warm-start encoder from this level's analytic classifier, then train
+        let level_lr = args.encoder_lr * (0.5_f64).powi(level as i32);
+        let level_epochs = (args.encoder_epochs / (level + 1)).max(10);
+
+        let level_classifier = LinkCommunityClassifier::from_stats(&level_stats, a0, b0);
+        encoder = LinkCommunityEncoder::from_classifier(&level_classifier, hidden_dim)?;
+
+        let level_loss = encoder.train(
+            &level_profiles,
+            &level_stats.membership,
+            level_epochs,
+            level_lr,
+        );
+
+        info!(
+            "Level {}: {} super-edges, {} Gibbs moves, score={:.2}, encoder({} epochs, lr={:.4}): loss={:.4}",
+            level, n_level_super, level_moves, level_score, level_epochs, level_lr, level_loss,
+        );
+    }
+
+    // 8. Build full fine profiles and predict with trained encoder
     let data_ref = &data_vec;
     let edges_ref = edges;
-    let m_ref = coarse_profiles.m;
 
     let profile_builder = |edge_indices: &[usize]| -> LinkProfileStore {
         if let Some(ref g2m) = gene_to_module {
-            build_module_profiles_for_edges(data_ref, edge_indices, edges_ref, g2m, m_ref)
+            build_module_profiles_for_edges(data_ref, edge_indices, edges_ref, g2m, m_dim)
                 .expect("module profile build failed")
         } else {
             let basis_ref = proj_basis.as_ref().expect("basis missing");
@@ -377,15 +467,6 @@ pub fn fit_srt_link_community(args: &SrtLinkCommunityArgs) -> anyhow::Result<()>
         }
     };
 
-    let comp_args = ComponentGibbsArgs {
-        graph: &srt_cell_pairs.graph,
-        edges,
-        k,
-        a0,
-        b0,
-    };
-
-    // Build all profiles upfront
     info!("Building full edge profiles...");
     let full_profiles = profile_builder(&(0..n_edges).collect::<Vec<_>>());
 
@@ -396,13 +477,45 @@ pub fn fit_srt_link_community(args: &SrtLinkCommunityArgs) -> anyhow::Result<()>
         (full_profiles.profiles.len() * std::mem::size_of::<f32>()) as f64 / 1_048_576.0
     );
 
-    let moves = sampler.run_components_em(
-        &mut current_labels,
-        &full_profiles,
-        &comp_args,
-        num_fine_sweeps,
+    // Predict fine labels using trained encoder
+    let mut current_labels = encoder.predict_labels(&full_profiles);
+
+    // Compare encoder vs transfer predictions
+    let transfer_labels_vec = transfer_labels(&fine_to_super, &coarse_stats.membership);
+    let n_differ = current_labels
+        .iter()
+        .zip(transfer_labels_vec.iter())
+        .filter(|(&a, &b)| a != b)
+        .count();
+    info!(
+        "Encoder vs transfer: {} / {} edges differ ({:.1}%)",
+        n_differ,
+        n_edges,
+        100.0 * n_differ as f64 / n_edges as f64,
     );
-    info!("EM Gibbs: {} moves", moves);
+
+    let comp_args = ComponentGibbsArgs {
+        graph: &srt_cell_pairs.graph,
+        edges,
+        k,
+        a0,
+        b0,
+    };
+
+    // Optional EM refinement
+    let num_fine_sweeps = args.num_em.unwrap_or((args.num_gibbs / 4).max(5));
+    if num_fine_sweeps > 0 {
+        info!("EM Gibbs on full edge set ({} sweeps)...", num_fine_sweeps);
+        let moves = sampler.run_components_em(
+            &mut current_labels,
+            &full_profiles,
+            &comp_args,
+            num_fine_sweeps,
+        );
+        info!("EM Gibbs: {} moves", moves);
+    } else {
+        info!("Skipping EM Gibbs (--num-em 0)");
+    }
 
     // Greedy finalization
     info!("Greedy finalization ({} max sweeps)...", args.num_greedy);

--- a/pinto/src/link_community_encoder.rs
+++ b/pinto/src/link_community_encoder.rs
@@ -1,0 +1,321 @@
+#![allow(dead_code)]
+#![allow(clippy::needless_range_loop)]
+//! Trainable amortized encoder for link community assignments.
+//!
+//! A 1-hidden-layer MLP trained on Gibbs outputs at each coarsening level,
+//! implemented with candle for autograd.
+//!
+//! Architecture:
+//!   input: y / s (size-factor-normalized profile, M dims)
+//!   hidden: ReLU(W1 · input + b1)     [H dims]
+//!   output: softmax(W2 · hidden + b2) [K dims]
+
+use crate::link_community_model::{LinkCommunityClassifier, LinkProfileStore};
+use candle_util::candle_core::{DType, Device, Tensor, Var};
+use candle_util::candle_nn::{
+    self, linear, Activation, Linear, Module, Optimizer, VarBuilder, VarMap,
+};
+
+/// Trainable MLP encoder for link community prediction.
+pub struct LinkCommunityEncoder {
+    /// candle variable map (owns parameters).
+    varmap: VarMap,
+    /// First linear layer (M → H).
+    layer1: Linear,
+    /// Second linear layer (H → K).
+    layer2: Linear,
+    /// Input dimension.
+    m: usize,
+    /// Hidden dimension.
+    h: usize,
+    /// Output dimension.
+    k: usize,
+    /// Device (CPU).
+    device: Device,
+}
+
+impl LinkCommunityEncoder {
+    /// Create with random initialization.
+    pub fn new(m: usize, hidden_dim: usize, k: usize) -> candle_util::candle_core::Result<Self> {
+        let device = Device::Cpu;
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+
+        let layer1 = linear(m, hidden_dim, vb.pp("layer1"))?;
+        let layer2 = linear(hidden_dim, k, vb.pp("layer2"))?;
+
+        Ok(LinkCommunityEncoder {
+            varmap,
+            layer1,
+            layer2,
+            m,
+            h: hidden_dim,
+            k,
+            device,
+        })
+    }
+
+    /// Initialize from the analytic classifier (warm start).
+    ///
+    /// Sets layer1 to identity-like pass-through and layer2 to log-rates,
+    /// so the MLP starts close to the linear classifier's predictions.
+    pub fn from_classifier(
+        classifier: &LinkCommunityClassifier,
+        hidden_dim: usize,
+    ) -> candle_util::candle_core::Result<Self> {
+        let m = classifier.m;
+        let k = classifier.k;
+        let h = hidden_dim;
+        let device = Device::Cpu;
+
+        // Build W1 [H × M]: identity-like for first min(H,M) units
+        let mut w1_data = vec![0.0f32; h * m];
+        for i in 0..h.min(m) {
+            w1_data[i * m + i] = 1.0;
+        }
+        let w1_tensor = Tensor::from_vec(w1_data, (h, m), &device)?;
+        let b1_tensor = Tensor::zeros((h,), DType::F32, &device)?;
+
+        // Build W2 [K × H]: log-rates from classifier
+        let mut w2_data = vec![0.0f32; k * h];
+        for c in 0..k {
+            for j in 0..h {
+                if j < m {
+                    w2_data[c * h + j] = classifier.log_rates[c * m + j] as f32;
+                }
+            }
+        }
+        let w2_tensor = Tensor::from_vec(w2_data, (k, h), &device)?;
+
+        // b2 [K]: log_prior - rate_totals
+        let b2_data: Vec<f32> = (0..k)
+            .map(|c| (classifier.log_prior[c] - classifier.rate_totals[c]) as f32)
+            .collect();
+        let b2_tensor = Tensor::from_vec(b2_data, (k,), &device)?;
+
+        // Create VarMap with our tensors
+        let varmap = VarMap::new();
+        {
+            let mut data = varmap.data().lock().unwrap();
+            data.insert("layer1.weight".to_string(), Var::from_tensor(&w1_tensor)?);
+            data.insert("layer1.bias".to_string(), Var::from_tensor(&b1_tensor)?);
+            data.insert("layer2.weight".to_string(), Var::from_tensor(&w2_tensor)?);
+            data.insert("layer2.bias".to_string(), Var::from_tensor(&b2_tensor)?);
+        }
+
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        let layer1 = linear(m, h, vb.pp("layer1"))?;
+        let layer2 = linear(h, k, vb.pp("layer2"))?;
+
+        Ok(LinkCommunityEncoder {
+            varmap,
+            layer1,
+            layer2,
+            m,
+            h,
+            k,
+            device,
+        })
+    }
+
+    /// Forward pass: profiles [N × M] → logits [N × K].
+    fn forward(&self, x: &Tensor) -> candle_util::candle_core::Result<Tensor> {
+        let h = self.layer1.forward(x)?;
+        let h = Activation::Relu.forward(&h)?;
+        self.layer2.forward(&h)
+    }
+
+    /// Build log1p-normalized input tensor [N × M] from profiles.
+    ///
+    /// Applies log1p(y_g / s_e) to compress dynamic range.
+    fn build_input_tensor(&self, profiles: &LinkProfileStore) -> Tensor {
+        let n = profiles.n_edges;
+        let m = profiles.m;
+        let mut input = vec![0.0f32; n * m];
+        for e in 0..n {
+            let sf_inv = if profiles.size_factors[e] > 0.0 {
+                1.0 / profiles.size_factors[e]
+            } else {
+                1.0
+            };
+            let row = profiles.profile(e);
+            let base = e * m;
+            for g in 0..m {
+                input[base + g] = (row[g] * sf_inv).ln_1p();
+            }
+        }
+        Tensor::from_vec(input, (n, m), &self.device).unwrap()
+    }
+
+    /// Predict community assignments for all edges, batched.
+    pub fn predict_labels(&self, profiles: &LinkProfileStore) -> Vec<usize> {
+        let x = self.build_input_tensor(profiles);
+        let logits = self.forward(&x).unwrap();
+        let argmax = logits.argmax(1).unwrap();
+        let labels: Vec<u32> = argmax.to_vec1().unwrap();
+        labels.iter().map(|&l| l as usize).collect()
+    }
+
+    /// Train the encoder on edge profiles with hard labels from Gibbs.
+    ///
+    /// Uses Adam optimizer with cross-entropy loss (full-batch).
+    /// Returns the final average loss.
+    pub fn train(
+        &mut self,
+        profiles: &LinkProfileStore,
+        labels: &[usize],
+        epochs: usize,
+        lr: f64,
+    ) -> f64 {
+        let n = profiles.n_edges;
+        debug_assert_eq!(labels.len(), n);
+
+        let x = self.build_input_tensor(profiles);
+        let target: Vec<u32> = labels.iter().map(|&l| l as u32).collect();
+        let target = Tensor::from_vec(target, (n,), &self.device).unwrap();
+
+        let mut opt = candle_nn::AdamW::new_lr(self.varmap.all_vars(), lr).unwrap();
+
+        let mut final_loss = 0.0;
+
+        for _epoch in 0..epochs {
+            let logits = self.forward(&x).unwrap();
+            let log_probs = candle_nn::ops::log_softmax(&logits, 1).unwrap();
+            let loss = candle_nn::loss::nll(&log_probs, &target).unwrap();
+
+            final_loss = loss.to_scalar::<f32>().unwrap() as f64;
+            opt.backward_step(&loss).unwrap();
+        }
+
+        final_loss
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::link_community_model::LinkCommunityStats;
+
+    fn make_planted(n_edges: usize, m: usize, k: usize) -> (LinkProfileStore, Vec<usize>) {
+        let mut profiles = vec![0.0f32; n_edges * m];
+        let mut labels = vec![0usize; n_edges];
+        for e in 0..n_edges {
+            let c = e % k;
+            labels[e] = c;
+            for g in 0..m {
+                let signal = if g % k == c { 10.0 } else { 1.0 };
+                profiles[e * m + g] = signal;
+            }
+        }
+        (LinkProfileStore::new(profiles, n_edges, m), labels)
+    }
+
+    #[test]
+    fn test_encoder_trains_on_planted() {
+        let k = 3;
+        let m = 9;
+        let n = 300;
+        let h = 16;
+
+        let (store, labels) = make_planted(n, m, k);
+        let mut encoder = LinkCommunityEncoder::new(m, h, k).unwrap();
+
+        let pred_before = encoder.predict_labels(&store);
+        let acc_before = pred_before
+            .iter()
+            .zip(labels.iter())
+            .filter(|(&p, &t)| p == t)
+            .count();
+
+        let loss = encoder.train(&store, &labels, 50, 0.01);
+
+        let pred_after = encoder.predict_labels(&store);
+        let acc_after = pred_after
+            .iter()
+            .zip(labels.iter())
+            .filter(|(&p, &t)| p == t)
+            .count();
+
+        assert!(
+            acc_after > acc_before || acc_before == n,
+            "Training should improve: before={}/{}, after={}/{}, loss={:.4}",
+            acc_before,
+            n,
+            acc_after,
+            n,
+            loss,
+        );
+        assert!(
+            acc_after >= n - 10,
+            "Should recover planted: {}/{}, loss={:.4}",
+            acc_after,
+            n,
+            loss,
+        );
+    }
+
+    #[test]
+    fn test_encoder_warm_start_from_classifier() {
+        let k = 3;
+        let m = 6;
+        let n = 60;
+        let h = 12;
+
+        let (store, labels) = make_planted(n, m, k);
+        let stats = LinkCommunityStats::from_profiles(&store, k, &labels);
+        let classifier = LinkCommunityClassifier::from_stats(&stats, 1.0, 1.0);
+
+        let encoder = LinkCommunityEncoder::from_classifier(&classifier, h).unwrap();
+        let pred = encoder.predict_labels(&store);
+        let acc = pred
+            .iter()
+            .zip(labels.iter())
+            .filter(|(&p, &t)| p == t)
+            .count();
+
+        assert_eq!(
+            acc, n,
+            "Warm-started encoder should match classifier: {}/{}",
+            acc, n
+        );
+    }
+
+    #[test]
+    fn test_encoder_generalizes_to_noisy() {
+        let k = 2;
+        let m = 8;
+        let n_train = 200;
+        let n_test = 100;
+        let h = 16;
+
+        let (train_store, train_labels) = make_planted(n_train, m, k);
+        let mut encoder = LinkCommunityEncoder::new(m, h, k).unwrap();
+        encoder.train(&train_store, &train_labels, 50, 0.01);
+
+        let mut test_profiles = vec![0.0f32; n_test * m];
+        let mut test_labels = vec![0usize; n_test];
+        for e in 0..n_test {
+            let c = e % k;
+            test_labels[e] = c;
+            for g in 0..m {
+                let signal = if g % k == c { 7.0 } else { 3.0 };
+                test_profiles[e * m + g] = signal;
+            }
+        }
+        let test_store = LinkProfileStore::new(test_profiles, n_test, m);
+
+        let pred = encoder.predict_labels(&test_store);
+        let acc = pred
+            .iter()
+            .zip(test_labels.iter())
+            .filter(|(&p, &t)| p == t)
+            .count();
+
+        assert!(
+            acc >= n_test - 5,
+            "Encoder should generalize: {}/{}",
+            acc,
+            n_test,
+        );
+    }
+}

--- a/pinto/src/link_community_model.rs
+++ b/pinto/src/link_community_model.rs
@@ -58,6 +58,24 @@ impl LinkProfileStore {
         }
         LinkProfileStore::new(profiles, n, m)
     }
+
+    /// Collapse columns by module assignment.
+    ///
+    /// Each column `p` is mapped to `assignments[p]`, and values are summed
+    /// within each module. Returns a new store with `n_modules` columns.
+    pub fn collapse_modules(&self, assignments: &[usize]) -> Self {
+        let n_modules = assignments.iter().copied().max().unwrap_or(0) + 1;
+        let n = self.n_edges;
+        let mut new_profiles = vec![0.0f32; n * n_modules];
+        for e in 0..n {
+            let row = self.profile(e);
+            let base = e * n_modules;
+            for (p, &module) in assignments.iter().enumerate() {
+                new_profiles[base + module] += row[p];
+            }
+        }
+        LinkProfileStore::new(new_profiles, n, n_modules)
+    }
 }
 
 /// Sufficient statistics for the link community model.
@@ -229,6 +247,114 @@ impl LinkCommunityStats {
             }
         }
         score
+    }
+}
+
+/// Amortized classifier for link community assignments.
+///
+/// Extracts posterior log-rates from converged sufficient statistics and
+/// predicts community assignments for new edge profiles via matrix multiply.
+///
+/// The collapsed Poisson-Gamma posterior gives rates:
+///   μ_{g,k} = (a0 + gene_sum[k,g]) / (b0 + size_sum[k])
+///
+/// The predictive log-probability for assigning edge e to community k is:
+///   log P(z_e = k | y_e) ≈ Σ_g y_e^g · log(μ_{g,k}) - s_e · Σ_g μ_{g,k} + log(n_k)
+///
+/// This is a linear classifier in the profile space, trained analytically
+/// from the Gibbs posterior — no gradient descent needed.
+pub struct LinkCommunityClassifier {
+    /// log(μ_{g,k}): [k × m] row-major.
+    pub log_rates: Vec<f64>,
+    /// Σ_g μ_{g,k} per community (rate totals for size-factor correction).
+    pub rate_totals: Vec<f64>,
+    /// log(edge_count[k]) per community (prior from empirical frequencies).
+    pub log_prior: Vec<f64>,
+    pub k: usize,
+    pub m: usize,
+}
+
+impl LinkCommunityClassifier {
+    /// Extract a classifier from converged sufficient statistics.
+    pub fn from_stats(stats: &LinkCommunityStats, a0: f64, b0: f64) -> Self {
+        let k = stats.k;
+        let m = stats.m;
+        let mut log_rates = vec![0.0f64; k * m];
+        let mut rate_totals = vec![0.0f64; k];
+
+        for c in 0..k {
+            let denom = b0 + stats.size_sum[c];
+            let base = c * m;
+            let mut rate_sum = 0.0f64;
+            for g in 0..m {
+                let mu = (a0 + stats.gene_sum[base + g]) / denom;
+                log_rates[base + g] = mu.ln();
+                rate_sum += mu;
+            }
+            rate_totals[c] = rate_sum;
+        }
+
+        // Empirical prior: log(edge_count + 1) to avoid -inf for empty communities
+        let log_prior: Vec<f64> = stats
+            .edge_count
+            .iter()
+            .map(|&n| ((n as f64) + 1.0).ln())
+            .collect();
+
+        LinkCommunityClassifier {
+            log_rates,
+            rate_totals,
+            log_prior,
+            k,
+            m,
+        }
+    }
+
+    /// Predict community assignment for a single edge profile.
+    ///
+    /// Returns the argmax community index.
+    #[inline]
+    pub fn predict_one(&self, profile: &[f32], size_factor: f32) -> usize {
+        let sf = size_factor as f64;
+        let mut best_k = 0;
+        let mut best_score = f64::NEG_INFINITY;
+        for c in 0..self.k {
+            let base = c * self.m;
+            let mut score = self.log_prior[c] - sf * self.rate_totals[c];
+            for g in 0..self.m {
+                score += profile[g] as f64 * self.log_rates[base + g];
+            }
+            if score > best_score {
+                best_score = score;
+                best_k = c;
+            }
+        }
+        best_k
+    }
+
+    /// Predict community assignments for all edges in a profile store.
+    ///
+    /// Returns a label vector of length `profiles.n_edges`.
+    pub fn predict_labels(&self, profiles: &LinkProfileStore) -> Vec<usize> {
+        (0..profiles.n_edges)
+            .map(|e| self.predict_one(profiles.profile(e), profiles.size_factors[e]))
+            .collect()
+    }
+
+    /// Predict community assignments in parallel using rayon.
+    pub fn predict_labels_parallel(&self, profiles: &LinkProfileStore) -> Vec<usize> {
+        use rayon::prelude::*;
+        let chunk_size = std::cmp::max(256, profiles.n_edges / rayon::current_num_threads().max(1));
+        let indices: Vec<usize> = (0..profiles.n_edges).collect();
+        indices
+            .par_chunks(chunk_size)
+            .flat_map(|chunk| {
+                chunk
+                    .iter()
+                    .map(|&e| self.predict_one(profiles.profile(e), profiles.size_factors[e]))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
     }
 }
 
@@ -460,5 +586,94 @@ mod tests {
         let store = LinkProfileStore::new(profiles, 2, 3);
         assert_eq!(store.size_factors[0], 6.0);
         assert_eq!(store.size_factors[1], 15.0);
+    }
+
+    #[test]
+    fn test_classifier_recovers_planted() {
+        // Create planted profiles: K=3 communities with distinct gene signatures
+        let k = 3;
+        let m = 6;
+        let n_edges = 60;
+
+        let (store, labels) = make_synthetic_profiles(n_edges, m, k);
+        let stats = LinkCommunityStats::from_profiles(&store, k, &labels);
+
+        let classifier = LinkCommunityClassifier::from_stats(&stats, 1.0, 1.0);
+        let predicted = classifier.predict_labels(&store);
+
+        // Classifier should recover the planted labels exactly
+        // (since it's trained on the same data)
+        assert_eq!(
+            predicted, labels,
+            "Classifier should recover planted labels exactly"
+        );
+    }
+
+    #[test]
+    fn test_classifier_generalizes() {
+        // Train classifier on one set of edges, test on another
+        let k = 2;
+        let m = 8;
+        let n_train = 100;
+        let n_test = 50;
+
+        // Training: planted profiles
+        let mut train_profiles = vec![0.0f32; n_train * m];
+        let mut train_labels = vec![0usize; n_train];
+        for e in 0..n_train {
+            let c = e % k;
+            train_labels[e] = c;
+            for g in 0..m {
+                let signal = if (g < m / 2) == (c == 0) { 10.0 } else { 1.0 };
+                train_profiles[e * m + g] = signal;
+            }
+        }
+        let train_store = LinkProfileStore::new(train_profiles, n_train, m);
+        let stats = LinkCommunityStats::from_profiles(&train_store, k, &train_labels);
+
+        let classifier = LinkCommunityClassifier::from_stats(&stats, 1.0, 1.0);
+
+        // Test: similar profiles with noise
+        let mut test_profiles = vec![0.0f32; n_test * m];
+        let mut test_labels = vec![0usize; n_test];
+        for e in 0..n_test {
+            let c = e % k;
+            test_labels[e] = c;
+            for g in 0..m {
+                let signal = if (g < m / 2) == (c == 0) { 8.0 } else { 2.0 };
+                test_profiles[e * m + g] = signal;
+            }
+        }
+        let test_store = LinkProfileStore::new(test_profiles, n_test, m);
+
+        let predicted = classifier.predict_labels(&test_store);
+        let correct: usize = predicted
+            .iter()
+            .zip(test_labels.iter())
+            .filter(|(&p, &t)| p == t)
+            .count();
+
+        assert!(
+            correct == n_test,
+            "Classifier should generalize to noisy test data: {}/{}",
+            correct,
+            n_test
+        );
+    }
+
+    #[test]
+    fn test_classifier_parallel_matches_sequential() {
+        let k = 3;
+        let m = 6;
+        let n_edges = 120;
+
+        let (store, labels) = make_synthetic_profiles(n_edges, m, k);
+        let stats = LinkCommunityStats::from_profiles(&store, k, &labels);
+        let classifier = LinkCommunityClassifier::from_stats(&stats, 1.0, 1.0);
+
+        let seq = classifier.predict_labels(&store);
+        let par = classifier.predict_labels_parallel(&store);
+
+        assert_eq!(seq, par, "Parallel predictions should match sequential");
     }
 }

--- a/pinto/src/main.rs
+++ b/pinto/src/main.rs
@@ -4,6 +4,7 @@ mod fit_srt_gene_pair_link_community;
 mod fit_srt_gene_pair_svd;
 mod fit_srt_link_community;
 mod fit_srt_propensity;
+mod link_community_encoder;
 mod link_community_gibbs;
 mod link_community_model;
 mod srt_cell_pairs;


### PR DESCRIPTION
## Summary
- Add candle-based MLP encoder trained progressively across coarsening levels to predict link community assignments, replacing naive label transfer
- Progressive pipeline: coarse Gibbs → encoder training at each coarsening level (predict → corrective Gibbs → retrain from analytic classifier) → encoder predicts fine edges → optional EM → greedy
- New CLI flags: `--num-gibbs`, `--num-em` (0 to skip EM), `--encoder-epochs`, `--encoder-lr`, `--encoder-hidden`
- Applied to both `link-community` and `gplc` subcommands
- Extract `build_super_edges()` helper and `collapse_modules()` method to deduplicate shared logic

**GBM Visium benchmark** (10k cells, 30k edges, K=20):

| Method | Time | Score |
|--------|------|-------|
| Baseline (transfer + 50 EM) | 26s | -1,946M |
| MLP all levels, no EM (`--num-em 0`) | **14s** | **-1,824M** |

## Test plan
- [x] All 21 link_community tests pass (model, gibbs, encoder)
- [x] Encoder recovers planted partitions, generalizes to noisy data, warm-start matches classifier
- [x] `cargo clippy` and `cargo fmt` clean
- [x] Benchmarked on temp_gbm Visium data with spatial visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)