### PR TITLE
senna: reuse per-cell projection across topic/layout (step 1 — manifest)

### DIFF
--- a/senna/src/fit_indexed_topic.rs
+++ b/senna/src/fit_indexed_topic.rs
@@ -544,6 +544,7 @@ pub fn fit_indexed_topic_model(args: &IndexedTopicArgs) -> anyhow::Result<()> {
         dictionary_suffix: Some("dictionary.parquet"),
         has_markers: args.markers.is_some(),
         has_model: true,
+        has_cell_proj: false,
         default_colour_by: "topic",
     })?;
 

--- a/senna/src/fit_joint_topic.rs
+++ b/senna/src/fit_joint_topic.rs
@@ -479,6 +479,7 @@ pub fn fit_joint_topic_model(args: &JointTopicArgs) -> anyhow::Result<()> {
         // joint-topic today.
         has_markers: false,
         has_model: false,
+        has_cell_proj: false,
         default_colour_by: "topic",
     })?;
 

--- a/senna/src/fit_topic.rs
+++ b/senna/src/fit_topic.rs
@@ -559,6 +559,7 @@ fn write_topic_manifest(
         dictionary_suffix: Some("dictionary.parquet"),
         has_markers,
         has_model: true,
+        has_cell_proj: false,
         default_colour_by: "topic",
     })
 }

--- a/senna/src/run_manifest.rs
+++ b/senna/src/run_manifest.rs
@@ -72,9 +72,12 @@ pub struct RunOutputs {
     /// marker file was given.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anchor_labels: Option<String>,
-    /// `{out}.pb_membership.parquet` — Pass-2 output (not written yet).
+    /// `{out}.cell_proj.parquet` — cell × `proj_dim` random projection
+    /// computed during training. Cached so `senna layout` can re-derive
+    /// PB structure (via RSVD + multi-level collapse on the projection)
+    /// without touching raw data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pb_membership: Option<String>,
+    pub cell_proj: Option<String>,
     /// `{out}.safetensors` — trained VAE weights (topic / itopic /
     /// joint-topic only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -191,6 +194,11 @@ pub struct RunDescription<'a> {
     /// `{basename}.metadata.json` (topic + itopic; not joint-topic, not
     /// SVD).
     pub has_model: bool,
+    /// True if the run emits `{basename}.cell_proj.parquet` — the
+    /// cached per-cell random projection layout reuses. All training
+    /// subcommands that produce PBs (topic, itopic, joint-topic, svd,
+    /// joint-svd) should set this.
+    pub has_cell_proj: bool,
     /// Default `--colour-by` for downstream plot / layout.
     pub default_colour_by: &'a str,
 }
@@ -222,6 +230,9 @@ pub fn write_run_manifest(desc: &RunDescription<'_>) -> anyhow::Result<()> {
     if desc.has_model {
         m.outputs.model = Some(format!("{basename}.safetensors"));
         m.outputs.metadata = Some(format!("{basename}.metadata.json"));
+    }
+    if desc.has_cell_proj {
+        m.outputs.cell_proj = Some(format!("{basename}.cell_proj.parquet"));
     }
     m.defaults.colour_by = Some(desc.default_colour_by.into());
 

--- a/senna/src/svd/fit.rs
+++ b/senna/src/svd/fit.rs
@@ -377,6 +377,7 @@ pub fn fit_svd(args: &SvdArgs) -> anyhow::Result<()> {
         dictionary_suffix: Some("dictionary.parquet"),
         has_markers: false,
         has_model: false,
+        has_cell_proj: false,
         // SVD produces no topic / cluster labels on its own; users
         // typically run `senna clustering` next, so the viz column
         // `cluster` is the natural default.

--- a/senna/src/svd/fit_joint.rs
+++ b/senna/src/svd/fit_joint.rs
@@ -239,6 +239,7 @@ pub fn fit_joint_svd(args: &JointSvdArgs) -> anyhow::Result<()> {
         dictionary_suffix: Some("dictionary.parquet"),
         has_markers: false,
         has_model: false,
+        has_cell_proj: false,
         default_colour_by: "cluster",
     })?;
 


### PR DESCRIPTION
## Summary

First step of a larger refactor to eliminate redundant pseudobulk (PB) computation between `senna topic|itopic|svd|...` and `senna layout`.

Today `senna layout` re-runs `load_and_collapse` (project raw cells → batch-correct → hierarchically partition into PBs) even though training just did the same work. The fix is to cache the per-cell random projection during training and have layout re-derive PB structure from it via RSVD + collapse, skipping the raw-data pass entirely.

This PR is schema-only prep:

- Drop the stale `outputs.pb_membership` manifest slot (marked *\"Pass-2 output (not written yet)\"* — never written, not needed in the new design).
- Add `outputs.cell_proj: Option<String>` pointing at `{prefix}.cell_proj.parquet`.
- Add `has_cell_proj: bool` to `RunDescription`; all five training call sites (topic, itopic, joint-topic, svd, joint-svd) opt in with `false` for now.

No behavioural change yet — the write and the layout fast path land in follow-up commits on this branch.

## Follow-ups (next commits on this branch)

- Write `{prefix}.cell_proj.parquet` at end of each training subcommand; flip `has_cell_proj: true`.
- Rename \`prepare_viz\` → \`preprocess_layout_data\` / \`VizPrep\` → \`LayoutPrep\`.
- Add \`preprocess_layout_data_from_cache\` fast path (load cell_proj → RSVD → collapse on SVD scores → proj-space PB features).
- Remove the non-working \`senna layout topic-pb\` subcommand.
- Add \`senna layout mst\` (Kruskal MST + Fruchterman–Reingold with random init + Nyström extension to cells).
- Switch all layout routines (tsne/phate/mst) to uniform random PB init with a shared \`--seed\` flag.

## Test plan

- [x] \`cargo build -p senna\` passes
- [ ] End-to-end run (\`senna topic\` → \`senna layout phate\` → \`senna plot\`) on the simulated 2000g×3000c dataset — deferred until the cache + fast-path commits land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)