### PR TITLE
feat(cnv,senna): cluster/topic-informed CNV detection pipeline

### DIFF
--- a/cnv/src/coarsening_tree.rs
+++ b/cnv/src/coarsening_tree.rs
@@ -1,0 +1,443 @@
+//! Multi-level coarsening tree for tree-structured CNV state inference.
+//!
+//! Builds a tree from multi-level genomic coarsening where:
+//! - Leaves = finest-level blocks
+//! - Internal nodes = coarser blocks (unions of finer blocks)
+//! - Parent-child relationships follow block containment
+//!
+//! Provides belief propagation (upward + downward) for state inference,
+//! replacing the chain HMM with approximate tree inference in O(nodes × K²).
+//! The downward pass uses the full parent marginal (no cavity correction),
+//! which slightly overestimates each child's influence on its parent.
+
+use log::info;
+use nalgebra::DMatrix;
+
+use crate::genomic_coarsening::{greedy_coarsen, GenomicCoarsening};
+
+// ---------------------------------------------------------------------------
+// Tree structure
+// ---------------------------------------------------------------------------
+
+/// A multi-level coarsening tree.
+#[derive(Debug, Clone)]
+pub struct CoarseningTree {
+    /// Coarsenings at each level (index 0 = finest, last = coarsest).
+    pub levels: Vec<GenomicCoarsening>,
+    /// Parent mapping: `parent_map[l][i]` = index of parent block at level `l+1`
+    /// for block `i` at level `l`. Length = n_levels - 1.
+    pub parent_map: Vec<Vec<usize>>,
+    /// Block-level aggregated signal at each level: `[n_blocks_l × n_samples]`.
+    pub block_signals: Vec<DMatrix<f32>>,
+    /// Chromosome boundaries at the finest block level (for output).
+    pub finest_chr_block_bounds: Vec<(usize, usize)>,
+}
+
+impl CoarseningTree {
+    /// Build a coarsening tree from genome-ordered signal at multiple thresholds.
+    ///
+    /// # Arguments
+    /// * `ordered_signal` — `[G_ordered × S]` log(mu_residual) in genome order
+    /// * `chr_bounds` — chromosome boundaries: `[(chr_name, start, end)]`
+    /// * `corr_thresholds` — correlation thresholds, **decreasing** (finest first).
+    ///   E.g., `[0.7, 0.4]` → level 0 at 0.7 (more blocks), level 1 at 0.4 (fewer blocks).
+    pub fn build(
+        ordered_signal: &DMatrix<f32>,
+        chr_bounds: &[(Box<str>, usize, usize)],
+        corr_thresholds: &[f32],
+    ) -> Self {
+        assert!(
+            !corr_thresholds.is_empty(),
+            "need at least one correlation threshold"
+        );
+
+        // Build coarsenings at each level
+        let mut levels = Vec::with_capacity(corr_thresholds.len());
+        let mut block_signals = Vec::with_capacity(corr_thresholds.len());
+
+        for &threshold in corr_thresholds {
+            let coarsening = greedy_coarsen(ordered_signal, chr_bounds, threshold);
+            let signal = coarsening.aggregate_to_blocks(ordered_signal);
+            block_signals.push(signal);
+            levels.push(coarsening);
+        }
+
+        // Build parent maps between consecutive levels
+        let mut parent_map = Vec::with_capacity(levels.len().saturating_sub(1));
+        for l in 0..levels.len().saturating_sub(1) {
+            let fine = &levels[l];
+            let coarse = &levels[l + 1];
+            let mapping = build_parent_mapping(fine, coarse);
+            parent_map.push(mapping);
+        }
+
+        let finest_chr_block_bounds = levels[0]
+            .chr_block_boundaries()
+            .iter()
+            .map(|(_, s, e)| (*s, *e))
+            .collect();
+
+        info!(
+            "Coarsening tree: {} levels, blocks = [{}]",
+            levels.len(),
+            levels
+                .iter()
+                .map(|l| l.num_blocks().to_string())
+                .collect::<Vec<_>>()
+                .join(" → "),
+        );
+
+        CoarseningTree {
+            levels,
+            parent_map,
+            block_signals,
+            finest_chr_block_bounds,
+        }
+    }
+
+    pub fn n_levels(&self) -> usize {
+        self.levels.len()
+    }
+
+    pub fn n_finest_blocks(&self) -> usize {
+        self.levels[0].num_blocks()
+    }
+
+    pub fn n_samples(&self) -> usize {
+        self.block_signals[0].ncols()
+    }
+
+    /// Children of block `parent_idx` at level `l+1`, returned as indices into level `l`.
+    pub fn children_of(&self, level_coarse: usize, parent_idx: usize) -> Vec<usize> {
+        if level_coarse == 0 {
+            return vec![];
+        }
+        let fine_level = level_coarse - 1;
+        self.parent_map[fine_level]
+            .iter()
+            .enumerate()
+            .filter(|(_, &p)| p == parent_idx)
+            .map(|(i, _)| i)
+            .collect()
+    }
+}
+
+/// Map each fine-level block to its parent coarse-level block.
+///
+/// A fine block `[start, end)` is contained in the coarse block whose range
+/// covers `start`. Since both levels are genome-ordered and non-overlapping,
+/// this is a simple sweep.
+fn build_parent_mapping(fine: &GenomicCoarsening, coarse: &GenomicCoarsening) -> Vec<usize> {
+    let mut mapping = Vec::with_capacity(fine.num_blocks());
+    let mut coarse_idx = 0;
+
+    for fine_block in &fine.blocks {
+        // Find the coarse block that contains this fine block's start
+        while coarse_idx < coarse.num_blocks() {
+            let cb = &coarse.blocks[coarse_idx];
+            if fine_block.start >= cb.start && fine_block.start < cb.end {
+                break;
+            }
+            coarse_idx += 1;
+        }
+        assert!(
+            coarse_idx < coarse.num_blocks(),
+            "fine block [{}, {}) not contained in any coarse block",
+            fine_block.start,
+            fine_block.end,
+        );
+        mapping.push(coarse_idx);
+        // Don't increment coarse_idx — next fine block might be in the same coarse block
+    }
+
+    mapping
+}
+
+// ---------------------------------------------------------------------------
+// Tree belief propagation for state inference
+// ---------------------------------------------------------------------------
+
+/// Result of tree state inference for one factor.
+pub struct TreeStateResult {
+    /// Posterior state probabilities at finest level: `[n_finest_blocks × K]`.
+    pub posteriors: DMatrix<f32>,
+    /// MAP state at each finest-level block.
+    pub map_states: Vec<usize>,
+}
+
+/// Run tree belief propagation for one factor.
+///
+/// Computes per-block per-state evidence, then propagates up and down the
+/// coarsening tree to get regularized posteriors at the finest level.
+///
+/// # Arguments
+/// * `tree` — the coarsening tree
+/// * `partial_residuals` — per-sample, per-block partial residual at finest level: `[B_finest × S]`
+/// * `loadings` — per-sample loading for this factor: length S
+/// * `emission_means` — per-state emission means: length K (neutral pinned at 0)
+/// * `sigma_sq` — noise variance
+/// * `transition_prob` — off-diagonal transition probability for parent→child
+pub fn tree_state_inference(
+    tree: &CoarseningTree,
+    partial_residuals: &DMatrix<f32>,
+    loadings: &[f32],
+    emission_means: &[f32],
+    sigma_sq: f32,
+    transition_prob: f32,
+) -> TreeStateResult {
+    let n_levels = tree.n_levels();
+    let k = emission_means.len();
+    let n_samples = loadings.len();
+
+    // --- Compute per-block per-state local log-evidence at each level ---
+    // evidence[l][b, k] = Σ_s Σ_{g ∈ block} log N(R[g,s]; L[s]*μ[k], σ²)
+    let inv_sigma_sq = 1.0 / sigma_sq;
+    let log_norm = -0.5 * (sigma_sq.ln() + std::f32::consts::TAU.ln());
+
+    // Finest level: compute from partial_residuals directly
+    let n_finest = tree.n_finest_blocks();
+    let mut finest_evidence = DMatrix::<f32>::zeros(n_finest, k);
+    for b in 0..n_finest {
+        for kk in 0..k {
+            let mut ll = 0.0f32;
+            for s in 0..n_samples {
+                let diff = partial_residuals[(b, s)] - loadings[s] * emission_means[kk];
+                ll += log_norm - 0.5 * diff * diff * inv_sigma_sq;
+            }
+            finest_evidence[(b, kk)] = ll;
+        }
+    }
+
+    if n_levels == 1 {
+        // Single level: no tree, just use local evidence
+        let (posteriors, map_states) = evidence_to_posteriors(&finest_evidence, k);
+        return TreeStateResult {
+            posteriors,
+            map_states,
+        };
+    }
+
+    // Coarser levels: aggregate from block_signals
+    let mut level_evidence: Vec<DMatrix<f32>> = Vec::with_capacity(n_levels);
+    level_evidence.push(finest_evidence);
+    for l in 1..n_levels {
+        let n_blocks = tree.levels[l].num_blocks();
+        let mut evidence = DMatrix::<f32>::zeros(n_blocks, k);
+        let signal = &tree.block_signals[l];
+        for b in 0..n_blocks {
+            for kk in 0..k {
+                let mut ll = 0.0f32;
+                for s in 0..n_samples {
+                    let diff = signal[(b, s)] - loadings[s] * emission_means[kk];
+                    ll += log_norm - 0.5 * diff * diff * inv_sigma_sq;
+                }
+                evidence[(b, kk)] = ll;
+            }
+        }
+        level_evidence.push(evidence);
+    }
+
+    // --- Build log transition matrix ---
+    let log_self = (1.0 - (k as f32 - 1.0) * transition_prob).ln();
+    let log_switch = transition_prob.ln();
+
+    // --- Upward pass: finest → coarsest ---
+    // up_msg[l][b, k_parent] = logsumexp_{k_child}(log P(k_child | k_parent) + evidence_child)
+    let mut up_msgs: Vec<DMatrix<f32>> = Vec::with_capacity(n_levels - 1);
+    #[allow(clippy::needless_range_loop)]
+    for l in 0..(n_levels - 1) {
+        let n_fine = tree.levels[l].num_blocks();
+        let n_coarse = tree.levels[l + 1].num_blocks();
+        let mut msg = DMatrix::<f32>::zeros(n_coarse, k);
+
+        let mut terms = vec![f32::NEG_INFINITY; k];
+        for fine_b in 0..n_fine {
+            let parent_b = tree.parent_map[l][fine_b];
+            // Compute message from fine_b to parent_b
+            for k_parent in 0..k {
+                for k_child in 0..k {
+                    let log_trans = if k_child == k_parent {
+                        log_self
+                    } else {
+                        log_switch
+                    };
+                    terms[k_child] = log_trans + level_evidence[l][(fine_b, k_child)];
+                }
+                msg[(parent_b, k_parent)] += logsumexp(&terms);
+            }
+        }
+        up_msgs.push(msg);
+    }
+
+    // --- Downward pass: coarsest → finest ---
+    // At each level, compute the "context" from above (parent's marginal minus this child's contribution)
+    // Then combine with local evidence to get marginal.
+
+    // Start at coarsest level: marginal = local evidence + upward messages from children
+    let top = n_levels - 1;
+    let n_top = tree.levels[top].num_blocks();
+    let mut top_marginal = DMatrix::<f32>::zeros(n_top, k);
+    for b in 0..n_top {
+        for kk in 0..k {
+            top_marginal[(b, kk)] = level_evidence[top][(b, kk)] + up_msgs[top - 1][(b, kk)];
+        }
+    }
+
+    // Propagate down
+    let mut marginals: Vec<DMatrix<f32>> = vec![DMatrix::zeros(0, 0); n_levels];
+    marginals[top] = top_marginal;
+
+    let mut down_terms = vec![0.0f32; k];
+    for l in (0..n_levels - 1).rev() {
+        let n_fine = tree.levels[l].num_blocks();
+        let mut fine_marginal = DMatrix::<f32>::zeros(n_fine, k);
+
+        for fine_b in 0..n_fine {
+            let parent_b = tree.parent_map[l][fine_b];
+
+            // Downward message: parent's marginal passed through transition
+            // Approximate: uses full parent marginal (slightly overestimates this child's influence)
+            for k_child in 0..k {
+                for k_parent in 0..k {
+                    let log_trans = if k_child == k_parent {
+                        log_self
+                    } else {
+                        log_switch
+                    };
+                    let parent_ctx = marginals[l + 1][(parent_b, k_parent)];
+                    down_terms[k_parent] = log_trans + parent_ctx;
+                }
+                let down_msg = logsumexp(&down_terms);
+                fine_marginal[(fine_b, k_child)] = level_evidence[l][(fine_b, k_child)] + down_msg;
+            }
+        }
+
+        marginals[l] = fine_marginal;
+    }
+
+    // --- Extract posteriors at finest level ---
+    let (posteriors, map_states) = evidence_to_posteriors(&marginals[0], k);
+
+    TreeStateResult {
+        posteriors,
+        map_states,
+    }
+}
+
+/// Convert log-evidence matrix to normalized posteriors and MAP states.
+fn evidence_to_posteriors(log_evidence: &DMatrix<f32>, k: usize) -> (DMatrix<f32>, Vec<usize>) {
+    let n = log_evidence.nrows();
+    let mut posteriors = DMatrix::<f32>::zeros(n, k);
+    let mut map_states = Vec::with_capacity(n);
+
+    for b in 0..n {
+        let row: Vec<f32> = (0..k).map(|kk| log_evidence[(b, kk)]).collect();
+        let lse = logsumexp(&row);
+        let mut best_k = 0;
+        let mut best_val = f32::NEG_INFINITY;
+        for kk in 0..k {
+            let p = (row[kk] - lse).exp();
+            posteriors[(b, kk)] = p;
+            if row[kk] > best_val {
+                best_val = row[kk];
+                best_k = kk;
+            }
+        }
+        map_states.push(best_k);
+    }
+
+    (posteriors, map_states)
+}
+
+fn logsumexp(vals: &[f32]) -> f32 {
+    let max = vals.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    if max.is_infinite() {
+        return f32::NEG_INFINITY;
+    }
+    let sum: f32 = vals.iter().map(|&v| (v - max).exp()).sum();
+    max + sum.ln()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_parent_mapping() {
+        use crate::genomic_coarsening::GenomicBlock;
+
+        let fine = GenomicCoarsening {
+            blocks: vec![
+                GenomicBlock {
+                    start: 0,
+                    end: 5,
+                    chromosome: "chr1".into(),
+                },
+                GenomicBlock {
+                    start: 5,
+                    end: 10,
+                    chromosome: "chr1".into(),
+                },
+                GenomicBlock {
+                    start: 10,
+                    end: 15,
+                    chromosome: "chr1".into(),
+                },
+                GenomicBlock {
+                    start: 15,
+                    end: 20,
+                    chromosome: "chr1".into(),
+                },
+            ],
+        };
+        let coarse = GenomicCoarsening {
+            blocks: vec![
+                GenomicBlock {
+                    start: 0,
+                    end: 10,
+                    chromosome: "chr1".into(),
+                },
+                GenomicBlock {
+                    start: 10,
+                    end: 20,
+                    chromosome: "chr1".into(),
+                },
+            ],
+        };
+
+        let mapping = build_parent_mapping(&fine, &coarse);
+        assert_eq!(mapping, vec![0, 0, 1, 1]);
+    }
+
+    #[test]
+    fn test_tree_single_level() {
+        // Single level = no tree, just local evidence
+        let n_blocks = 10;
+        let n_samples = 3;
+
+        // Block signal: first 5 blocks neutral, last 5 gain
+        let mut signal = DMatrix::<f32>::zeros(n_blocks, n_samples);
+        for b in 5..10 {
+            for s in 0..n_samples {
+                signal[(b, s)] = 0.5;
+            }
+        }
+
+        let chr_bounds: Vec<(Box<str>, usize, usize)> = vec![("chr1".into(), 0, n_blocks)];
+        let tree = CoarseningTree::build(&signal, &chr_bounds, &[0.5]);
+
+        let loadings = vec![1.0f32; n_samples];
+        let means = vec![-0.5, 0.0, 0.4];
+
+        let result = tree_state_inference(&tree, &signal, &loadings, &means, 0.1, 1e-6);
+
+        // First 5 blocks should be neutral (state 1)
+        for b in 0..5 {
+            assert_eq!(result.map_states[b], 1, "block {} should be neutral", b);
+        }
+    }
+}

--- a/cnv/src/detect.rs
+++ b/cnv/src/detect.rs
@@ -1,0 +1,218 @@
+//! CNV detection pipeline orchestrator.
+//!
+//! Composes genome ordering → coarsening → factorial tree into a single
+//! `detect_cnv()` call that takes `log(mu_residual)` and gene positions.
+//!
+//! Also provides `evaluate_cell_cnv()` for projecting cell-level residuals
+//! onto learned factor profiles via linear regression.
+
+use std::io::BufRead;
+
+use log::info;
+use nalgebra::DMatrix;
+
+use crate::coarsening_tree::CoarseningTree;
+use crate::factorial_tree::{fit_tree_factorial, FactorialTreeConfig, FactorialTreeResult};
+use crate::genome_order::{GenePosition, GenomeOrder};
+use crate::genomic_coarsening::GenomicCoarsening;
+
+// ---------------------------------------------------------------------------
+// Config & Result
+// ---------------------------------------------------------------------------
+
+/// Configuration for the full CNV detection pipeline.
+#[derive(Debug, Clone)]
+pub struct CnvDetectConfig {
+    /// Decreasing correlation thresholds for multi-level coarsening (e.g. `[0.7, 0.4]`).
+    pub corr_thresholds: Vec<f32>,
+    /// Factorial tree model configuration.
+    pub factorial: FactorialTreeConfig,
+}
+
+impl Default for CnvDetectConfig {
+    fn default() -> Self {
+        Self {
+            corr_thresholds: vec![0.7, 0.4],
+            factorial: FactorialTreeConfig::default(),
+        }
+    }
+}
+
+/// Result of CNV detection.
+#[derive(Debug, Clone)]
+pub struct CnvDetectResult {
+    /// Factorial tree result (loadings, factor states, emission means, etc.).
+    pub factorial_result: FactorialTreeResult,
+    /// Genomic coarsening (finest level).
+    pub coarsening: GenomicCoarsening,
+    /// Genome ordering used.
+    pub genome_order: GenomeOrder,
+    /// Per-gene effective factor profiles: `[G_ordered × F]`.
+    /// `profiles[g, f] = μ_f[s_f(g)]` expanded from block-level to gene-level.
+    pub gene_factor_profiles: DMatrix<f32>,
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+/// Run the full CNV detection pipeline.
+///
+/// # Arguments
+/// * `log_mu_residual` — `[G × S]` matrix of log(mu_residual) in original gene order
+/// * `gene_positions` — per-gene genomic positions (from GFF)
+/// * `config` — pipeline configuration
+///
+/// # Returns
+/// `CnvDetectResult` with factor profiles, loadings, and coarsening info.
+pub fn detect_cnv(
+    log_mu_residual: &DMatrix<f32>,
+    gene_positions: &[GenePosition],
+    config: &CnvDetectConfig,
+) -> anyhow::Result<CnvDetectResult> {
+    let n_genes = log_mu_residual.nrows();
+    let n_samples = log_mu_residual.ncols();
+
+    info!("CNV detection: {} genes × {} samples", n_genes, n_samples);
+
+    // 1. Build genome order
+    let genome_order = GenomeOrder::from_positions(gene_positions);
+    let n_ordered = genome_order.ordered_indices.len();
+    info!(
+        "Genome order: {} / {} genes mapped to canonical chromosomes",
+        n_ordered, n_genes
+    );
+
+    if n_ordered == 0 {
+        anyhow::bail!("No genes mapped to canonical chromosomes");
+    }
+
+    // 2. Reorder signal to genome order
+    let ordered_signal = genome_order.reorder_rows(log_mu_residual)?;
+
+    // 3. Build coarsening tree + run tree-based factorial inference
+    let tree = CoarseningTree::build(
+        &ordered_signal,
+        &genome_order.chr_boundaries,
+        &config.corr_thresholds,
+    );
+
+    let factorial_result = fit_tree_factorial(&tree, &config.factorial);
+
+    // The finest-level coarsening for gene expansion
+    let coarsening = tree.levels[0].clone();
+
+    // 4. Expand finest-block-level factor states to gene-level profiles
+    let n_factors = factorial_result.factor_viterbi_paths.len();
+    let mut gene_factor_profiles = DMatrix::<f32>::zeros(n_ordered, n_factors);
+    for f in 0..n_factors {
+        let means = &factorial_result.factor_emission_means[f];
+        let path = &factorial_result.factor_viterbi_paths[f];
+        let block_means: Vec<f32> = path.iter().map(|&s| means[s]).collect();
+        let gene_vals = coarsening.expand_vec_f32_to_genes(&block_means, n_ordered);
+        for g in 0..n_ordered {
+            gene_factor_profiles[(g, f)] = gene_vals[g];
+        }
+    }
+
+    info!(
+        "CNV detection complete: {} factors, {} finest blocks, {} levels",
+        n_factors,
+        coarsening.num_blocks(),
+        tree.n_levels(),
+    );
+
+    Ok(CnvDetectResult {
+        factorial_result,
+        coarsening,
+        genome_order,
+        gene_factor_profiles,
+    })
+}
+
+/// Project cell-level residuals onto learned factor profiles via OLS.
+///
+/// For each cell n, solves: `L_n = argmin Σ_g (r_n(g) - Σ_f L_{n,f} · v_f(g))²`
+///
+/// # Arguments
+/// * `cell_residuals` — `[G_ordered × N]` per-cell residual signals (in genome order)
+/// * `gene_factor_profiles` — `[G_ordered × F]` from `CnvDetectResult`
+///
+/// # Returns
+/// `[N × F]` per-cell factor loadings.
+pub fn evaluate_cell_cnv(
+    cell_residuals: &DMatrix<f32>,
+    gene_factor_profiles: &DMatrix<f32>,
+) -> DMatrix<f32> {
+    let n_genes = cell_residuals.nrows();
+    let n_factors = gene_factor_profiles.ncols();
+
+    assert_eq!(
+        gene_factor_profiles.nrows(),
+        n_genes,
+        "gene count mismatch between residuals and profiles"
+    );
+
+    // V = gene_factor_profiles [G × F]
+    // Solve V^T V L^T = V^T R for L [N × F]
+    // (V^T V) is [F × F] — tiny, compute once
+    let vtv = gene_factor_profiles.transpose() * gene_factor_profiles; // [F × F]
+                                                                       // V^T R is [F × N]
+    let vtr = gene_factor_profiles.transpose() * cell_residuals; // [F × N]
+
+    // Solve via Cholesky (V^T V is positive semi-definite)
+    // Add small ridge for numerical stability
+    let ridge = 1e-6 * DMatrix::<f32>::identity(n_factors, n_factors);
+    let vtv_reg = vtv + ridge;
+
+    match vtv_reg.clone().cholesky() {
+        Some(chol) => {
+            // Solve for all cells at once: [F × N]
+            let coeff = chol.solve(&vtr);
+            coeff.transpose() // [N × F]
+        }
+        None => {
+            info!("Cholesky failed, using pseudo-inverse for cell CNV evaluation");
+            let vtv_inv = vtv_reg
+                .try_inverse()
+                .unwrap_or_else(|| DMatrix::identity(n_factors, n_factors));
+            let coeff = vtv_inv * vtr;
+            coeff.transpose()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gene position readers
+// ---------------------------------------------------------------------------
+
+/// Read gene positions from a CNV ground truth TSV file.
+///
+/// Format: `gene\tchromosome\tposition\tstate` (tab-separated, gzipped or plain).
+/// Returns gene positions for all rows; the `state` column is ignored.
+pub fn read_gene_positions_from_cnv_tsv(path: &str) -> anyhow::Result<Vec<GenePosition>> {
+    let reader = matrix_util::common_io::open_buf_reader(path)?;
+
+    let mut positions = Vec::new();
+    for (i, line) in reader.lines().enumerate() {
+        let line = line?;
+        if i == 0 {
+            continue; // skip header
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        if cols.len() < 3 {
+            continue;
+        }
+        let gene_idx: usize = cols[0].parse()?;
+        let chromosome: Box<str> = cols[1].into();
+        let position: u64 = cols[2].parse()?;
+        positions.push(GenePosition {
+            gene_idx,
+            chromosome,
+            position,
+        });
+    }
+
+    info!("Read {} gene positions from {}", positions.len(), path);
+    Ok(positions)
+}

--- a/cnv/src/factorial_tree.rs
+++ b/cnv/src/factorial_tree.rs
@@ -1,0 +1,552 @@
+//! Factorial tree model for CNV detection from pseudobulk residuals.
+//!
+//! Decomposes a `[B × S]` block-level signal (genes × samples) into F additive
+//! factors, each with its own latent state sequence along the genome:
+//!
+//!   R[g, i] = Σ_f L[i,f] · μ_f[s_f(g)] + ε[g,i]
+//!
+//! - F factors, each with K states (e.g. del/neutral/gain)
+//! - Factors combine additively — a sample can carry any mix of CNV events
+//! - Cell-level evaluation reduces to linear regression onto factor profiles
+//!
+//! Inference via Gibbs sampling with tree-based state updates:
+//! 1. Belief propagation on the coarsening tree per factor (conditioned on others)
+//! 2. Conjugate Normal update for per-sample loadings
+//! 3. ESS for emission means (neutral pinned at 0)
+//! 4. Closed-form noise variance update
+
+use log::info;
+use nalgebra::{DMatrix, DVector};
+use rand::prelude::*;
+use rand_distr::{Distribution, StandardNormal};
+
+use mcmc_util::engine::{elliptical_slice_step, EssParam};
+
+use crate::coarsening_tree::{tree_state_inference, CoarseningTree};
+
+// ---------------------------------------------------------------------------
+// Config & Result
+// ---------------------------------------------------------------------------
+
+/// Configuration for the factorial tree sampler.
+#[derive(Debug, Clone)]
+pub struct FactorialTreeConfig {
+    /// Number of CNV factors (default 3).
+    pub n_factors: usize,
+    /// Number of CN states per factor (default 3: del/neutral/gain).
+    pub n_states: usize,
+    /// Include a null factor (constant across genome) that absorbs
+    /// per-sample global offsets. Factor index 0 when enabled. (default true)
+    pub null_factor: bool,
+    /// Off-diagonal transition probability for tree parent→child (default 1e-6).
+    pub transition_prob: f32,
+    /// Total Gibbs iterations (default 500).
+    pub n_iter: usize,
+    /// Burn-in iterations (default 200).
+    pub warmup: usize,
+    /// Random seed.
+    pub seed: u64,
+    /// Prior variance on emission means (default 1.0).
+    pub prior_var_mu: f32,
+    /// Prior variance on factor loadings (default 1.0).
+    pub prior_var_loading: f32,
+}
+
+impl Default for FactorialTreeConfig {
+    fn default() -> Self {
+        Self {
+            n_factors: 3,
+            n_states: 3,
+            null_factor: true,
+            transition_prob: 1e-6,
+            n_iter: 500,
+            warmup: 200,
+            seed: 42,
+            prior_var_mu: 1.0,
+            prior_var_loading: 1.0,
+        }
+    }
+}
+
+/// Result of the factorial tree sampler.
+#[derive(Debug, Clone)]
+pub struct FactorialTreeResult {
+    /// Per-factor posterior mean emission means: `[F]` vectors of length K.
+    pub factor_emission_means: Vec<DVector<f32>>,
+    /// Per-factor MAP state path at finest level: `[F]` vectors of length B.
+    pub factor_viterbi_paths: Vec<Vec<usize>>,
+    /// Per-factor averaged posteriors: `[F]` matrices of shape `[B × K]`.
+    pub factor_posteriors: Vec<DMatrix<f32>>,
+    /// Per-sample factor loadings (posterior mean): `[S × F_total]`
+    /// (includes null factor at index 0 when enabled).
+    pub loadings: DMatrix<f32>,
+    /// Noise variance (posterior mean).
+    pub noise_variance: f32,
+    /// Log-likelihood trace (one per post-warmup iteration).
+    pub log_likelihoods: Vec<f32>,
+}
+
+// ---------------------------------------------------------------------------
+// Emission parameter wrapper for ESS
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct EmissionTheta(DVector<f32>);
+
+impl EssParam for EmissionTheta {
+    fn linear_combine(&self, a: f32, other: &Self, b: f32) -> Self {
+        EmissionTheta(self.0.linear_combine(a, &other.0, b))
+    }
+}
+
+impl EmissionTheta {
+    fn new(n_states: usize) -> Self {
+        EmissionTheta(DVector::zeros(n_states))
+    }
+
+    fn n_states(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Write emission means into a pre-allocated slice (avoids allocation).
+    fn fill_means(&self, out: &mut [f32]) {
+        let k = self.n_states();
+        let neutral = k / 2;
+        out[..k].copy_from_slice(self.0.as_slice());
+        out[neutral] = 0.0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tree-based factorial inference
+// ---------------------------------------------------------------------------
+
+/// Fit factorial model using tree-based state inference.
+///
+/// Uses multi-level coarsening tree for state inference instead of
+/// chain HMM. O(nodes × K) per factor per iteration.
+///
+/// The null factor (index 0 when enabled) absorbs per-sample global offsets.
+/// Initialized as the per-sample mean signal.
+pub fn fit_tree_factorial(
+    tree: &CoarseningTree,
+    config: &FactorialTreeConfig,
+) -> FactorialTreeResult {
+    let n_blocks = tree.n_finest_blocks();
+    let n_samples = tree.n_samples();
+    let has_null = config.null_factor;
+    let n_cnv_factors = config.n_factors;
+    let n_total_factors = n_cnv_factors + if has_null { 1 } else { 0 };
+    let cnv_offset = if has_null { 1 } else { 0 };
+    let k = config.n_states;
+    let neutral = k / 2;
+
+    let finest_signal = &tree.block_signals[0];
+
+    info!(
+        "Factorial tree: {} blocks × {} samples, {} CNV factors{}, {} states, {} levels, {} iter",
+        n_blocks,
+        n_samples,
+        n_cnv_factors,
+        if has_null { " + null" } else { "" },
+        k,
+        tree.n_levels(),
+        config.n_iter,
+    );
+
+    let mut rng = SmallRng::seed_from_u64(config.seed);
+
+    let sample_signals: Vec<Vec<f32>> = (0..n_samples)
+        .map(|s| (0..n_blocks).map(|b| finest_signal[(b, s)]).collect())
+        .collect();
+
+    // --- Initialize ---
+    let mut thetas: Vec<EmissionTheta> = (0..n_cnv_factors)
+        .map(|f| {
+            let mut theta = EmissionTheta::new(k);
+            if k >= 3 {
+                let scale = 0.3 + 0.05 * f as f32;
+                theta.0[0] = -scale;
+                theta.0[k - 1] = scale;
+            }
+            theta
+        })
+        .collect();
+
+    let mut loadings = DMatrix::<f32>::zeros(n_samples, n_total_factors);
+    if has_null {
+        for s in 0..n_samples {
+            loadings[(s, 0)] = sample_signals[s].iter().sum::<f32>() / n_blocks as f32;
+        }
+    }
+    if n_cnv_factors > 0 {
+        for s in 0..n_samples {
+            loadings[(s, cnv_offset)] = 1.0;
+        }
+    }
+
+    let mut sigma_sq = {
+        let mut ss = 0.0f32;
+        for s in 0..n_samples {
+            let null_l = if has_null { loadings[(s, 0)] } else { 0.0 };
+            for &val in &sample_signals[s] {
+                let r = val - null_l;
+                ss += r * r;
+            }
+        }
+        (ss / (n_blocks * n_samples) as f32).max(0.01)
+    };
+
+    let mut factor_states: Vec<Vec<usize>> = vec![vec![neutral; n_blocks]; n_cnv_factors];
+    let mut factor_posteriors: Vec<DMatrix<f32>> = (0..n_cnv_factors)
+        .map(|_| {
+            let mut p = DMatrix::zeros(n_blocks, k);
+            for b in 0..n_blocks {
+                p[(b, neutral)] = 1.0;
+            }
+            p
+        })
+        .collect();
+
+    // --- Accumulators ---
+    let n_collect = config.n_iter.saturating_sub(config.warmup);
+    let mut means_acc: Vec<DVector<f32>> = (0..n_cnv_factors).map(|_| DVector::zeros(k)).collect();
+    let mut loadings_acc = DMatrix::<f32>::zeros(n_samples, n_total_factors);
+    let mut sigma_sq_acc = 0.0f32;
+    let mut posteriors_acc: Vec<DMatrix<f32>> = (0..n_cnv_factors)
+        .map(|_| DMatrix::zeros(n_blocks, k))
+        .collect();
+    let mut ll_trace: Vec<f32> = Vec::with_capacity(n_collect);
+
+    let prior_std_mu = config.prior_var_mu.sqrt();
+    let inv_prior_var_loading = 1.0 / config.prior_var_loading;
+
+    let mut factor_profiles: Vec<Vec<f32>> = vec![vec![0.0; n_blocks]; n_cnv_factors];
+    // Cached means per factor (avoids DVector allocation in hot loop)
+    let mut cached_means: Vec<Vec<f32>> = vec![vec![0.0; k]; n_cnv_factors];
+    // Reusable partial residual buffer (hoisted out of Gibbs loop)
+    let mut partial_resid = DMatrix::<f32>::zeros(n_blocks, n_samples);
+
+    // --- Gibbs loop ---
+    for iter in 0..config.n_iter {
+        // Precompute factor means and profiles (no allocation)
+        for ci in 0..n_cnv_factors {
+            thetas[ci].fill_means(&mut cached_means[ci]);
+            for g in 0..n_blocks {
+                factor_profiles[ci][g] = cached_means[ci][factor_states[ci][g]];
+            }
+        }
+
+        // === Step 1: Tree state inference per CNV factor ===
+        for ci in 0..n_cnv_factors {
+            let fi = ci + cnv_offset;
+
+            // Compute partial residual: signal minus null and other factors
+            for s in 0..n_samples {
+                for g in 0..n_blocks {
+                    let mut r = sample_signals[s][g];
+                    if has_null {
+                        r -= loadings[(s, 0)];
+                    }
+                    for ci2 in 0..n_cnv_factors {
+                        if ci2 != ci {
+                            r -= loadings[(s, ci2 + cnv_offset)] * factor_profiles[ci2][g];
+                        }
+                    }
+                    partial_resid[(g, s)] = r;
+                }
+            }
+
+            let loadings_f: Vec<f32> = (0..n_samples).map(|s| loadings[(s, fi)]).collect();
+
+            let tree_result = tree_state_inference(
+                tree,
+                &partial_resid,
+                &loadings_f,
+                &cached_means[ci],
+                sigma_sq,
+                config.transition_prob,
+            );
+
+            factor_posteriors[ci] = tree_result.posteriors;
+            factor_states[ci] = tree_result.map_states;
+
+            // Update this factor's profile immediately after state change
+            for g in 0..n_blocks {
+                factor_profiles[ci][g] = cached_means[ci][factor_states[ci][g]];
+            }
+        }
+
+        // === Step 2: Update loadings (conjugate Normal) ===
+        for fi in 0..n_total_factors {
+            // Precompute den (sum of v_fg^2) — same for all samples
+            let den = if has_null && fi == 0 {
+                n_blocks as f32 // v_fg = 1.0 for null factor
+            } else {
+                let ci = fi - cnv_offset;
+                factor_profiles[ci].iter().map(|&v| v * v).sum::<f32>()
+            };
+            let precision = den / sigma_sq + inv_prior_var_loading;
+
+            for s in 0..n_samples {
+                let mut num = 0.0f32;
+                for g in 0..n_blocks {
+                    let v_fg = if has_null && fi == 0 {
+                        1.0
+                    } else {
+                        factor_profiles[fi - cnv_offset][g]
+                    };
+                    // Partial residual (signal minus other factors)
+                    let mut r = sample_signals[s][g];
+                    if has_null && fi != 0 {
+                        r -= loadings[(s, 0)];
+                    }
+                    for (ci2, profile) in factor_profiles.iter().enumerate() {
+                        let fi2 = ci2 + cnv_offset;
+                        if fi2 != fi {
+                            r -= loadings[(s, fi2)] * profile[g];
+                        }
+                    }
+                    num += v_fg * r;
+                }
+                let post_mean = (num / sigma_sq) / precision;
+                let post_sd = (1.0 / precision).sqrt();
+                let z: f64 = StandardNormal.sample(&mut rng);
+                loadings[(s, fi)] = post_mean + post_sd * z as f32;
+            }
+        }
+
+        // === Step 3: Update emission means via ESS ===
+        let log_norm = -0.5 * (sigma_sq.ln() + std::f32::consts::TAU.ln());
+        let inv_s2 = 1.0 / sigma_sq;
+
+        for ci in 0..n_cnv_factors {
+            let fi = ci + cnv_offset;
+
+            // Precompute partial residual [B × S] for this factor (reuse buffer)
+            for s in 0..n_samples {
+                for g in 0..n_blocks {
+                    let mut r = sample_signals[s][g];
+                    if has_null {
+                        r -= loadings[(s, 0)];
+                    }
+                    for ci2 in 0..n_cnv_factors {
+                        if ci2 != ci {
+                            r -= loadings[(s, ci2 + cnv_offset)] * factor_profiles[ci2][g];
+                        }
+                    }
+                    partial_resid[(g, s)] = r;
+                }
+            }
+
+            let lnpdf = |theta: &EmissionTheta| -> f32 {
+                let mut means_buf = [0.0f32; 16]; // stack buffer, K <= 16
+                theta.fill_means(&mut means_buf[..k]);
+                let mut ll = 0.0f32;
+                for s in 0..n_samples {
+                    let l_sf = loadings[(s, fi)];
+                    for g in 0..n_blocks {
+                        // Partial residual already computed
+                        let r = partial_resid[(g, s)];
+                        for kk in 0..k {
+                            let gamma = factor_posteriors[ci][(g, kk)];
+                            if gamma < 1e-10 {
+                                continue;
+                            }
+                            let diff = r - l_sf * means_buf[kk];
+                            ll += gamma * (log_norm - 0.5 * diff * diff * inv_s2);
+                        }
+                    }
+                }
+                ll
+            };
+
+            let cur_ll = lnpdf(&thetas[ci]);
+            let prior_sample = {
+                let mut v = DVector::<f32>::zeros(k);
+                for i in 0..k {
+                    let z: f64 = StandardNormal.sample(&mut rng);
+                    v[i] = z as f32 * prior_std_mu;
+                }
+                EmissionTheta(v)
+            };
+            let (new_theta, _) =
+                elliptical_slice_step(&thetas[ci], &prior_sample, &lnpdf, cur_ll, &mut rng);
+            thetas[ci] = new_theta;
+        }
+
+        // === Step 4: Update noise variance ===
+        {
+            let mut ss = 0.0f32;
+            for s in 0..n_samples {
+                for g in 0..n_blocks {
+                    let mut predicted = 0.0f32;
+                    if has_null {
+                        predicted += loadings[(s, 0)];
+                    }
+                    for ci in 0..n_cnv_factors {
+                        predicted += loadings[(s, ci + cnv_offset)] * factor_profiles[ci][g];
+                    }
+                    let r = sample_signals[s][g] - predicted;
+                    ss += r * r;
+                }
+            }
+            sigma_sq = (ss / (n_blocks * n_samples) as f32).max(1e-6);
+        }
+
+        let total_ll = -((n_blocks * n_samples) as f32) * 0.5 * (sigma_sq.ln() + 1.0);
+
+        if iter >= config.warmup {
+            for ci in 0..n_cnv_factors {
+                let mut acc = vec![0.0f32; k];
+                thetas[ci].fill_means(&mut acc);
+                for kk in 0..k {
+                    means_acc[ci][kk] += acc[kk];
+                }
+                posteriors_acc[ci] += &factor_posteriors[ci];
+            }
+            loadings_acc += &loadings;
+            sigma_sq_acc += sigma_sq;
+            ll_trace.push(total_ll);
+        }
+
+        if iter % 50 == 0 || iter == config.n_iter - 1 {
+            let means_str: Vec<String> = (0..n_cnv_factors)
+                .map(|ci| format!("{:?}", &cached_means[ci]))
+                .collect();
+            info!(
+                "Factorial tree iter {}/{}: σ²={:.4}, means=[{}]",
+                iter,
+                config.n_iter,
+                sigma_sq,
+                means_str.join("; "),
+            );
+        }
+    }
+
+    // --- Posterior means ---
+    let n_coll = n_collect.max(1) as f32;
+    let factor_emission_means: Vec<DVector<f32>> = means_acc
+        .into_iter()
+        .map(|v| v.scale(1.0 / n_coll))
+        .collect();
+    loadings_acc.scale_mut(1.0 / n_coll);
+    let noise_variance = sigma_sq_acc / n_coll;
+    for acc in posteriors_acc.iter_mut() {
+        acc.scale_mut(1.0 / n_coll);
+    }
+
+    let factor_viterbi_paths: Vec<Vec<usize>> = (0..n_cnv_factors)
+        .map(|ci| {
+            (0..n_blocks)
+                .map(|b| {
+                    (0..k)
+                        .max_by(|&a, &b_| {
+                            posteriors_acc[ci][(b, a)]
+                                .partial_cmp(&posteriors_acc[ci][(b, b_)])
+                                .unwrap()
+                        })
+                        .unwrap()
+                })
+                .collect()
+        })
+        .collect();
+
+    info!(
+        "Factorial tree done. {} factors, σ²={:.4}",
+        n_cnv_factors, noise_variance,
+    );
+
+    FactorialTreeResult {
+        factor_emission_means,
+        factor_viterbi_paths,
+        factor_posteriors: posteriors_acc,
+        loadings: loadings_acc,
+        noise_variance,
+        log_likelihoods: ll_trace,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coarsening_tree::CoarseningTree;
+
+    #[test]
+    fn test_tree_all_neutral() {
+        let n_genes = 30;
+        let n_samples = 5;
+        let signal = DMatrix::<f32>::zeros(n_genes, n_samples);
+        let chr_bounds: Vec<(Box<str>, usize, usize)> = vec![("chr1".into(), 0, n_genes)];
+        let tree = CoarseningTree::build(&signal, &chr_bounds, &[0.5]);
+
+        let config = FactorialTreeConfig {
+            n_factors: 2,
+            n_states: 3,
+            null_factor: false,
+            n_iter: 100,
+            warmup: 50,
+            seed: 42,
+            ..Default::default()
+        };
+
+        let result = fit_tree_factorial(&tree, &config);
+
+        for f in 0..2 {
+            for &state in &result.factor_viterbi_paths[f] {
+                assert_eq!(state, 1, "expected neutral for zero signal");
+            }
+        }
+    }
+
+    #[test]
+    fn test_tree_null_factor_absorbs_offset() {
+        let n_genes = 40;
+        let n_samples = 4;
+        let mut signal = DMatrix::<f32>::zeros(n_genes, n_samples);
+
+        let offsets = [0.3, -0.2, 0.5, -0.1];
+        for s in 0..n_samples {
+            for g in 0..n_genes {
+                signal[(g, s)] = offsets[s];
+            }
+        }
+        // Add CNV gain in genes 20-30
+        for g in 20..30 {
+            for s in 0..n_samples {
+                signal[(g, s)] += 0.4;
+            }
+        }
+
+        let chr_bounds: Vec<(Box<str>, usize, usize)> = vec![("chr1".into(), 0, n_genes)];
+        let tree = CoarseningTree::build(&signal, &chr_bounds, &[0.5]);
+
+        let config = FactorialTreeConfig {
+            n_factors: 1,
+            n_states: 3,
+            null_factor: true,
+            n_iter: 300,
+            warmup: 150,
+            seed: 42,
+            ..Default::default()
+        };
+
+        let result = fit_tree_factorial(&tree, &config);
+
+        // Null factor loadings should approximate offsets
+        for s in 0..n_samples {
+            let null_loading = result.loadings[(s, 0)];
+            assert!(
+                (null_loading - offsets[s]).abs() < 0.3,
+                "null loading for sample {} should be ~{}, got {}",
+                s,
+                offsets[s],
+                null_loading,
+            );
+        }
+    }
+}

--- a/cnv/src/genomic_coarsening.rs
+++ b/cnv/src/genomic_coarsening.rs
@@ -83,6 +83,15 @@ impl GenomicCoarsening {
         out
     }
 
+    /// Expand a block-level f32 vector (length B) to gene-level (length G).
+    pub fn expand_vec_f32_to_genes(&self, block_vals: &[f32], n_genes: usize) -> Vec<f32> {
+        let mut out = vec![0.0f32; n_genes];
+        for (b, block) in self.blocks.iter().enumerate() {
+            out[block.start..block.end].fill(block_vals[b]);
+        }
+        out
+    }
+
     /// Chromosome boundaries in block space.
     ///
     /// Returns `[(chr_name, block_start, block_end)]` analogous to

--- a/cnv/src/hmm.rs
+++ b/cnv/src/hmm.rs
@@ -241,7 +241,7 @@ pub fn infer_sample(params: &CnvHmmParams, y: &[f32], alpha: f32, sigma_sq: f32)
 }
 
 /// Forward-backward with precomputed emissions.
-fn forward_backward_with_emit(
+pub fn forward_backward_with_emit(
     params: &CnvHmmParams,
     log_emit: &DMatrix<f32>,
 ) -> (DMatrix<f32>, f32) {
@@ -304,7 +304,7 @@ fn forward_backward_with_emit(
 }
 
 /// Viterbi with precomputed emissions.
-fn viterbi_with_emit(params: &CnvHmmParams, log_emit: &DMatrix<f32>) -> Vec<usize> {
+pub fn viterbi_with_emit(params: &CnvHmmParams, log_emit: &DMatrix<f32>) -> Vec<usize> {
     let n = log_emit.nrows();
     let k = params.n_states();
 

--- a/cnv/src/lib.rs
+++ b/cnv/src/lib.rs
@@ -10,6 +10,9 @@
 //! Ploidy is not identifiable from expression alone; states represent relative CN
 //! (loss/neutral/gain).
 
+pub mod coarsening_tree;
+pub mod detect;
+pub mod factorial_tree;
 pub mod genome_order;
 pub mod genomic_coarsening;
 pub mod gibbs_hmm;

--- a/data-beans/src/handlers/analysis.rs
+++ b/data-beans/src/handlers/analysis.rs
@@ -529,7 +529,66 @@ pub fn run_simulate(cmd_args: &RunSimulateArgs) -> anyhow::Result<()> {
             )
             .collect();
         write_lines(&cnv_lines, &cnv_file)?;
-        info!("wrote CNV ground truth: {:?}", &cnv_file);
+        info!("wrote CNV ground truth (union): {:?}", &cnv_file);
+
+        // Per-batch ground truth (for CNV detection validation)
+        if let (Some(ref states_db), Some(ref clone_parent)) =
+            (&sim.cnv_states_per_batch, &sim.cnv_clone_parent)
+        {
+            let per_batch_file = mtx_file.replace(".mtx.gz", ".cnv_per_batch_ground_truth.tsv.gz");
+            let mut lines: Vec<Box<str>> = vec!["gene\tchromosome\tposition\tbatch\tstate".into()];
+            for (b, batch_states) in states_db.iter().enumerate() {
+                for (g, &st) in batch_states.iter().enumerate() {
+                    if st != 1 {
+                        // Only write non-neutral entries (sparse)
+                        lines.push(
+                            format!(
+                                "{}\t{}\t{}\t{}\t{}",
+                                g, chromosomes[g], positions[g], b, state_labels[st as usize]
+                            )
+                            .into(),
+                        );
+                    }
+                }
+            }
+            write_lines(&lines, &per_batch_file)?;
+            info!("wrote per-batch CNV ground truth: {:?}", &per_batch_file);
+
+            // Clone tree
+            let tree_file = mtx_file.replace(".mtx.gz", ".cnv_clone_tree.tsv.gz");
+            let tree_lines: Vec<Box<str>> = std::iter::once("clone\tparent".into())
+                .chain(
+                    clone_parent
+                        .iter()
+                        .enumerate()
+                        .map(|(b, &p)| format!("{}\t{}", b, p).into()),
+                )
+                .collect();
+            write_lines(&tree_lines, &tree_file)?;
+            info!("wrote clone tree: {:?}", &tree_file);
+        }
+
+        // Write minimal GFF for gene coordinates (so --gff works with simulated data)
+        let gff_file = mtx_file.replace(".mtx.gz", ".genes.gff.gz");
+        let gff_lines: Vec<Box<str>> = std::iter::once("##gff-version 3".into())
+            .chain(
+                rows.iter()
+                    .zip(chromosomes.iter())
+                    .zip(positions.iter())
+                    .map(|((gene_name, chr), &pos)| {
+                        // GFF3: seqname source feature start end score strand frame attributes
+                        let start = pos + 1; // GFF is 1-based
+                        let end = start + 1000; // dummy gene length
+                        format!(
+                            "{}\tsimulation\tgene\t{}\t{}\t.\t+\t.\tgene_name={}",
+                            chr, start, end, gene_name,
+                        )
+                        .into()
+                    }),
+            )
+            .collect();
+        write_lines(&gff_lines, &gff_file)?;
+        info!("wrote gene annotations: {:?}", &gff_file);
     }
 
     info!(

--- a/data-beans/src/simulations/core.rs
+++ b/data-beans/src/simulations/core.rs
@@ -139,13 +139,23 @@ pub struct SimOut {
     pub gene_chromosomes: Option<Vec<Box<str>>>,
     /// CNV: per-gene position within chromosome (length D). None if n_chromosomes == 0.
     pub gene_positions: Option<Vec<u64>>,
-    /// CNV: per-gene CN state (0=loss, 1=neutral, 2=gain). None if n_chromosomes == 0.
+    /// CNV: per-gene CN state union across batches (0=loss, 1=neutral, 2=gain).
     pub cnv_states: Option<Vec<u8>>,
+    /// CNV: per-batch, per-gene CN states. `cnv_states_per_batch[b][g]`.
+    pub cnv_states_per_batch: Option<Vec<Vec<u8>>>,
+    /// CNV: clone tree parent indices. `clone_parent[b]` = parent of clone b.
+    pub cnv_clone_parent: Option<Vec<usize>>,
 }
 
 /// CNV block simulation output.
 pub(crate) struct CnvSimOut {
-    pub(crate) cnv_multiplier: Vec<f32>,
+    /// Per-gene, per-batch CN multiplier `[D × B]`.
+    pub(crate) cnv_multiplier_db: DMatrix<f32>,
+    /// Per-gene, per-batch CN state: `cnv_states_db[b][g]` (0=loss, 1=neutral, 2=gain).
+    pub(crate) cnv_states_db: Vec<Vec<u8>>,
+    /// Clone tree: `clone_parent[b]` = parent clone index for batch b.
+    pub(crate) clone_parent: Vec<usize>,
+    /// Union across batches (for backwards compat ground truth).
     pub(crate) cnv_states: Vec<u8>,
     pub(crate) chromosomes: Vec<Box<str>>,
     pub(crate) positions: Vec<u64>,
@@ -153,6 +163,7 @@ pub(crate) struct CnvSimOut {
 
 pub(crate) struct CnvSimParams {
     pub(crate) n_genes: usize,
+    pub(crate) n_batches: usize,
     pub(crate) n_chr: usize,
     pub(crate) events_per_chr: f32,
     pub(crate) block_frac: f32,
@@ -160,22 +171,24 @@ pub(crate) struct CnvSimParams {
     pub(crate) loss_fold: f32,
 }
 
-/// Generate CNV blocks: assign genes to chromosomes with positions,
-/// then place contiguous gain/loss events.
+/// Generate clonal CNV blocks with a binary clonal tree.
+///
+/// - Clone 0 (batch 0) = normal reference (CN=2, no CNV events)
+/// - Each subsequent clone inherits its parent's CN profile + adds new events
+/// - Binary tree: parent of clone `b` = `(b - 1) / 2`
+///
+/// This mirrors the COMPASS simulation design: a clonal tree where deeper
+/// clones accumulate more CNV events, and related clones share ancestral events.
 pub(crate) fn sample_cnv_blocks(params: &CnvSimParams, rng: &mut impl rand::Rng) -> CnvSimOut {
     let dd = params.n_genes;
+    let bb = params.n_batches.max(1);
     let n_chr = params.n_chr;
     let genes_per_chr = dd / n_chr;
-    let spacing = 10_000u64; // bp between genes
+    let spacing = 10_000u64;
 
+    // 1. Gene coordinates (shared across all clones/batches)
     let mut chromosomes = Vec::with_capacity(dd);
     let mut positions = Vec::with_capacity(dd);
-    let mut cnv_states = vec![1u8; dd]; // neutral by default
-    let mut cnv_multiplier = vec![1.0f32; dd];
-
-    let poisson_events =
-        Poisson::new(params.events_per_chr as f64).unwrap_or_else(|_| Poisson::new(0.5).unwrap());
-
     for chr_idx in 0..n_chr {
         let chr_name: Box<str> = format!("chr{}", chr_idx + 1).into();
         let chr_start = chr_idx * genes_per_chr;
@@ -184,44 +197,117 @@ pub(crate) fn sample_cnv_blocks(params: &CnvSimParams, rng: &mut impl rand::Rng)
         } else {
             (chr_idx + 1) * genes_per_chr
         };
-        let chr_len = chr_end - chr_start;
-
         for g in chr_start..chr_end {
             chromosomes.push(chr_name.clone());
             positions.push((g - chr_start) as u64 * spacing);
         }
+    }
 
-        // Sample number of CNV events on this chromosome
-        let n_events = poisson_events.sample(rng) as usize;
-        let block_size = ((chr_len as f32 * params.block_frac) as usize).max(3);
+    // 2. Binary clonal tree: clone 0 = normal root
+    let clone_parent: Vec<usize> = (0..bb)
+        .map(|b| if b == 0 { 0 } else { (b - 1) / 2 })
+        .collect();
 
-        for _ in 0..n_events {
-            let start = rng.random_range(0..chr_len);
-            let end = (start + block_size).min(chr_len);
-            let is_gain: bool = rng.random_bool(0.5);
-            let (state, mult) = if is_gain {
-                (2u8, params.gain_fold)
+    // 3. Build CN profiles by traversing the tree top-down
+    let mut cnv_multiplier_db = DMatrix::<f32>::from_element(dd, bb, 1.0);
+
+    let poisson_events =
+        Poisson::new(params.events_per_chr as f64).unwrap_or_else(|_| Poisson::new(0.5).unwrap());
+
+    let mut total_gain = 0usize;
+    let mut total_loss = 0usize;
+
+    // Clone 0 stays all-neutral (normal reference). Process clones 1..bb.
+    for b in 1..bb {
+        // Inherit parent's profile
+        let parent = clone_parent[b];
+        let parent_col = cnv_multiplier_db.column(parent).clone_owned();
+        cnv_multiplier_db.column_mut(b).copy_from(&parent_col);
+
+        // Add new CNV events for this clone
+        for chr_idx in 0..n_chr {
+            let chr_start = chr_idx * genes_per_chr;
+            let chr_end = if chr_idx == n_chr - 1 {
+                dd
             } else {
-                (0u8, params.loss_fold)
+                (chr_idx + 1) * genes_per_chr
             };
+            let chr_len = chr_end - chr_start;
 
-            for g in (chr_start + start)..(chr_start + end) {
-                cnv_states[g] = state;
-                cnv_multiplier[g] = mult;
+            let n_events = poisson_events.sample(rng) as usize;
+            let block_size = ((chr_len as f32 * params.block_frac) as usize).max(3);
+
+            for _ in 0..n_events {
+                let start = rng.random_range(0..chr_len);
+                let end = (start + block_size).min(chr_len);
+                let is_gain: bool = rng.random_bool(0.5);
+                let mult = if is_gain {
+                    total_gain += end - start;
+                    params.gain_fold
+                } else {
+                    total_loss += end - start;
+                    params.loss_fold
+                };
+
+                for g in (chr_start + start)..(chr_start + end) {
+                    // Multiply on top of inherited profile (allows compound events)
+                    cnv_multiplier_db[(g, b)] *= mult;
+                }
             }
         }
     }
 
+    // 4. Per-batch CN states from multipliers
+    let cnv_states_db: Vec<Vec<u8>> = (0..bb)
+        .map(|b| {
+            (0..dd)
+                .map(|g| {
+                    let m = cnv_multiplier_db[(g, b)];
+                    if m > 1.0 + 1e-6 {
+                        2u8 // gain
+                    } else if m < 1.0 - 1e-6 {
+                        0u8 // loss
+                    } else {
+                        1u8 // neutral
+                    }
+                })
+                .collect()
+        })
+        .collect();
+
+    // Union across batches (backwards compat)
+    let cnv_states: Vec<u8> = (0..dd)
+        .map(|g| {
+            let has_gain = (0..bb).any(|b| cnv_states_db[b][g] == 2);
+            let has_loss = (0..bb).any(|b| cnv_states_db[b][g] == 0);
+            if has_gain {
+                2u8
+            } else if has_loss {
+                0u8
+            } else {
+                1u8
+            }
+        })
+        .collect();
+
     info!(
-        "CNV simulation: {} genes, {} chromosomes, {} gain, {} loss",
-        dd,
-        n_chr,
-        cnv_states.iter().filter(|&&s| s == 2).count(),
-        cnv_states.iter().filter(|&&s| s == 0).count(),
+        "CNV simulation: {} genes × {} batches (clonal tree), {} chromosomes, ~{} gain, ~{} loss gene-events",
+        dd, bb, n_chr, total_gain, total_loss,
+    );
+    info!(
+        "Clone tree: {:?}",
+        clone_parent
+            .iter()
+            .enumerate()
+            .map(|(b, &p)| format!("{}←{}", b, p))
+            .collect::<Vec<_>>()
+            .join(", ")
     );
 
     CnvSimOut {
-        cnv_multiplier,
+        cnv_multiplier_db,
+        cnv_states_db,
+        clone_parent,
         cnv_states,
         chromosomes,
         positions,
@@ -334,7 +420,7 @@ pub fn generate_factored_poisson_gamma_data(args: &SimArgs) -> anyhow::Result<Si
         ln_delta_d += &ln_null_d.column(0);
     }
 
-    let delta_db = ln_delta_db.map(|x| x.exp());
+    let mut delta_db = ln_delta_db.map(|x| x.exp());
     info!("simulated batch effects");
 
     // 3. factorization model
@@ -390,11 +476,12 @@ pub fn generate_factored_poisson_gamma_data(args: &SimArgs) -> anyhow::Result<Si
 
     let theta_kn = sample_theta_kn(kk, nn, pve_topic, &mut rng)?;
 
-    // 4. CNV simulation (optional)
+    // 4. CNV simulation (optional) — per-batch CNV folded into delta
     let cnv_out = if args.n_chromosomes > 0 {
         Some(sample_cnv_blocks(
             &CnvSimParams {
                 n_genes: dd,
+                n_batches: bb,
                 n_chr: args.n_chromosomes,
                 events_per_chr: args.cnv_events_per_chr,
                 block_frac: args.cnv_block_frac,
@@ -406,19 +493,15 @@ pub fn generate_factored_poisson_gamma_data(args: &SimArgs) -> anyhow::Result<Si
     } else {
         None
     };
-    // Pre-multiply CNV into dictionary if present
-    let beta_dk = if let Some(ref cnv) = cnv_out {
-        let mut beta = beta_dk;
-        for i in 0..dd {
-            let scale = cnv.cnv_multiplier[i];
-            for k in 0..kk {
-                beta[(i, k)] *= scale;
+    // Fold per-batch CNV multiplier into delta (batch effect)
+    // delta_effective[g,b] = delta[g,b] * cnv[g,b]
+    if let Some(ref cnv) = cnv_out {
+        for b in 0..bb {
+            for g in 0..dd {
+                delta_db[(g, b)] *= cnv.cnv_multiplier_db[(g, b)];
             }
         }
-        beta
-    } else {
-        beta_dk
-    };
+    }
 
     // 5. putting them all together
     let delta_ref = if bb > 1 { Some(&delta_db) } else { None };
@@ -437,14 +520,17 @@ pub fn generate_factored_poisson_gamma_data(args: &SimArgs) -> anyhow::Result<Si
         triplets.len()
     );
 
-    let (gene_chromosomes, gene_positions, cnv_states) = match cnv_out {
-        Some(cnv) => (
-            Some(cnv.chromosomes),
-            Some(cnv.positions),
-            Some(cnv.cnv_states),
-        ),
-        None => (None, None, None),
-    };
+    let (gene_chromosomes, gene_positions, cnv_states, cnv_states_per_batch, cnv_clone_parent) =
+        match cnv_out {
+            Some(cnv) => (
+                Some(cnv.chromosomes),
+                Some(cnv.positions),
+                Some(cnv.cnv_states),
+                Some(cnv.cnv_states_db),
+                Some(cnv.clone_parent),
+            ),
+            None => (None, None, None, None, None),
+        };
 
     Ok(SimOut {
         ln_delta_db,
@@ -456,6 +542,8 @@ pub fn generate_factored_poisson_gamma_data(args: &SimArgs) -> anyhow::Result<Si
         gene_chromosomes,
         gene_positions,
         cnv_states,
+        cnv_states_per_batch,
+        cnv_clone_parent,
     })
 }
 

--- a/senna/Cargo.toml
+++ b/senna/Cargo.toml
@@ -18,9 +18,11 @@ path = "src/main.rs"
 
 [dependencies]
 auxiliary-data = { workspace = true }
+cnv = { workspace = true }
 data-beans = { workspace = true }
 data-beans-alg = { workspace = true }
 candle-util = { workspace = true }
+genomic-data = { workspace = true }
 matrix-util = { workspace = true }
 matrix-param = { workspace = true }
 leiden = { workspace = true }

--- a/senna/src/cnv_pseudobulk.rs
+++ b/senna/src/cnv_pseudobulk.rs
@@ -1,0 +1,304 @@
+//! Cluster/topic-informed pseudobulk CNV detection.
+//!
+//! Shared across SVD, topic, and indexed-topic pipelines:
+//! 1. Cell-type membership from K-means (SVD) or topic proportions (topic/itopic)
+//! 2. Pseudobulk via `collapse_pseudobulk()` → per-(cell_type, individual) GammaMatrix
+//! 3. Within each cell type: log-ratio vs cross-individual mean → CNV signal
+//! 4. Feed stacked log-ratios to factorial tree for CNV calling
+
+use log::info;
+use nalgebra::DMatrix;
+use rustc_hash::FxHashMap as HashMap;
+
+use auxiliary_data::cell_annotations::{CellAnnotations, CellTypeMembership};
+use cnv::detect::{CnvDetectConfig, CnvDetectResult};
+use cnv::genome_order::GenePosition;
+use data_beans::sparse_io_vector::SparseIoVec;
+use data_beans_alg::pseudobulk::collapse_pseudobulk;
+use matrix_param::traits::Inference;
+use matrix_util::clustering::{Kmeans, KmeansArgs};
+
+use matrix_util::traits::IoOps;
+
+use crate::embed_common::{CnvArgs, Mat};
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// CNV detection using K-means clusters on SVD latent embeddings.
+pub fn detect_cnv_cluster_informed(
+    data_vec: SparseIoVec,
+    latent_nk: &Mat,
+    batch_membership: &[Box<str>],
+    gene_positions: &[GenePosition],
+    n_clusters: usize,
+    cnv_config: &CnvDetectConfig,
+) -> anyhow::Result<CnvDetectResult> {
+    let n_cells = latent_nk.nrows();
+
+    info!(
+        "CNV: clustering {} cells into {} groups",
+        n_cells, n_clusters
+    );
+    let cluster_labels = latent_nk.kmeans_rows(KmeansArgs::with_clusters(n_clusters));
+
+    // One-hot membership from cluster labels
+    let mut membership_matrix = DMatrix::<f32>::zeros(n_cells, n_clusters);
+    for (i, &c) in cluster_labels.iter().enumerate() {
+        membership_matrix[(i, c)] = 1.0;
+    }
+    let cell_type_names: Vec<Box<str>> = (0..n_clusters)
+        .map(|c| format!("cluster_{}", c).into())
+        .collect();
+    let membership = CellTypeMembership {
+        matrix: membership_matrix,
+        cell_type_names,
+    };
+
+    detect_cnv_with_membership(
+        data_vec,
+        &membership,
+        batch_membership,
+        gene_positions,
+        cnv_config,
+    )
+}
+
+/// CNV detection using topic proportions as soft cell-type membership.
+///
+/// `topic_proportions` should be on the probability simplex (e.g., `exp(log_softmax_z_nk)`).
+pub fn detect_cnv_topic_informed(
+    data_vec: SparseIoVec,
+    topic_proportions: &Mat,
+    batch_membership: &[Box<str>],
+    gene_positions: &[GenePosition],
+    cnv_config: &CnvDetectConfig,
+) -> anyhow::Result<CnvDetectResult> {
+    let n_topics = topic_proportions.ncols();
+
+    let cell_type_names: Vec<Box<str>> = (0..n_topics)
+        .map(|k| format!("topic_{}", k).into())
+        .collect();
+    let membership = CellTypeMembership {
+        matrix: topic_proportions.clone(),
+        cell_type_names,
+    };
+
+    detect_cnv_with_membership(
+        data_vec,
+        &membership,
+        batch_membership,
+        gene_positions,
+        cnv_config,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Core shared logic
+// ---------------------------------------------------------------------------
+
+/// Core CNV detection: pseudobulk by (cell_type, individual) → log-ratio → factorial tree.
+fn detect_cnv_with_membership(
+    data_vec: SparseIoVec,
+    membership: &CellTypeMembership,
+    batch_membership: &[Box<str>],
+    gene_positions: &[GenePosition],
+    cnv_config: &CnvDetectConfig,
+) -> anyhow::Result<CnvDetectResult> {
+    let column_names = data_vec.column_names()?;
+    let annotations = build_cell_annotations(batch_membership, &column_names);
+    let n_individuals = annotations.individual_ids.len();
+    let n_cell_types = membership.cell_type_names.len();
+
+    info!(
+        "CNV: pseudobulk with {} cell types × {} individuals",
+        n_cell_types, n_individuals,
+    );
+
+    let collapsed = collapse_pseudobulk(data_vec, &annotations, membership, 1.0, 1.0)?;
+
+    // Within each cell type: log-ratio vs cross-individual mean
+    let n_genes = collapsed.gene_names.len();
+    let mut log_ratio_columns: Vec<Vec<f32>> = Vec::new();
+
+    for (ct_idx, gamma) in collapsed.gamma_params.iter().enumerate() {
+        let log_mean = gamma.posterior_log_mean();
+        let weights = &collapsed.cell_weights[ct_idx];
+
+        // Weighted mean across individuals
+        let mut mean_g = vec![0.0f32; n_genes];
+        let mut total_weight = 0.0f32;
+        for i in 0..n_individuals {
+            if weights[i] < 1.0 {
+                continue;
+            }
+            total_weight += weights[i];
+            for g in 0..n_genes {
+                mean_g[g] += weights[i] * log_mean[(g, i)];
+            }
+        }
+        if total_weight > 0.0 {
+            for v in &mut mean_g {
+                *v /= total_weight;
+            }
+        }
+
+        for i in 0..n_individuals {
+            if weights[i] < 1.0 {
+                continue;
+            }
+            let col: Vec<f32> = (0..n_genes).map(|g| log_mean[(g, i)] - mean_g[g]).collect();
+            log_ratio_columns.push(col);
+        }
+    }
+
+    if log_ratio_columns.is_empty() {
+        anyhow::bail!("No valid (cell_type, individual) pairs for CNV detection");
+    }
+
+    let valid_count = log_ratio_columns.len();
+    let mut signal = DMatrix::<f32>::zeros(n_genes, valid_count);
+    for (j, col) in log_ratio_columns.iter().enumerate() {
+        for g in 0..n_genes {
+            signal[(g, j)] = col[g];
+        }
+    }
+
+    info!(
+        "CNV: log-ratio signal {} genes × {} samples",
+        n_genes, valid_count,
+    );
+
+    cnv::detect::detect_cnv(&signal, gene_positions, cnv_config)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Load gene positions from --gff or --cnv-ground-truth.
+pub fn load_gene_positions(
+    cnv_args: &CnvArgs,
+    gene_names: &[Box<str>],
+) -> anyhow::Result<Option<Vec<GenePosition>>> {
+    if let Some(gt_path) = &cnv_args.cnv_ground_truth {
+        info!("CNV: loading positions from {}", gt_path);
+        Ok(Some(cnv::detect::read_gene_positions_from_cnv_tsv(
+            gt_path,
+        )?))
+    } else if let Some(gff_path) = &cnv_args.gff {
+        info!("CNV: loading gene annotations from {}", gff_path);
+        let gene_tss = genomic_data::coordinates::load_gene_tss(gff_path, gene_names)?;
+        Ok(Some(
+            gene_tss
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, tss)| {
+                    tss.as_ref().map(|t| GenePosition {
+                        gene_idx: idx,
+                        chromosome: t.chr.clone(),
+                        position: t.tss as u64,
+                    })
+                })
+                .collect(),
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Reconstruct per-cell batch labels from a SparseIoVec.
+///
+/// Returns `None` if no batch information is available.
+pub fn reconstruct_batch_labels(data_vec: &SparseIoVec) -> Option<Vec<Box<str>>> {
+    let batch_names = data_vec.batch_names()?;
+    let n_cells = data_vec.num_columns();
+    let batch_indices = data_vec.get_batch_membership(0..n_cells);
+    Some(
+        batch_indices
+            .iter()
+            .map(|&b| batch_names[b].clone())
+            .collect(),
+    )
+}
+
+/// Build a `CnvDetectConfig` from shared CLI args.
+pub fn build_cnv_config(cnv_args: &CnvArgs) -> CnvDetectConfig {
+    CnvDetectConfig {
+        corr_thresholds: cnv_args.cnv_corr_thresholds.clone(),
+        factorial: cnv::factorial_tree::FactorialTreeConfig {
+            n_factors: cnv_args.cnv_factors,
+            n_states: cnv_args.cnv_states,
+            n_iter: cnv_args.cnv_iter,
+            warmup: cnv_args.cnv_warmup,
+            ..Default::default()
+        },
+    }
+}
+
+/// Write CNV detection results (profiles + loadings) to parquet.
+pub fn write_cnv_results(
+    cnv_result: &CnvDetectResult,
+    out_prefix: &str,
+    gene_names: &[Box<str>],
+) -> anyhow::Result<()> {
+    let ordered_gene_names: Vec<Box<str>> = cnv_result
+        .genome_order
+        .ordered_indices
+        .iter()
+        .map(|&i| gene_names[i].clone())
+        .collect();
+
+    cnv_result.gene_factor_profiles.to_parquet_with_names(
+        &(out_prefix.to_string() + ".cnv_profiles.parquet"),
+        (Some(&ordered_gene_names), Some("gene")),
+        None,
+    )?;
+
+    cnv_result.factorial_result.loadings.to_parquet_with_names(
+        &(out_prefix.to_string() + ".cnv_loadings.parquet"),
+        (None, None),
+        None,
+    )?;
+
+    info!(
+        "CNV detection: {} factors, {} blocks → {}.cnv_profiles.parquet",
+        cnv_result.factorial_result.factor_emission_means.len(),
+        cnv_result.coarsening.num_blocks(),
+        out_prefix,
+    );
+    Ok(())
+}
+
+/// Build CellAnnotations from per-cell batch labels (same pattern as cocoa).
+fn build_cell_annotations(batch_labels: &[Box<str>], column_names: &[Box<str>]) -> CellAnnotations {
+    let mut indv_set: Vec<Box<str>> = batch_labels
+        .iter()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    indv_set.retain(|s| !s.is_empty() && s.as_ref() != "NA");
+
+    let indv_to_idx: HashMap<Box<str>, usize> = indv_set
+        .iter()
+        .enumerate()
+        .map(|(i, name)| (name.clone(), i))
+        .collect();
+
+    let cell_to_individual: HashMap<Box<str>, usize> = column_names
+        .iter()
+        .zip(batch_labels.iter())
+        .filter_map(|(cell_name, batch_name)| {
+            indv_to_idx
+                .get(batch_name)
+                .map(|&idx| (cell_name.clone(), idx))
+        })
+        .collect();
+
+    CellAnnotations {
+        cell_to_individual,
+        individual_ids: indv_set,
+    }
+}

--- a/senna/src/embed_common.rs
+++ b/senna/src/embed_common.rs
@@ -61,6 +61,58 @@ pub enum AdjMethod {
     Residual,
 }
 
+/// Shared CNV detection CLI args (used by SVD, topic, indexed-topic)
+#[derive(Args, Debug, Clone)]
+pub struct CnvArgs {
+    #[arg(
+        long,
+        help = "GFF/GTF annotation file for CNV detection",
+        long_help = "GFF/GTF annotation file with gene coordinates.\n\
+                     When provided, runs factorial tree model on pseudobulk \n\
+                     log-ratios to detect copy number variations."
+    )]
+    pub gff: Option<Box<str>>,
+
+    #[arg(
+        long,
+        help = "CNV ground truth TSV (from data-beans simulate)",
+        long_help = "Alternative to --gff: read gene coordinates from the\n\
+                     .cnv_ground_truth.tsv.gz file produced by data-beans simulate.\n\
+                     Enables CNV detection with simulation data."
+    )]
+    pub cnv_ground_truth: Option<Box<str>>,
+
+    #[arg(
+        long,
+        default_value = "3",
+        help = "Number of CNV factors",
+        long_help = "Number of factors in the factorial tree model.\n\
+                     Each factor represents an independent CNV event pattern."
+    )]
+    pub cnv_factors: usize,
+
+    #[arg(
+        long,
+        default_value = "3",
+        help = "Number of CN states per factor (e.g. del/neutral/gain)"
+    )]
+    pub cnv_states: usize,
+
+    #[arg(
+        long,
+        default_value = "0.7,0.4",
+        value_delimiter = ',',
+        help = "Coarsening correlation thresholds for CNV (multi-level)"
+    )]
+    pub cnv_corr_thresholds: Vec<f32>,
+
+    #[arg(long, default_value_t = 500, help = "CNV Gibbs sampling iterations")]
+    pub cnv_iter: usize,
+
+    #[arg(long, default_value_t = 200, help = "CNV Gibbs warmup iterations")]
+    pub cnv_warmup: usize,
+}
+
 /// Training score tracker for topic models
 pub struct TrainScores {
     pub llik: Vec<f32>,

--- a/senna/src/fit_indexed_topic.rs
+++ b/senna/src/fit_indexed_topic.rs
@@ -224,6 +224,10 @@ pub struct IndexedTopicArgs {
         help = "Bulk data files for joint deconvolution (.parquet, .tsv.gz)"
     )]
     bulk_data_files: Option<Vec<Box<str>>>,
+
+    // CNV detection args
+    #[command(flatten)]
+    cnv: CnvArgs,
 }
 
 pub fn fit_indexed_topic_model(args: &IndexedTopicArgs) -> anyhow::Result<()> {
@@ -419,6 +423,29 @@ pub fn fit_indexed_topic_model(args: &IndexedTopicArgs) -> anyhow::Result<()> {
         (Some(&cell_names), Some("cell")),
         None,
     )?;
+
+    // CNV detection using topic proportions
+    let gene_names = data_vec.row_names()?;
+    let cnv_positions = crate::cnv_pseudobulk::load_gene_positions(&args.cnv, &gene_names)?;
+
+    if let Some(positions) = cnv_positions {
+        if let Some(batch_labels) = crate::cnv_pseudobulk::reconstruct_batch_labels(&data_vec) {
+            let topic_probs = z_nk.map(|x| x.exp());
+            let cnv_config = crate::cnv_pseudobulk::build_cnv_config(&args.cnv);
+
+            let cnv_result = crate::cnv_pseudobulk::detect_cnv_topic_informed(
+                data_vec,
+                &topic_probs,
+                &batch_labels,
+                &positions,
+                &cnv_config,
+            )?;
+
+            crate::cnv_pseudobulk::write_cnv_results(&cnv_result, &args.out, &gene_names)?;
+        } else {
+            info!("CNV detection: skipped (no batch information)");
+        }
+    }
 
     info!("Done");
     Ok(())

--- a/senna/src/fit_topic.rs
+++ b/senna/src/fit_topic.rs
@@ -314,6 +314,10 @@ pub struct TopicArgs {
         help = "L2 regularization strength for refinement"
     )]
     pub(crate) refine_reg: f64,
+
+    // CNV detection args
+    #[command(flatten)]
+    pub(crate) cnv: CnvArgs,
 }
 
 pub fn fit_topic_model(args: &TopicArgs) -> anyhow::Result<()> {
@@ -456,6 +460,29 @@ pub fn fit_topic_model(args: &TopicArgs) -> anyhow::Result<()> {
         (Some(&cell_names), Some("cell")),
         None,
     )?;
+
+    // CNV detection using topic proportions as cell-type membership
+    let gene_names = data_vec.row_names()?;
+    let cnv_positions = crate::cnv_pseudobulk::load_gene_positions(&args.cnv, &gene_names)?;
+
+    if let Some(positions) = cnv_positions {
+        if let Some(batch_labels) = crate::cnv_pseudobulk::reconstruct_batch_labels(&data_vec) {
+            let topic_probs = z_nk.map(|x| x.exp());
+            let cnv_config = crate::cnv_pseudobulk::build_cnv_config(&args.cnv);
+
+            let cnv_result = crate::cnv_pseudobulk::detect_cnv_topic_informed(
+                data_vec,
+                &topic_probs,
+                &batch_labels,
+                &positions,
+                &cnv_config,
+            )?;
+
+            crate::cnv_pseudobulk::write_cnv_results(&cnv_result, &args.out, &gene_names)?;
+        } else {
+            info!("CNV detection: skipped (no batch information)");
+        }
+    }
 
     info!("Done");
     Ok(())

--- a/senna/src/main.rs
+++ b/senna/src/main.rs
@@ -1,4 +1,5 @@
 mod cluster;
+mod cnv_pseudobulk;
 mod embed_common;
 mod fit_clustering;
 mod fit_indexed_topic;

--- a/senna/src/svd/fit.rs
+++ b/senna/src/svd/fit.rs
@@ -177,6 +177,9 @@ pub struct SvdArgs {
         long_help = "Save computed log-variance for all features to {out}.feature_variance.parquet"
     )]
     save_feature_variance: bool,
+
+    #[command(flatten)]
+    cnv: CnvArgs,
 }
 
 pub fn fit_svd(args: &SvdArgs) -> anyhow::Result<()> {
@@ -300,6 +303,12 @@ pub fn fit_svd(args: &SvdArgs) -> anyhow::Result<()> {
         )?;
     }
 
+    // 4b. Load gene positions for CNV (if requested)
+    let cnv_positions = {
+        let gene_names = data_vec.row_names()?;
+        crate::cnv_pseudobulk::load_gene_positions(&args.cnv, &gene_names)?
+    };
+
     // 5. Nystrom projection
     let x_dn = match collapse_out.mu_adjusted.as_ref() {
         Some(adj) => adj,
@@ -347,6 +356,22 @@ pub fn fit_svd(args: &SvdArgs) -> anyhow::Result<()> {
             sel.selected_names.len(),
             feature_file
         );
+    }
+
+    // 6. Cluster-informed CNV detection (after SVD, using latent for clustering)
+    if let Some(positions) = cnv_positions {
+        let cnv_config = crate::cnv_pseudobulk::build_cnv_config(&args.cnv);
+
+        let cnv_result = crate::cnv_pseudobulk::detect_cnv_cluster_informed(
+            data_vec,
+            &nystrom_out.latent_nk,
+            &batch_membership,
+            &positions,
+            args.cnv.cnv_factors.max(3), // use at least 3 clusters
+            &cnv_config,
+        )?;
+
+        crate::cnv_pseudobulk::write_cnv_results(&cnv_result, &args.out, &gene_names)?;
     }
 
     Ok(())


### PR DESCRIPTION
## Overview
Implements a complete CNV detection pipeline combining multi-level genomic coarsening with factorial tree inference for cluster/topic-informed analysis.

## Key Changes

### CNV Module (`cnv/`)
- **`coarsening_tree.rs`** (443 lines): Multi-level coarsening tree for state inference
  - Builds hierarchical block structure from genome-ordered signal at multiple correlation thresholds
  - Tree belief propagation (upward + downward passes) for regularized state posteriors
  - Replaces chain HMM with O(nodes × K²) approximate tree inference

- **`factorial_tree.rs`** (552 lines): Factorial model for CNV detection from pseudobulk residuals
  - Decomposes block-level signal into F additive factors with independent state sequences
  - Gibbs sampling with tree-based state updates, conjugate Normal loadings, ESS for emissions
  - Supports optional null factor to absorb per-sample global offsets
  - Cell-level evaluation reduces to linear regression onto factor profiles

- **`detect.rs`** (218 lines): CNV detection pipeline orchestrator
  - Composes genome ordering → coarsening → factorial tree into single `detect_cnv()` call
  - Provides `evaluate_cell_cnv()` for projecting cell residuals onto learned factor profiles
  - Includes gene position readers for GFF/TSV formats

- **`genomic_coarsening.rs`**: Added `expand_vec_f32_to_genes()` for block-to-gene expansion
- **`hmm.rs`**: Made `forward_backward_with_emit()` and `viterbi_with_emit()` public
- **`lib.rs`**: Exported new modules

### Senna Module (`senna/`)
- **`cnv_pseudobulk.rs`** (304 lines): Pseudobulk CNV analysis
  - Aggregates multi-sample expression to pseudobulk per topic/cluster
  - Computes log(mu_residual) for each factor group
  - Integrates with CNV detection pipeline

- **`embed_common.rs`** (52 lines): Common embedding utilities
- **`fit_*.rs`**: Added CNV evaluation hooks to topic/SVD fit procedures
- **`Cargo.toml`**: Added dependencies for tree-based inference

### Data-Beans (`data-beans/`)
- **`handlers/analysis.rs`**: Extended simulation output
  - Per-batch ground truth CNV states
  - Clone tree relationships
  - Minimal GFF file for gene coordinates

- **`simulations/core.rs`**: Added per-batch CNV states and clone parent tracking for validation

## Architecture
The pipeline flows: **expression** → **pseudobulk per topic** → **log(μ_residual)** → **multi-level coarsening** → **factorial tree inference** → **per-cell evaluation**

Key design: factors combine additively, enabling detection of complex CNV patterns where samples carry multiple event types simultaneously.