### PR TITLE
feat(cocoa): spatial-diff subcommand + NB-Fisher housekeeping

### DIFF
--- a/cocoa/src/collapse_cocoa_data.rs
+++ b/cocoa/src/collapse_cocoa_data.rs
@@ -13,6 +13,10 @@ pub struct CocoaCollapseIn<'a> {
     pub hyper_param: Option<(f32, f32)>,
     pub cell_topic_nk: Mat,                  // cell x cell type topic
     pub exposure_assignment: &'a Vec<usize>, // exposure assignment
+    /// Optional per-gene NB-Fisher housekeeping weights. If present, y1/y0/y1_di
+    /// sufficient stats are row-scaled by w_g after accumulation so housekeeping
+    /// genes contract toward the prior in τ, μ, γ posteriors.
+    pub gene_weights: Option<&'a [f32]>,
 }
 
 pub trait CocoaCollapseOps {
@@ -57,7 +61,25 @@ impl CocoaCollapseOps for SparseIoVec {
         info!("matching and collecting statistics per topic (cell type)");
         self.visit_columns_by_group(&collect_matched_stat_visitor, cocoa_input, &mut cocoa_stat)?;
 
+        if let Some(w) = cocoa_input.gene_weights {
+            apply_gene_weights_to_stat(&mut cocoa_stat, w);
+        }
+
         Ok(cocoa_stat)
+    }
+}
+
+/// Row-scale every (g, ·) entry of y1, y0, and indv_y1 sufficient stats by
+/// w_g. The denom / size stats are untouched — this is the same pattern as
+/// pinto's `apply_gene_weights` on gene-topic sufficient stats.
+pub(crate) fn apply_gene_weights_to_stat(stat: &mut CocoaStat, weights: &[f32]) {
+    let n_topics = stat.num_topics();
+    for k in 0..n_topics {
+        for (g, &w) in weights.iter().enumerate() {
+            stat.y1_stat_mut(k).row_mut(g).scale_mut(w);
+            stat.y0_stat_mut(k).row_mut(g).scale_mut(w);
+            stat.indv_y1_stat_mut(k).row_mut(g).scale_mut(w);
+        }
     }
 }
 
@@ -255,6 +277,7 @@ impl MatchCache {
         n_topics: usize,
         n_opt_iter: Option<usize>,
         hyper_param: Option<(f32, f32)>,
+        gene_weights: Option<&[f32]>,
     ) -> anyhow::Result<CocoaStat> {
         let n_samples = self.samples.len();
         let n_indv = self.n_indv;
@@ -280,6 +303,10 @@ impl MatchCache {
                 n_indv,
                 &mut cocoa_stat,
             )?;
+        }
+
+        if let Some(w) = gene_weights {
+            apply_gene_weights_to_stat(&mut cocoa_stat, w);
         }
 
         Ok(cocoa_stat)

--- a/cocoa/src/main.rs
+++ b/cocoa/src/main.rs
@@ -6,12 +6,17 @@ mod run_collapse;
 mod run_diff;
 mod run_sim_collider;
 mod run_sim_one_type;
+mod run_sim_spatial;
+mod run_spatial_diff;
+mod spatial_match;
 mod stat;
 
 use crate::run_collapse::*;
 use crate::run_diff::*;
 use crate::run_sim_collider::*;
 use crate::run_sim_one_type::*;
+use crate::run_sim_spatial::*;
+use crate::run_spatial_diff::*;
 
 use clap::{Parser, Subcommand};
 
@@ -55,6 +60,107 @@ References:
         alias = "pseudobulk"
     )]
     Collapse(CollapseArgs),
+
+    #[command(
+        about = "Per-topic spatial differential expression",
+        long_about = "\
+Per-topic spatial differential expression with topic-confounder adjustment.
+
+Problem:
+  Given pinto's cell-to-topic propensity θ and spatial coordinates, find
+  genes whose expression differs across *spatial context* within each
+  latent topic. Topic identity is a confounder between location and
+  expression — we condition on topic by stratification rather than by
+  propensity modeling (which is poorly posed when spatial features are
+  high-dimensional and locally smooth).
+
+Algorithm (per topic k):
+  1. Stratify cells on θ_{·,k}:
+        HIGH  if θ ≥ q_high  (default 0.75)
+        LOW   if θ ≤ q_low   (default 0.25)
+        DROP  otherwise
+  2. Build a spatial kNN graph over all cells (--spatial-knn, optionally
+     clipped by --spatial-radius).
+  3. For each HIGH cell, collect its spatial-kNN neighbors that are in
+     the LOW stratum. Weight each (HIGH, LOW_neighbor) pair by
+        w_ij = θ_i · exp(−d_ij) · (1 − θ_j) / Σ_j'
+  4. Accumulate sufficient stats into pseudobulks per individual
+     (or a single cohort bin if --indv-files is absent):
+        y_high[g, i] = Σ_cell∈HIGH θ · y_{g,cell}
+        y_low [g, i] = Σ matched-LOW contributions (same gene, weighted)
+  5. Optionally row-scale y_high / y_low by NB-Fisher housekeeping
+     weights (default ON, --no-adjust-housekeeping disables).
+  6. Fit independent Gamma posteriors τ_high, τ_low per (gene × indv)
+     and report log τ_high − log τ_low as the contrast.
+  7. Hybrid permutation + CLT p-values (--n-permutations N):
+       - Shuffle HIGH/LOW labels within each individual, keeping the
+         spatial graph and DROP cells fixed.
+       - Recompute matching, accumulation, and Gamma fit per permutation.
+       - Estimate null mean/sd per gene via Welford; report
+         z = (observed − null_mean) / null_sd and
+         p = erfc(|z|/√2) (two-sided Gaussian).
+       - 100 reps is usually enough for z-based ranking; increase for
+         stable tail p-values.
+
+Outputs:
+  {out}.spatial_diff.tsv.gz
+      columns: gene, topic, contrast_log, null_mean, null_sd, z, pval
+  {out}.spatial_diff_indiv.tsv.gz  (only when --indv-files is set)
+      columns: gene, topic, individual, log_fold_change
+      — per-individual log τ_high − log τ_low, analogous to cocoa
+        diff's τ_{d,i} output.
+
+References:
+  Park & Kellis (2021) Genome Biol — CoCoA-diff (counterfactual match)
+  Hartwig et al. (2023) Eur J Epidemiol — residual collider stratification
+"
+    )]
+    SpatialDiff(SpatialDiffArgs),
+
+    #[command(
+        about = "Simulate spatial single-cell data with ground-truth within-topic DE markers",
+        long_about = "\
+Minimal spatial-DE simulator for validating `cocoa spatial-diff`.
+
+Generative model:
+  Cells are placed on an integer grid of size --grid-x × --grid-y and
+  split along x into --n-indv contiguous individual blocks. For each
+  cell i:
+    θ_i  ~ Dirichlet(1, …, 1) with --n-topics components
+           (intermixed HIGH/LOW cells so spatial kNN can bridge them)
+    y_{g,i} ~ Poisson(λ_{g,i})
+    λ_{g,i} = --baseline-rate, or --effect-size if cell i is a marker
+              cell for gene g (see below).
+
+Marker injection:
+  --n-spatial-markers random (gene, topic k, region R) triples are
+  drawn. A cell is a \"marker cell\" for gene g iff
+     θ_{i,k} ≥ quantile_{--topic-high-quantile}(θ_{·,k})  AND  (x_i, y_i) ∈ R
+  where R is one of {x<median, x≥median, y<median, y≥median}.
+  Each gene is used at most once.
+
+Outputs (prefixed by --out):
+  {out}.zarr (or .h5)              — sparse G × N counts
+  {out}.topic.parquet              — N × K Dirichlet propensities
+                                     (directly usable as `spatial-diff
+                                     --topic-proportion-files`)
+  {out}.coords.tsv.gz              — row-order `x<TAB>y` (no header)
+  {out}.indv.tsv.gz                — cell<TAB>individual
+  {out}.ground_truth.tsv.gz        — gene<TAB>topic<TAB>region<TAB>effect
+
+Typical workflow:
+  cocoa simulate-spatial --out sim/demo
+  cocoa spatial-diff sim/demo.zarr \\
+        -r sim/demo.topic.parquet \\
+        -i sim/demo.indv.tsv.gz \\
+        --coords-file sim/demo.coords.tsv.gz \\
+        --n-permutations 100 \\
+        --out sim/demo_result
+  # compare sim/demo.ground_truth.tsv.gz to the top-|z| hits per topic
+",
+        aliases = ["sim-spatial"]
+    )]
+    SimulateSpatial(SimSpatialArgs),
 
     #[command(
         about = "Simulate single-cell data with confounded exposure (one cell type)",
@@ -160,6 +266,12 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Collapse(args) => {
             run_collapse(args.clone())?;
+        }
+        Commands::SpatialDiff(args) => {
+            run_cocoa_spatial_diff(args.clone())?;
+        }
+        Commands::SimulateSpatial(args) => {
+            run_sim_spatial(args.clone())?;
         }
         Commands::SimulateOne(args) => {
             run_sim_one_type_data(args.clone())?;

--- a/cocoa/src/randomly_partition_data.rs
+++ b/cocoa/src/randomly_partition_data.rs
@@ -1,8 +1,36 @@
 use crate::common::*;
 
-use data_beans_alg::collapse_data::CollapsingOps;
+use data_beans_alg::collapse_data::{
+    CollapsingOps, MultilevelCollapsingOps, MultilevelParams, DEFAULT_KNN, DEFAULT_OPT_ITER,
+};
 use data_beans_alg::random_projection::RandProjOps;
+use data_beans_alg::refine_multilevel::RefineParams;
 use rustc_hash::FxHashMap as HashMap;
+
+/// Opt-in multilevel refinement settings for pseudobulk assignment.
+/// When `Some`, cocoa routes pseudobulk construction through
+/// `collapse_columns_multilevel_vec` (same path senna uses) so each
+/// pseudobulk is DC-Poisson-refined instead of being a raw hash partition.
+#[derive(Clone)]
+pub struct RefineSettings {
+    pub num_levels: usize,
+    pub knn_super_cells: usize,
+    pub sort_dim: usize,
+    pub num_opt_iter: usize,
+    pub refine_params: RefineParams,
+}
+
+impl RefineSettings {
+    pub fn with_proj_dim(proj_dim: usize) -> Self {
+        Self {
+            num_levels: 2,
+            knn_super_cells: DEFAULT_KNN,
+            sort_dim: proj_dim.min(12),
+            num_opt_iter: DEFAULT_OPT_ITER,
+            refine_params: RefineParams::default(),
+        }
+    }
+}
 
 pub trait RandPartitionOps {
     fn assign_pseudobulk_individuals<T>(
@@ -10,6 +38,19 @@ pub trait RandPartitionOps {
         proj_dim: usize,
         block_size: usize,
         cell_to_indv: &[T],
+    ) -> anyhow::Result<()>
+    where
+        T: Sync + Send + std::hash::Hash + Eq + Clone + ToString;
+
+    /// Multilevel DC-Poisson-refined pseudobulk assignment. Mirrors
+    /// senna's `collapse_columns_multilevel_vec` pathway so the refined
+    /// cell→pseudobulk mapping is DC-Poisson coherent across tools.
+    fn assign_pseudobulk_individuals_refined<T>(
+        &mut self,
+        proj_dim: usize,
+        block_size: usize,
+        cell_to_indv: &[T],
+        refine: &RefineSettings,
     ) -> anyhow::Result<()>
     where
         T: Sync + Send + std::hash::Hash + Eq + Clone + ToString;
@@ -94,6 +135,45 @@ impl RandPartitionOps for SparseIoVec {
         )?;
         let raw = self.project_columns(proj_dim, Some(block_size))?;
         apply_projections(self, &centred.proj, &raw.proj, cell_to_indv)
+    }
+
+    fn assign_pseudobulk_individuals_refined<T>(
+        &mut self,
+        proj_dim: usize,
+        block_size: usize,
+        cell_to_indv: &[T],
+        refine: &RefineSettings,
+    ) -> anyhow::Result<()>
+    where
+        T: Sync + Send + std::hash::Hash + Eq + Clone + ToString,
+    {
+        let centred = self.project_columns_with_batch_correction(
+            proj_dim,
+            Some(block_size),
+            Some(cell_to_indv),
+        )?;
+
+        let params = MultilevelParams {
+            knn_super_cells: refine.knn_super_cells,
+            num_levels: refine.num_levels.max(1),
+            sort_dim: refine.sort_dim,
+            num_opt_iter: refine.num_opt_iter,
+            oversample: false,
+            refine: Some(refine.refine_params.clone()),
+        };
+
+        // collapse_columns_multilevel_vec:
+        // - registers batch membership (cell_to_indv)
+        // - builds per-batch HNSW (raw proj_kn is the centred one here; cocoa's
+        //   KNN matching uses the HNSW index built here)
+        // - hash-partitions at the finest level then DC-Poisson refines
+        //   sibling-constrained moves
+        // - leaves `self.grouped_columns` set to the finest refined level
+        // We drop the returned Vec<CollapsedOut> — cocoa doesn't use the
+        // per-level collapsed Gamma stats; it only needs the refined
+        // cell→group mapping + HNSW.
+        let _levels = self.collapse_columns_multilevel_vec(&centred.proj, cell_to_indv, &params)?;
+        Ok(())
     }
 
     fn assign_pseudobulk_with_known_confounders<T>(

--- a/cocoa/src/run_collapse.rs
+++ b/cocoa/src/run_collapse.rs
@@ -3,8 +3,10 @@ use crate::input::*;
 
 use auxiliary_data::cell_annotations::{CellAnnotations, CellTypeMembership};
 use clap::Parser;
-use data_beans_alg::pseudobulk::collapse_pseudobulk;
+use data_beans_alg::gene_weighting::compute_nb_fisher_weights;
+use data_beans_alg::pseudobulk::collapse_pseudobulk_weighted;
 use matrix_param::io::ParamIo;
+use matrix_util::common_io::write_lines;
 use rustc_hash::FxHashMap as HashMap;
 
 #[derive(Parser, Debug, Clone)]
@@ -84,6 +86,25 @@ pub struct CollapseArgs {
         help = "Preload all the columns data."
     )]
     preload_data: bool,
+
+    #[arg(
+        long = "no-adjust-housekeeping",
+        default_value_t = false,
+        help = "Disable NB-Fisher housekeeping gene adjustment.",
+        long_help = "By default, per-(individual, cell_type) count sums are row-scaled by\n\
+                     NB-Fisher weights w_g = 1 / (1 + π_g · s̄ · φ(μ_g)) before the\n\
+                     Gamma posterior update. High-mean / high-dispersion housekeeping\n\
+                     genes get attenuated, matching pinto's gene-topic adjustment.\n\
+                     Use this flag to disable for raw rates."
+    )]
+    no_adjust_housekeeping: bool,
+
+    #[arg(
+        long = "block-size",
+        default_value_t = 1000,
+        help = "Block size for reading cells when fitting the NB trend."
+    )]
+    block_size: usize,
 }
 
 pub fn run_collapse(args: CollapseArgs) -> anyhow::Result<()> {
@@ -110,13 +131,43 @@ pub fn run_collapse(args: CollapseArgs) -> anyhow::Result<()> {
         cell_type_names: data.sorted_topic_names,
     };
 
-    // Delegate to data-beans-alg's collapse_pseudobulk
-    let collapsed = collapse_pseudobulk(
+    // NB-Fisher housekeeping weights (default ON, matches pinto)
+    let gene_weights: Option<Vec<f32>> = if args.no_adjust_housekeeping {
+        None
+    } else {
+        info!("Computing NB-Fisher housekeeping weights (--no-adjust-housekeeping to disable)");
+        let w = compute_nb_fisher_weights(&data.sparse_data, Some(args.block_size))?;
+        let wmin = w.iter().cloned().fold(f32::INFINITY, f32::min);
+        let wmax = w.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        info!(
+            "NB-Fisher weights: {} genes, min={:.4}, max={:.4}",
+            w.len(),
+            wmin,
+            wmax
+        );
+        let gw_path = format!("{}.gene_weights.tsv.gz", args.out);
+        let gene_names_w = data.sparse_data.row_names()?;
+        let gw_lines: Vec<Box<str>> = std::iter::once("gene\tweight".into())
+            .chain(
+                gene_names_w
+                    .iter()
+                    .zip(w.iter())
+                    .map(|(g, &wg)| format!("{}\t{}", g, wg).into()),
+            )
+            .collect();
+        write_lines(&gw_lines, &gw_path)?;
+        info!("Wrote gene weights to {}", gw_path);
+        Some(w)
+    };
+
+    // Delegate to data-beans-alg's collapse_pseudobulk_weighted
+    let collapsed = collapse_pseudobulk_weighted(
         data.sparse_data,
         &annotations,
         &membership,
         args.a0,
         args.b0,
+        gene_weights.as_deref(),
     )?;
 
     // Write per cell type

--- a/cocoa/src/run_diff.rs
+++ b/cocoa/src/run_diff.rs
@@ -5,6 +5,7 @@ use crate::randomly_partition_data::*;
 use crate::stat::*;
 
 use clap::Parser;
+use data_beans_alg::gene_weighting::compute_nb_fisher_weights;
 use matrix_param::io::*;
 use matrix_util::common_io::write_lines;
 use matrix_util::traits::{IoOps, MatOps};
@@ -193,6 +194,45 @@ pub struct DiffArgs {
                      Hartwig et al. (2023) Eur J Epidemiol."
     )]
     no_residualize_topics: bool,
+
+    #[arg(
+        long = "no-adjust-housekeeping",
+        default_value_t = false,
+        help = "Disable NB-Fisher housekeeping gene adjustment.",
+        long_help = "By default, y1/y0 sufficient statistics are row-scaled by NB-Fisher\n\
+                     weights w_g = 1 / (1 + π_g · s̄ · φ(μ_g)) after accumulation, so\n\
+                     τ, μ, γ posteriors contract toward the prior for housekeeping\n\
+                     (high-mean / high-dispersion) genes. Matches pinto's adjustment."
+    )]
+    no_adjust_housekeeping: bool,
+
+    #[arg(
+        long = "refine",
+        default_value_t = false,
+        help = "Refine cell→pseudobulk membership via senna's multilevel DC-Poisson pass.",
+        long_help = "When set, cocoa routes pseudobulk assignment through the same\n\
+                     multilevel path senna uses (collapse_columns_multilevel_vec with\n\
+                     BBKNN + DC-Poisson refinement). Cells are reassigned across\n\
+                     sibling pseudobulks by Poisson likelihood under NB-Fisher gene\n\
+                     weighting, so each pseudobulk is more internally coherent.\n\
+                     Only applies when using the default pseudobulk path\n\
+                     (no --covariate-file and no --adjustment-data-files)."
+    )]
+    refine: bool,
+
+    #[arg(
+        long = "refine-num-levels",
+        default_value_t = 2,
+        help = "Number of coarsening levels for multilevel refinement."
+    )]
+    refine_num_levels: usize,
+
+    #[arg(
+        long = "refine-knn-super-cells",
+        default_value_t = 10,
+        help = "BBKNN fan-out for multilevel refinement."
+    )]
+    refine_knn_super_cells: usize,
 }
 
 /////////////////////////////////////
@@ -307,6 +347,21 @@ pub fn run_cocoa_diff(args: DiffArgs) -> anyhow::Result<()> {
             args.block_size,
             &data.cell_to_indv,
         )?;
+    } else if args.refine {
+        info!(
+            "Refining pseudobulk assignment via multilevel DC-Poisson (num_levels={}, knn_super_cells={})",
+            args.refine_num_levels, args.refine_knn_super_cells
+        );
+        let mut refine_settings =
+            crate::randomly_partition_data::RefineSettings::with_proj_dim(args.proj_dim);
+        refine_settings.num_levels = args.refine_num_levels;
+        refine_settings.knn_super_cells = args.refine_knn_super_cells;
+        data.sparse_data.assign_pseudobulk_individuals_refined(
+            args.proj_dim,
+            args.block_size,
+            &data.cell_to_indv,
+            &refine_settings,
+        )?;
     } else {
         data.sparse_data.assign_pseudobulk_individuals(
             args.proj_dim,
@@ -346,6 +401,22 @@ pub fn run_cocoa_diff(args: DiffArgs) -> anyhow::Result<()> {
     let n_topics = data.cell_topic.ncols();
     let gene_names = data.sparse_data.row_names()?;
 
+    let gene_weights: Option<Vec<f32>> = if args.no_adjust_housekeeping {
+        None
+    } else {
+        info!("Computing NB-Fisher housekeeping weights (--no-adjust-housekeeping to disable)");
+        let w = compute_nb_fisher_weights(&data.sparse_data, Some(args.block_size))?;
+        let wmin = w.iter().cloned().fold(f32::INFINITY, f32::min);
+        let wmax = w.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        info!(
+            "NB-Fisher weights: {} genes, min={:.4}, max={:.4}",
+            w.len(),
+            wmin,
+            wmax
+        );
+        Some(w)
+    };
+
     let cocoa_input = CocoaCollapseIn {
         n_genes,
         n_topics,
@@ -354,6 +425,7 @@ pub fn run_cocoa_diff(args: DiffArgs) -> anyhow::Result<()> {
         hyper_param: Some((args.a0, args.b0)),
         cell_topic_nk: data.cell_topic,
         exposure_assignment: &exposure_assignment,
+        gene_weights: gene_weights.as_deref(),
     };
 
     info!("Collecting statistics...");
@@ -412,6 +484,7 @@ pub fn run_cocoa_diff(args: DiffArgs) -> anyhow::Result<()> {
         let num_opt_iter = args.num_opt_iter;
         let cell_topic = &cocoa_input.cell_topic_nk;
         let n_perm = args.n_permutations;
+        let perm_gene_weights = gene_weights.as_deref();
 
         let perm_contrasts: Vec<Vec<f32>> = permuted_exposures
             .into_par_iter()
@@ -424,6 +497,7 @@ pub fn run_cocoa_diff(args: DiffArgs) -> anyhow::Result<()> {
                     n_topics,
                     num_opt_iter,
                     hyper_param,
+                    perm_gene_weights,
                 )?;
                 let perm_params = perm_stat.estimate_parameters()?;
                 let contrast = compute_exposure_contrast(&perm_params, &perm_exposure);

--- a/cocoa/src/run_sim_spatial.rs
+++ b/cocoa/src/run_sim_spatial.rs
@@ -1,0 +1,321 @@
+//! `cocoa simulate-spatial` — minimal spatial-DE simulator.
+//!
+//! Generates ground-truth inputs to validate `cocoa spatial-diff`.
+//! See `main.rs` long_about for the generative model and output layout.
+
+use crate::common::*;
+
+use clap::Parser;
+use matrix_util::common_io::{mkdir, write_lines};
+use matrix_util::traits::IoOps;
+use rand::{RngExt, SeedableRng};
+use rand_distr::{Distribution, Gamma as GammaDist, Poisson};
+use rustc_hash::FxHashSet;
+
+#[derive(Parser, Debug, Clone)]
+pub struct SimSpatialArgs {
+    #[arg(long, default_value_t = 30, help = "Grid width (number of x bins).")]
+    grid_x: usize,
+
+    #[arg(long, default_value_t = 30, help = "Grid height (number of y bins).")]
+    grid_y: usize,
+
+    #[arg(
+        long,
+        default_value_t = 100,
+        help = "Number of genes in the simulated panel."
+    )]
+    n_genes: usize,
+
+    #[arg(
+        long,
+        default_value_t = 3,
+        help = "Number of latent topics (Dirichlet components)."
+    )]
+    n_topics: usize,
+
+    #[arg(
+        long,
+        default_value_t = 4,
+        help = "Number of individuals (contiguous x-blocks of the grid)."
+    )]
+    n_indv: usize,
+
+    #[arg(
+        long,
+        default_value_t = 5,
+        help = "Number of ground-truth spatial DE markers to inject.",
+        long_help = "Each marker is a random (gene, topic, region) triple.\n\
+                     The gene is elevated in cells that are simultaneously\n\
+                     HIGH in the target topic and inside the region.\n\
+                     Each gene is chosen at most once across markers."
+    )]
+    n_spatial_markers: usize,
+
+    #[arg(
+        long,
+        default_value_t = 0.5,
+        help = "Baseline Poisson rate for non-marker cells."
+    )]
+    baseline_rate: f32,
+
+    #[arg(
+        long,
+        default_value_t = 15.0,
+        help = "Elevated Poisson rate inside a marker region."
+    )]
+    effect_size: f32,
+
+    #[arg(
+        long,
+        default_value_t = 0.75,
+        help = "θ_k quantile defining HIGH cells for marker injection."
+    )]
+    topic_high_quantile: f32,
+
+    #[arg(long, default_value_t = 42, help = "Random seed.")]
+    rseed: u64,
+
+    #[arg(
+        long,
+        value_enum,
+        default_value = "zarr",
+        help = "Sparse matrix backend for counts (`zarr` or `hdf5`)."
+    )]
+    backend: SparseIoBackend,
+
+    #[arg(
+        long,
+        short,
+        required = true,
+        help = "Output prefix (all files share this prefix)."
+    )]
+    out: Box<str>,
+}
+
+/// One injected spatial marker: gene `g` is elevated in cells whose
+/// θ_k ≥ HIGH and (x, y) lie in `region`.
+struct SpatialMarker {
+    gene: usize,
+    topic: usize,
+    region: Region,
+}
+
+#[derive(Clone, Copy)]
+enum Region {
+    XLeft(f32),
+    XRight(f32),
+    YBottom(f32),
+    YTop(f32),
+}
+
+impl Region {
+    fn contains(&self, x: f32, y: f32) -> bool {
+        match *self {
+            Region::XLeft(thr) => x < thr,
+            Region::XRight(thr) => x >= thr,
+            Region::YBottom(thr) => y < thr,
+            Region::YTop(thr) => y >= thr,
+        }
+    }
+    fn label(&self) -> String {
+        match *self {
+            Region::XLeft(t) => format!("x<{t}"),
+            Region::XRight(t) => format!("x>={t}"),
+            Region::YBottom(t) => format!("y<{t}"),
+            Region::YTop(t) => format!("y>={t}"),
+        }
+    }
+}
+
+pub fn run_sim_spatial(args: SimSpatialArgs) -> anyhow::Result<()> {
+    let n_cells = args.grid_x * args.grid_y;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(args.rseed);
+
+    info!(
+        "Simulating {} cells on {}x{} grid, {} genes, {} topics, {} individuals",
+        n_cells, args.grid_x, args.grid_y, args.n_genes, args.n_topics, args.n_indv
+    );
+
+    // Coords (row-major: (xi, yi) for cell i = xi * grid_y + yi)
+    let coords: Vec<(f32, f32)> = (0..n_cells)
+        .map(|i| {
+            let xi = (i / args.grid_y) as f32;
+            let yi = (i % args.grid_y) as f32;
+            (xi, yi)
+        })
+        .collect();
+
+    // Per-cell Dirichlet topic θ
+    let gu = GammaDist::new(1.0, 1.0).unwrap();
+    let mut theta = Mat::zeros(n_cells, args.n_topics);
+    for i in 0..n_cells {
+        let mut s = 0f32;
+        let mut row = vec![0f32; args.n_topics];
+        for r in row.iter_mut() {
+            *r = gu.sample(&mut rng) as f32;
+            s += *r;
+        }
+        for (k, &r) in row.iter().enumerate() {
+            theta[(i, k)] = r / s;
+        }
+    }
+
+    // Per-cell individual: split along x into n_indv blocks
+    let indv_ids: Vec<Box<str>> = (0..args.n_indv)
+        .map(|i| format!("indv{i}").into_boxed_str())
+        .collect();
+    let cell_to_indv: Vec<Box<str>> = (0..n_cells)
+        .map(|i| {
+            let xi = i / args.grid_y;
+            let bin = (xi * args.n_indv) / args.grid_x;
+            indv_ids[bin.min(args.n_indv - 1)].clone()
+        })
+        .collect();
+
+    // Per-topic HIGH quantile thresholds
+    let mut hi_thr = vec![0f32; args.n_topics];
+    for k in 0..args.n_topics {
+        let mut col: Vec<f32> = (0..n_cells).map(|i| theta[(i, k)]).collect();
+        col.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        hi_thr[k] = col[((n_cells as f32) * args.topic_high_quantile) as usize];
+    }
+
+    // Pick markers: random (gene, topic, region)
+    let x_median = (args.grid_x as f32 - 1.0) * 0.5;
+    let y_median = (args.grid_y as f32 - 1.0) * 0.5;
+    let region_menu = [
+        Region::XLeft(x_median),
+        Region::XRight(x_median),
+        Region::YBottom(y_median),
+        Region::YTop(y_median),
+    ];
+    let mut markers: Vec<SpatialMarker> = Vec::with_capacity(args.n_spatial_markers);
+    let mut used_genes: FxHashSet<usize> = Default::default();
+    while markers.len() < args.n_spatial_markers && used_genes.len() < args.n_genes {
+        let g: usize = rng.random_range(0..args.n_genes);
+        if !used_genes.insert(g) {
+            continue;
+        }
+        let k: usize = rng.random_range(0..args.n_topics);
+        let r = region_menu[rng.random_range(0..region_menu.len())];
+        markers.push(SpatialMarker {
+            gene: g,
+            topic: k,
+            region: r,
+        });
+    }
+    info!(
+        "Injected {} spatial markers (quantile > {})",
+        markers.len(),
+        args.topic_high_quantile
+    );
+
+    // Generate counts (triplets)
+    let baseline = Poisson::new(args.baseline_rate).unwrap();
+    let elevated = Poisson::new(args.effect_size).unwrap();
+    let mut triplets: Vec<(u64, u64, f32)> = Vec::new();
+    for i in 0..n_cells {
+        let (xi, yi) = coords[i];
+        for g in 0..args.n_genes {
+            let mut hit = false;
+            for m in &markers {
+                if m.gene == g
+                    && theta[(i, m.topic)] >= hi_thr[m.topic]
+                    && m.region.contains(xi, yi)
+                {
+                    hit = true;
+                    break;
+                }
+            }
+            let y: f32 = if hit {
+                elevated.sample(&mut rng)
+            } else {
+                baseline.sample(&mut rng)
+            };
+            if y > 0.0 {
+                triplets.push((g as u64, i as u64, y));
+            }
+        }
+    }
+
+    // Write out
+    let out = args.out.clone();
+    mkdir(&out)?;
+
+    let backend_file = match args.backend {
+        SparseIoBackend::HDF5 => format!("{out}.h5"),
+        SparseIoBackend::Zarr => format!("{out}.zarr"),
+    };
+
+    let gene_names: Vec<Box<str>> = (0..args.n_genes)
+        .map(|g| format!("gene{g}").into_boxed_str())
+        .collect();
+    let cell_names: Vec<Box<str>> = (0..n_cells)
+        .map(|i| format!("cell{i}").into_boxed_str())
+        .collect();
+
+    let mut sp = create_sparse_from_triplets(
+        &triplets,
+        (args.n_genes, n_cells, triplets.len()),
+        Some(&backend_file),
+        Some(&args.backend),
+    )?;
+    sp.register_row_names_vec(&gene_names);
+    sp.register_column_names_vec(&cell_names);
+    info!("Wrote sparse counts to {backend_file}");
+
+    // Topic propensity parquet (N × K, cell-name as row index, "topic{k}" columns)
+    let topic_cols: Vec<Box<str>> = (0..args.n_topics)
+        .map(|k| format!("topic{k}").into_boxed_str())
+        .collect();
+    let theta_path = format!("{out}.topic.parquet");
+    theta.to_parquet_with_names(
+        &theta_path,
+        (Some(&cell_names), Some("cell")),
+        Some(&topic_cols),
+    )?;
+    info!("Wrote topic propensity to {theta_path}");
+
+    // Coords TSV.gz
+    // Coords: row-order (no header, no cell-name column) so they align
+    // with data column positions regardless of batch-tag suffixes.
+    let coords_path = format!("{out}.coords.tsv.gz");
+    let mut lines: Vec<Box<str>> = Vec::with_capacity(n_cells);
+    for &(x, y) in &coords {
+        lines.push(format!("{x}\t{y}").into());
+    }
+    write_lines(&lines, &coords_path)?;
+    info!("Wrote coords to {coords_path}");
+
+    // Individual labels TSV.gz (cell\tindv)
+    let indv_path = format!("{out}.indv.tsv.gz");
+    let mut ilines: Vec<Box<str>> = Vec::with_capacity(n_cells);
+    for i in 0..n_cells {
+        ilines.push(format!("{}\t{}", cell_names[i], cell_to_indv[i]).into());
+    }
+    write_lines(&ilines, &indv_path)?;
+    info!("Wrote individual labels to {indv_path}");
+
+    // Ground truth TSV.gz
+    let gt_path = format!("{out}.ground_truth.tsv.gz");
+    let mut gtl: Vec<Box<str>> = Vec::with_capacity(markers.len() + 1);
+    gtl.push("gene\ttopic\tregion\teffect_size".into());
+    for m in &markers {
+        gtl.push(
+            format!(
+                "{}\t{}\t{}\t{}",
+                gene_names[m.gene],
+                topic_cols[m.topic],
+                m.region.label(),
+                args.effect_size
+            )
+            .into(),
+        );
+    }
+    write_lines(&gtl, &gt_path)?;
+    info!("Wrote ground truth to {gt_path}");
+
+    info!("Spatial simulation complete.");
+    Ok(())
+}

--- a/cocoa/src/run_spatial_diff.rs
+++ b/cocoa/src/run_spatial_diff.rs
@@ -1,0 +1,736 @@
+//! `cocoa spatial-diff` — per-topic spatial differential expression.
+//!
+//! Stratify cells by θ_k (HIGH/LOW/DROP), match HIGH to spatial-kNN LOW
+//! neighbors, and report log τ_high − log τ_low per (gene, topic) with
+//! hybrid permutation + CLT calibration.
+//!
+//! Outputs:
+//! - `{out}.spatial_diff.tsv.gz` — gene, topic, contrast_log, null_mean, null_sd, z, pval
+//! - `{out}.spatial_diff_indiv.tsv.gz` — per-individual log-fold-change (with `--indv-files`)
+
+use crate::common::*;
+use crate::input::*;
+use crate::spatial_match::*;
+use crate::stat::z_to_pvalue;
+
+use clap::Parser;
+use data_beans_alg::gene_weighting::{apply_gene_weights, compute_nb_fisher_weights};
+use matrix_param::dmatrix_gamma::GammaMatrix;
+use matrix_param::traits::{CalibrateTarget, Inference, TwoStatParam};
+use matrix_util::common_io::write_lines;
+use matrix_util::knn_graph::KnnGraph;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+use rustc_hash::FxHashMap as HashMap;
+use std::collections::BTreeSet;
+
+#[derive(Parser, Debug, Clone)]
+pub struct SpatialDiffArgs {
+    #[arg(required = true, help = "Sparse count files (.zarr or .h5).")]
+    data_files: Vec<Box<str>>,
+
+    #[arg(
+        short = 'i',
+        long,
+        value_delimiter = ',',
+        help = "Per-cell individual membership files (comma-separated)."
+    )]
+    indv_files: Option<Vec<Box<str>>>,
+
+    #[arg(
+        short = 'r',
+        long = "topic-proportion-files",
+        value_delimiter = ',',
+        required = true,
+        help = "Cell × topic propensity parquet files (e.g. pinto's .propensity.parquet)."
+    )]
+    topic_proportion_files: Vec<Box<str>>,
+
+    #[arg(
+        long = "topic-proportion-value",
+        default_value = "prob",
+        help = "Topic proportion scale (`prob` or `logit`)."
+    )]
+    topic_proportion_value: TopicValue,
+
+    #[arg(
+        long = "coords-file",
+        required = true,
+        help = "TSV of cell coords: `cell<TAB>x<TAB>y[<TAB>z]` or `x<TAB>y[<TAB>z]` (row-order)."
+    )]
+    coords_file: Box<str>,
+
+    #[arg(long = "spatial-knn", default_value_t = DEFAULT_SPATIAL_KNN, help = "Spatial kNN fan-out.")]
+    spatial_knn: usize,
+
+    #[arg(
+        long = "spatial-radius",
+        help = "Optional hard radius cap on kNN edges."
+    )]
+    spatial_radius: Option<f32>,
+
+    #[arg(long = "topic-high-quantile", default_value_t = DEFAULT_HIGH_Q, help = "HIGH θ_k quantile.")]
+    topic_high_quantile: f32,
+
+    #[arg(long = "topic-low-quantile", default_value_t = DEFAULT_LOW_Q, help = "LOW θ_k quantile.")]
+    topic_low_quantile: f32,
+
+    #[arg(long, default_value_t = 1.0, help = "Gamma prior shape a0.")]
+    a0: f32,
+
+    #[arg(long, default_value_t = 1.0, help = "Gamma prior rate b0.")]
+    b0: f32,
+
+    #[arg(long, default_value_t = 1000, help = "Block size for sparse reads.")]
+    block_size: usize,
+
+    #[arg(
+        long = "no-adjust-housekeeping",
+        default_value_t = false,
+        help = "Disable NB-Fisher housekeeping gene adjustment (default ON)."
+    )]
+    no_adjust_housekeeping: bool,
+
+    #[arg(short, long = "out", required = true, help = "Output prefix.")]
+    out: Box<str>,
+
+    #[arg(long, default_value_t = false, help = "Preload all columns.")]
+    preload_data: bool,
+
+    #[arg(
+        long = "n-permutations",
+        default_value_t = 0,
+        help = "Permutation reps for hybrid permutation+CLT null (0 disables)."
+    )]
+    n_permutations: usize,
+
+    #[arg(long, default_value_t = 42, help = "Random seed for permutation RNG.")]
+    rseed: u64,
+}
+
+struct TopicStat {
+    y_high: Mat,
+    size_high: DVec,
+    y_low_matched: Mat,
+    size_low_matched: DVec,
+}
+
+impl TopicStat {
+    fn new(n_genes: usize, n_indv: usize) -> Self {
+        Self {
+            y_high: Mat::zeros(n_genes, n_indv),
+            size_high: DVec::zeros(n_indv),
+            y_low_matched: Mat::zeros(n_genes, n_indv),
+            size_low_matched: DVec::zeros(n_indv),
+        }
+    }
+
+    fn n_genes(&self) -> usize {
+        self.y_high.nrows()
+    }
+
+    fn n_indv(&self) -> usize {
+        self.y_high.ncols()
+    }
+
+    fn scale_rows(&mut self, w: &[f32]) {
+        apply_gene_weights(&mut self.y_high, w);
+        apply_gene_weights(&mut self.y_low_matched, w);
+    }
+}
+
+struct PermCtx<'a> {
+    data: &'a SparseIoVec,
+    graph: &'a KnnGraph,
+    strata: &'a [Stratum],
+    cell_to_indv_idx: &'a [usize],
+    n_indv: usize,
+    theta_k: &'a [f32],
+    radius: Option<f32>,
+    block_size: usize,
+    gene_weights: Option<&'a [f32]>,
+    a0: f32,
+    b0: f32,
+    n_genes: usize,
+}
+
+pub fn run_cocoa_spatial_diff(args: SpatialDiffArgs) -> anyhow::Result<()> {
+    if args.topic_low_quantile >= args.topic_high_quantile {
+        return Err(anyhow::anyhow!(
+            "--topic-low-quantile must be < --topic-high-quantile"
+        ));
+    }
+
+    let data = read_input_data(InputDataArgs {
+        data_files: args.data_files,
+        indv_files: args.indv_files.clone(),
+        topic_assignment_files: None,
+        topic_proportion_files: Some(args.topic_proportion_files),
+        exposure_assignment_file: None,
+        preload_data: args.preload_data,
+        topic_value: args.topic_proportion_value,
+    })?;
+
+    let n_cells = data.sparse_data.num_columns();
+    let n_genes = data.sparse_data.num_rows();
+    let n_topics = data.cell_topic.ncols();
+    let gene_names = data.sparse_data.row_names()?;
+    let column_names = data.sparse_data.column_names()?;
+
+    info!(
+        "Loaded {} cells × {} genes, {} topics",
+        n_cells, n_genes, n_topics
+    );
+
+    let coords = read_coords_file(&args.coords_file, &column_names, n_cells)?;
+    info!("Spatial coords: {} × {}", coords.nrows(), coords.ncols());
+
+    let (cell_to_indv_idx, indv_names): (Vec<usize>, Vec<Box<str>>) =
+        build_indv_index(&data.cell_to_indv, args.indv_files.is_some());
+    let n_indv = indv_names.len().max(1);
+    info!("Using {} individual bins", n_indv);
+
+    let gene_weights: Option<Vec<f32>> = if args.no_adjust_housekeeping {
+        None
+    } else {
+        info!("Computing NB-Fisher housekeeping weights");
+        Some(compute_nb_fisher_weights(
+            &data.sparse_data,
+            Some(args.block_size),
+        )?)
+    };
+
+    info!(
+        "Building spatial kNN graph (k={}, radius={:?})",
+        args.spatial_knn, args.spatial_radius
+    );
+    let graph = build_spatial_graph(&coords, args.spatial_knn, args.block_size)?;
+    info!("Spatial graph: {} edges", graph.num_edges());
+
+    type CohortRow = (Box<str>, usize, f32, f32, f32, f32, f32);
+    type IndvRow = (Box<str>, usize, Box<str>, f32);
+    let mut all_rows: Vec<CohortRow> = Vec::new();
+    let mut indv_rows: Vec<IndvRow> = Vec::new();
+
+    let mut perm_rng = rand::rngs::StdRng::seed_from_u64(args.rseed);
+
+    for k in 0..n_topics {
+        let theta_k: Vec<f32> = (0..n_cells).map(|i| data.cell_topic[(i, k)]).collect();
+        let strata = stratify_topic(&theta_k, args.topic_low_quantile, args.topic_high_quantile);
+        let n_high = strata.iter().filter(|&&s| s == Stratum::High).count();
+        let n_low = strata.iter().filter(|&&s| s == Stratum::Low).count();
+        info!(
+            "topic {}/{}: {} HIGH, {} LOW cells",
+            k + 1,
+            n_topics,
+            n_high,
+            n_low
+        );
+        if n_high == 0 || n_low == 0 {
+            warn!("  topic {}: empty HIGH or LOW stratum — skipping", k);
+            continue;
+        }
+
+        let matches = high_to_low_neighbors(&graph, &strata, args.spatial_radius);
+        let mut stat = TopicStat::new(n_genes, n_indv);
+        accumulate_topic(
+            &data.sparse_data,
+            &matches,
+            &cell_to_indv_idx,
+            &theta_k,
+            &strata,
+            &mut stat,
+            args.block_size,
+        )?;
+        if let Some(w) = gene_weights.as_deref() {
+            stat.scale_rows(w);
+        }
+
+        let (tau_high, tau_low) = fit_gamma_pair(&stat, args.a0, args.b0);
+        let obs_contrast = cohort_contrast_per_gene(&stat, &tau_high, &tau_low);
+
+        let (null_mean, null_sd) = if args.n_permutations > 0 {
+            info!("  topic {}: {} permutations", k, args.n_permutations);
+            let ctx = PermCtx {
+                data: &data.sparse_data,
+                graph: &graph,
+                strata: &strata,
+                cell_to_indv_idx: &cell_to_indv_idx,
+                n_indv,
+                theta_k: &theta_k,
+                radius: args.spatial_radius,
+                block_size: args.block_size,
+                gene_weights: gene_weights.as_deref(),
+                a0: args.a0,
+                b0: args.b0,
+                n_genes,
+            };
+            run_permutations(&ctx, args.n_permutations, &mut perm_rng)?
+        } else {
+            (vec![f32::NAN; n_genes], vec![f32::NAN; n_genes])
+        };
+
+        let tau_high_log = tau_high.posterior_log_mean();
+        let tau_low_log = tau_low.posterior_log_mean();
+
+        for g in 0..n_genes {
+            let c = obs_contrast[g];
+            let (nm, ns) = (null_mean[g], null_sd[g]);
+            let (z, p) = if ns.is_finite() && ns > 1e-8 {
+                let zv = (c - nm) / ns;
+                (zv, z_to_pvalue(zv))
+            } else {
+                (f32::NAN, f32::NAN)
+            };
+            all_rows.push((gene_names[g].clone(), k, c, nm, ns, z, p));
+
+            if args.indv_files.is_some() {
+                for i in 0..n_indv {
+                    if stat.size_high[i] > 0.0 && stat.size_low_matched[i] > 0.0 {
+                        let diff = tau_high_log[(g, i)] - tau_low_log[(g, i)];
+                        indv_rows.push((gene_names[g].clone(), k, indv_names[i].clone(), diff));
+                    }
+                }
+            }
+        }
+    }
+
+    let out_path = format!("{}.spatial_diff.tsv.gz", args.out);
+    let mut lines: Vec<Box<str>> = Vec::with_capacity(all_rows.len() + 1);
+    lines.push("gene\ttopic\tcontrast_log\tnull_mean\tnull_sd\tz\tpval".into());
+    for (gene, topic, c, nm, ns, z, p) in &all_rows {
+        lines.push(format!("{gene}\t{topic}\t{c}\t{nm}\t{ns}\t{z}\t{p}").into());
+    }
+    write_lines(&lines, &out_path)?;
+    info!("Wrote cohort contrasts to {out_path}");
+
+    if args.indv_files.is_some() && !indv_rows.is_empty() {
+        let indv_path = format!("{}.spatial_diff_indiv.tsv.gz", args.out);
+        let mut ilines: Vec<Box<str>> = Vec::with_capacity(indv_rows.len() + 1);
+        ilines.push("gene\ttopic\tindividual\tlog_fold_change".into());
+        for (gene, topic, indv, d) in &indv_rows {
+            ilines.push(format!("{gene}\t{topic}\t{indv}\t{d}").into());
+        }
+        write_lines(&ilines, &indv_path)?;
+        info!("Wrote individual-level contrasts to {indv_path}");
+    }
+
+    info!("Done");
+    Ok(())
+}
+
+fn build_indv_index(cell_to_indv: &[Box<str>], have_indv: bool) -> (Vec<usize>, Vec<Box<str>>) {
+    if !have_indv {
+        return (vec![0; cell_to_indv.len()], vec!["cohort".into()]);
+    }
+    let mut unique: BTreeSet<Box<str>> = BTreeSet::new();
+    for s in cell_to_indv {
+        if !s.is_empty() && s.as_ref() != "NA" {
+            unique.insert(s.clone());
+        }
+    }
+    let names: Vec<Box<str>> = unique.into_iter().collect();
+    let name_to_idx: HashMap<Box<str>, usize> = names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.clone(), i))
+        .collect();
+    let idx: Vec<usize> = cell_to_indv
+        .iter()
+        .map(|n| name_to_idx.get(n).copied().unwrap_or(usize::MAX))
+        .collect();
+    (idx, names)
+}
+
+fn read_coords_file(path: &str, column_names: &[Box<str>], n_cells: usize) -> anyhow::Result<Mat> {
+    use matrix_util::common_io::read_lines_of_words_delim;
+    let parsed = read_lines_of_words_delim(path, &['\t', ',', ' '], -1)?;
+    let lines = parsed.lines;
+    if lines.is_empty() {
+        return Err(anyhow::anyhow!("coords file {} is empty", path));
+    }
+
+    let first_is_numeric = lines[0][0].as_ref().parse::<f32>().is_ok();
+    let ncol = lines[0].len();
+    let d = if first_is_numeric { ncol } else { ncol - 1 };
+    if d < 2 {
+        return Err(anyhow::anyhow!(
+            "coords file must have at least 2 coordinate columns"
+        ));
+    }
+
+    let mut coords = Mat::zeros(n_cells, d);
+
+    if first_is_numeric {
+        if lines.len() != n_cells {
+            return Err(anyhow::anyhow!(
+                "coords file has {} rows but data has {} cells (no cell-name column)",
+                lines.len(),
+                n_cells
+            ));
+        }
+        for (i, line) in lines.iter().enumerate() {
+            for j in 0..d {
+                coords[(i, j)] = line[j].parse::<f32>()?;
+            }
+        }
+    } else {
+        let name_to_idx: HashMap<Box<str>, usize> = column_names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.clone(), i))
+            .collect();
+        let mut matched = 0usize;
+        for line in lines.iter() {
+            if let Some(&idx) = name_to_idx.get(&line[0]) {
+                for j in 0..d {
+                    coords[(idx, j)] = line[j + 1].parse::<f32>()?;
+                }
+                matched += 1;
+            }
+        }
+        info!("coords: matched {}/{} cells by name", matched, n_cells);
+        if matched == 0 {
+            return Err(anyhow::anyhow!(
+                "no cell names from coords file matched data columns"
+            ));
+        }
+        if matched < n_cells {
+            return Err(anyhow::anyhow!(
+                "coords file matched only {}/{} cells by name; remaining cells would have zero coords and bias kNN matching",
+                matched,
+                n_cells
+            ));
+        }
+    }
+
+    Ok(coords)
+}
+
+fn accumulate_topic(
+    data: &SparseIoVec,
+    matches: &[Vec<(usize, f32)>],
+    cell_to_indv_idx: &[usize],
+    theta_k: &[f32],
+    strata: &[Stratum],
+    stat: &mut TopicStat,
+    block_size: usize,
+) -> anyhow::Result<()> {
+    let n_cells = data.num_columns();
+    debug_assert_eq!(data.num_rows(), stat.n_genes());
+
+    let high_cells: Vec<usize> = (0..n_cells)
+        .filter(|&i| strata.get(i).copied() == Some(Stratum::High) && !matches[i].is_empty())
+        .collect();
+    if high_cells.is_empty() {
+        return Ok(());
+    }
+
+    for block in high_cells.chunks(block_size) {
+        let y_high_block = data.read_columns_csc(block.iter().cloned())?;
+
+        // Batch-read LOW neighbors for the whole block so each sparse backend
+        // call amortizes over many HIGH cells.
+        let mut low_ids: Vec<usize> = Vec::new();
+        let mut low_offsets: Vec<usize> = Vec::with_capacity(block.len() + 1);
+        low_offsets.push(0);
+        for &cell_i in block {
+            for &(j, _) in &matches[cell_i] {
+                low_ids.push(j);
+            }
+            low_offsets.push(low_ids.len());
+        }
+        let y_low_block = if low_ids.is_empty() {
+            None
+        } else {
+            Some(data.read_columns_csc(low_ids.iter().cloned())?)
+        };
+
+        for (bpos, &cell_i) in block.iter().enumerate() {
+            let indv_i = cell_to_indv_idx[cell_i];
+            if indv_i == usize::MAX {
+                continue;
+            }
+            let theta_i = theta_k[cell_i];
+
+            if let Some(col) = y_high_block.get_col(bpos) {
+                for (&g, &y) in col.row_indices().iter().zip(col.values().iter()) {
+                    stat.y_high[(g, indv_i)] += theta_i * y;
+                }
+            }
+            stat.size_high[indv_i] += theta_i;
+
+            let nbrs = &matches[cell_i];
+            let weights: Vec<f32> = nbrs
+                .iter()
+                .map(|&(j, d)| (-d).exp() * (1.0 - theta_k[j]).max(0.0))
+                .collect();
+            let denom: f32 = weights.iter().sum();
+            if denom < 1e-8 {
+                continue;
+            }
+            let lo = low_offsets[bpos];
+            let y_low = y_low_block.as_ref().expect("low block present");
+            for (p, &w) in weights.iter().enumerate() {
+                let scale = (theta_i * w) / denom;
+                if let Some(col) = y_low.get_col(lo + p) {
+                    for (&g, &y) in col.row_indices().iter().zip(col.values().iter()) {
+                        stat.y_low_matched[(g, indv_i)] += scale * y;
+                    }
+                }
+                stat.size_low_matched[indv_i] += scale;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn cohort_contrast_per_gene(
+    stat: &TopicStat,
+    tau_high: &GammaMatrix,
+    tau_low: &GammaMatrix,
+) -> Vec<f32> {
+    let hi = tau_high.posterior_log_mean();
+    let lo = tau_low.posterior_log_mean();
+    let n_genes = stat.n_genes();
+    let n_indv = stat.n_indv();
+    let mut out = Vec::with_capacity(n_genes);
+    for g in 0..n_genes {
+        let mut acc = 0f32;
+        let mut n_eff = 0usize;
+        for i in 0..n_indv {
+            if stat.size_high[i] > 0.0 && stat.size_low_matched[i] > 0.0 {
+                acc += hi[(g, i)] - lo[(g, i)];
+                n_eff += 1;
+            }
+        }
+        out.push(if n_eff > 0 {
+            acc / n_eff as f32
+        } else {
+            f32::NAN
+        });
+    }
+    out
+}
+
+fn permute_strata_within_indv(
+    strata: &[Stratum],
+    cell_to_indv_idx: &[usize],
+    n_indv: usize,
+    rng: &mut rand::rngs::StdRng,
+) -> Vec<Stratum> {
+    let mut out = strata.to_vec();
+    for i in 0..n_indv {
+        let mut positions: Vec<usize> = Vec::new();
+        let mut labels: Vec<Stratum> = Vec::new();
+        for (c, s) in strata.iter().enumerate() {
+            if cell_to_indv_idx.get(c).copied() == Some(i)
+                && (*s == Stratum::High || *s == Stratum::Low)
+            {
+                positions.push(c);
+                labels.push(*s);
+            }
+        }
+        labels.shuffle(rng);
+        for (p, l) in positions.iter().zip(labels.iter()) {
+            out[*p] = *l;
+        }
+    }
+    out
+}
+
+fn run_permutations(
+    ctx: &PermCtx<'_>,
+    n_perm: usize,
+    rng: &mut rand::rngs::StdRng,
+) -> anyhow::Result<(Vec<f32>, Vec<f32>)> {
+    let n_genes = ctx.n_genes;
+    let mut mean = vec![0f32; n_genes];
+    let mut m2 = vec![0f32; n_genes];
+    let mut count = vec![0u32; n_genes];
+
+    for rep in 0..n_perm {
+        let perm_strata =
+            permute_strata_within_indv(ctx.strata, ctx.cell_to_indv_idx, ctx.n_indv, rng);
+        let perm_matches = high_to_low_neighbors(ctx.graph, &perm_strata, ctx.radius);
+        let mut pstat = TopicStat::new(n_genes, ctx.n_indv);
+        accumulate_topic(
+            ctx.data,
+            &perm_matches,
+            ctx.cell_to_indv_idx,
+            ctx.theta_k,
+            &perm_strata,
+            &mut pstat,
+            ctx.block_size,
+        )?;
+        if let Some(w) = ctx.gene_weights {
+            pstat.scale_rows(w);
+        }
+        let (th, tl) = fit_gamma_pair(&pstat, ctx.a0, ctx.b0);
+        let c = cohort_contrast_per_gene(&pstat, &th, &tl);
+        for g in 0..n_genes {
+            if !c[g].is_finite() {
+                continue;
+            }
+            count[g] += 1;
+            let n = count[g] as f32;
+            let delta = c[g] - mean[g];
+            mean[g] += delta / n;
+            let delta2 = c[g] - mean[g];
+            m2[g] += delta * delta2;
+        }
+        if (rep + 1) % 50 == 0 {
+            info!("    permutation {}/{}", rep + 1, n_perm);
+        }
+    }
+
+    let mut null_mean = vec![f32::NAN; n_genes];
+    let mut null_sd = vec![f32::NAN; n_genes];
+    for g in 0..n_genes {
+        if count[g] >= 2 {
+            null_mean[g] = mean[g];
+            null_sd[g] = (m2[g] / (count[g] as f32 - 1.0)).sqrt();
+        }
+    }
+    Ok((null_mean, null_sd))
+}
+
+fn fit_gamma_pair(stat: &TopicStat, a0: f32, b0: f32) -> (GammaMatrix, GammaMatrix) {
+    let n_g = stat.n_genes();
+    let n_i = stat.n_indv();
+
+    let mut tau_high = GammaMatrix::new((n_g, n_i), a0, b0);
+    let mut tau_low = GammaMatrix::new((n_g, n_i), a0, b0);
+
+    let denom_high = Mat::from_fn(n_g, n_i, |_g, i| stat.size_high[i].max(1e-8));
+    let denom_low = Mat::from_fn(n_g, n_i, |_g, i| stat.size_low_matched[i].max(1e-8));
+
+    tau_high.update_stat(&stat.y_high, &denom_high);
+    tau_high.calibrate_with(CalibrateTarget::MeanOnly);
+    tau_high.calibrate();
+
+    tau_low.update_stat(&stat.y_low_matched, &denom_low);
+    tau_low.calibrate_with(CalibrateTarget::MeanOnly);
+    tau_low.calibrate();
+
+    (tau_high, tau_low)
+}
+
+#[cfg(test)]
+mod recovery_tests {
+    use super::*;
+    use data_beans::sparse_io::create_sparse_from_ndarray;
+    use data_beans::sparse_io_vector::SparseIoVec;
+    use nalgebra::DMatrix;
+    use ndarray::Array2;
+    use rand::SeedableRng;
+    use rand_distr::{Distribution, Gamma as GammaDist, Poisson};
+    use std::sync::Arc;
+    type SparseData = dyn SparseIo<IndexIter = Vec<usize>>;
+
+    #[test]
+    fn recovers_spatial_marker_gene_in_correct_topic() -> anyhow::Result<()> {
+        const NX: usize = 20;
+        const NY: usize = 10;
+        const N_GENES: usize = 30;
+        const N_TOPICS: usize = 3;
+        const MARKER: usize = 0;
+        const TARGET_K: usize = 0;
+        let n_cells = NX * NY;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+
+        let coords = DMatrix::<f32>::from_fn(n_cells, 2, |i, j| {
+            if j == 0 {
+                (i / NY) as f32
+            } else {
+                (i % NY) as f32
+            }
+        });
+
+        let gamma_unit = GammaDist::new(1.0, 1.0).unwrap();
+        let mut theta = Mat::zeros(n_cells, N_TOPICS);
+        for i in 0..n_cells {
+            let mut row = [0f32; N_TOPICS];
+            let mut sum = 0f32;
+            for r in row.iter_mut() {
+                *r = gamma_unit.sample(&mut rng) as f32;
+                sum += *r;
+            }
+            for (k, &r) in row.iter().enumerate() {
+                theta[(i, k)] = r / sum;
+            }
+        }
+
+        let bg = Poisson::new(0.5).unwrap();
+        let hot = Poisson::new(15.0).unwrap();
+        let mut counts = Array2::<f32>::zeros((N_GENES, n_cells));
+        for i in 0..n_cells {
+            for g in 0..N_GENES {
+                counts[(g, i)] = bg.sample(&mut rng) as f32;
+            }
+        }
+        let x_median = (NX as f32 - 1.0) * 0.5;
+        let mut sorted: Vec<f32> = (0..n_cells).map(|i| theta[(i, TARGET_K)]).collect();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let thr = sorted[(n_cells as f32 * 0.75) as usize];
+        for i in 0..n_cells {
+            if theta[(i, TARGET_K)] >= thr && coords[(i, 0)] < x_median {
+                counts[(MARKER, i)] = hot.sample(&mut rng) as f32;
+            }
+        }
+
+        let gene_names: Vec<Box<str>> = (0..N_GENES)
+            .map(|g| format!("gene{g}").into_boxed_str())
+            .collect();
+        let cell_names: Vec<Box<str>> = (0..n_cells)
+            .map(|i| format!("cell{i}").into_boxed_str())
+            .collect();
+        let mut sp = create_sparse_from_ndarray(&counts, None, None)?;
+        sp.register_row_names_vec(&gene_names);
+        sp.register_column_names_vec(&cell_names);
+        sp.preload_columns()?;
+        let sparse: Arc<SparseData> = Arc::from(sp);
+        let mut data = SparseIoVec::new();
+        data.push(sparse, Some("batch0".into()))?;
+
+        let graph = build_spatial_graph(&coords, 8, 1000)?;
+
+        let mut top_gene = [0usize; N_TOPICS];
+        let mut top_c = [f32::NEG_INFINITY; N_TOPICS];
+        let mut marker_c = [f32::NAN; N_TOPICS];
+
+        for k in 0..N_TOPICS {
+            let theta_k: Vec<f32> = (0..n_cells).map(|i| theta[(i, k)]).collect();
+            let strata = stratify_topic(&theta_k, 0.25, 0.75);
+            let matches = high_to_low_neighbors(&graph, &strata, None);
+            let mut stat = TopicStat::new(N_GENES, 1);
+            accumulate_topic(
+                &data,
+                &matches,
+                &vec![0usize; n_cells],
+                &theta_k,
+                &strata,
+                &mut stat,
+                1000,
+            )?;
+            let (th, tl) = fit_gamma_pair(&stat, 1.0, 1.0);
+            let hi = th.posterior_log_mean();
+            let lo = tl.posterior_log_mean();
+            for g in 0..N_GENES {
+                let c = hi[(g, 0)] - lo[(g, 0)];
+                if c > top_c[k] {
+                    top_c[k] = c;
+                    top_gene[k] = g;
+                }
+                if g == MARKER {
+                    marker_c[k] = c;
+                }
+            }
+        }
+
+        assert_eq!(top_gene[TARGET_K], MARKER);
+        assert!(marker_c[TARGET_K] > marker_c[1].max(marker_c[2]) + 0.5);
+        Ok(())
+    }
+}

--- a/cocoa/src/spatial_match.rs
+++ b/cocoa/src/spatial_match.rs
@@ -1,0 +1,133 @@
+//! Per-topic spatial stratification and kNN matching for `cocoa spatial-diff`.
+//!
+//! Given cell-to-topic propensities and spatial coordinates, stratify cells
+//! by θ_k into HIGH / LOW / DROP, build a spatial kNN graph, and expose
+//! per-cell HIGH → LOW neighbor lookups used by the sufficient-stat
+//! accumulator.
+
+use matrix_util::knn_graph::{KnnGraph, KnnGraphArgs};
+use nalgebra::DMatrix;
+
+pub const DEFAULT_SPATIAL_KNN: usize = 25;
+pub const DEFAULT_HIGH_Q: f32 = 0.75;
+pub const DEFAULT_LOW_Q: f32 = 0.25;
+
+/// Per-cell stratum assignment for a single topic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Stratum {
+    High,
+    Low,
+    Drop,
+}
+
+/// Stratify cells within one topic k by quantile thresholds on θ_{·,k}.
+///
+/// Returns a vector of length n_cells.
+pub fn stratify_topic(theta_k: &[f32], low_q: f32, high_q: f32) -> Vec<Stratum> {
+    assert!((0.0..=1.0).contains(&low_q));
+    assert!((0.0..=1.0).contains(&high_q));
+    assert!(low_q < high_q);
+    let mut sorted = theta_k.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = sorted.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let lo_idx = ((n as f32) * low_q) as usize;
+    let hi_idx = ((n as f32) * high_q).min((n - 1) as f32) as usize;
+    let lo_thr = sorted[lo_idx.min(n - 1)];
+    let hi_thr = sorted[hi_idx];
+
+    theta_k
+        .iter()
+        .map(|&v| {
+            if v >= hi_thr {
+                Stratum::High
+            } else if v <= lo_thr {
+                Stratum::Low
+            } else {
+                Stratum::Drop
+            }
+        })
+        .collect()
+}
+
+/// Build a spatial kNN graph from cell coordinates.
+///
+/// `coords` is (n_cells × d); `knn` is the fan-out per cell.
+pub fn build_spatial_graph(
+    coords: &DMatrix<f32>,
+    knn: usize,
+    block_size: usize,
+) -> anyhow::Result<KnnGraph> {
+    KnnGraph::from_rows(
+        coords,
+        KnnGraphArgs {
+            knn,
+            block_size,
+            reciprocal: false,
+        },
+    )
+}
+
+/// For one topic k: return `high_to_low[i]` = indices of spatial-kNN
+/// neighbors of HIGH cell `i` that are in stratum LOW. Cells not in HIGH
+/// get an empty list. Optional radius clipping is applied when `radius`
+/// is `Some` — neighbors with edge distance > radius are dropped.
+pub fn high_to_low_neighbors(
+    graph: &KnnGraph,
+    strata: &[Stratum],
+    radius: Option<f32>,
+) -> Vec<Vec<(usize, f32)>> {
+    let n = graph.num_nodes();
+    let mut out: Vec<Vec<(usize, f32)>> = vec![Vec::new(); n];
+
+    // Build per-node neighbor+distance list from edge list.
+    // edges are canonical (i < j). Symmetric expand.
+    let mut adj: Vec<Vec<(usize, f32)>> = vec![Vec::new(); n];
+    for (&(i, j), &d) in graph.edges.iter().zip(graph.distances.iter()) {
+        if let Some(r) = radius {
+            if d > r {
+                continue;
+            }
+        }
+        adj[i].push((j, d));
+        adj[j].push((i, d));
+    }
+
+    for (i, nbrs) in adj.into_iter().enumerate() {
+        if strata.get(i).copied() != Some(Stratum::High) {
+            continue;
+        }
+        for (j, d) in nbrs {
+            if strata.get(j).copied() == Some(Stratum::Low) {
+                out[i].push((j, d));
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stratify_topic_splits_into_three_strata() {
+        let theta = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
+        let s = stratify_topic(&theta, 0.25, 0.75);
+        // low_q=0.25 → idx 2 → 0.3; high_q=0.75 → idx 7 → 0.8
+        assert_eq!(s[0], Stratum::Low); // 0.1 <= 0.3
+        assert_eq!(s[2], Stratum::Low); // 0.3 <= 0.3
+        assert_eq!(s[4], Stratum::Drop); // 0.5 in middle
+        assert_eq!(s[7], Stratum::High); // 0.8 >= 0.8
+        assert_eq!(s[9], Stratum::High); // 1.0 >= 0.8
+    }
+
+    #[test]
+    fn empty_theta_yields_empty_strata() {
+        let s = stratify_topic(&[], 0.25, 0.75);
+        assert!(s.is_empty());
+    }
+}

--- a/cocoa/src/stat.rs
+++ b/cocoa/src/stat.rs
@@ -58,6 +58,10 @@ impl CocoaStat {
         }
     }
 
+    pub fn num_topics(&self) -> usize {
+        self.n_topics
+    }
+
     pub fn y1_stat_mut(&mut self, k: usize) -> &mut Mat {
         &mut self.y1_sum_dp_vec[k]
     }

--- a/data-beans-alg/src/pseudobulk.rs
+++ b/data-beans-alg/src/pseudobulk.rs
@@ -58,11 +58,27 @@ pub struct CollapsedPseudobulk {
 /// * `a0` - Gamma prior shape parameter (default: 1.0)
 /// * `b0` - Gamma prior rate parameter (default: 1.0)
 pub fn collapse_pseudobulk(
+    data_vec: SparseIoVec,
+    annotations: &CellAnnotations,
+    membership: &CellTypeMembership,
+    a0: f32,
+    b0: f32,
+) -> Result<CollapsedPseudobulk> {
+    collapse_pseudobulk_weighted(data_vec, annotations, membership, a0, b0, None)
+}
+
+/// Same as [`collapse_pseudobulk`], but row-scales the per-(individual,
+/// cell_type) count sums by `gene_weights[g]` before the Gamma update. This
+/// is the NB-Fisher housekeeping adjustment used by pinto (see
+/// `gene_weighting::compute_nb_fisher_weights`); housekeeping genes get
+/// attenuated in the posterior mean while informative genes stay at w≈1.
+pub fn collapse_pseudobulk_weighted(
     mut data_vec: SparseIoVec,
     annotations: &CellAnnotations,
     membership: &CellTypeMembership,
     a0: f32,
     b0: f32,
+    gene_weights: Option<&[f32]>,
 ) -> Result<CollapsedPseudobulk> {
     let num_genes = data_vec.num_rows();
     let num_cells = data_vec.num_columns();
@@ -149,6 +165,16 @@ pub fn collapse_pseudobulk(
         .map(|key| ind_lookup.get(key.as_ref()).copied())
         .collect();
 
+    if let Some(w) = gene_weights {
+        if w.len() != num_genes {
+            bail!(
+                "gene_weights length {} != num_genes {}",
+                w.len(),
+                num_genes
+            );
+        }
+    }
+
     for ct_idx in 0..n_cell_types {
         let mut count_sum_ct = DMatrix::<f32>::zeros(num_genes, n_individuals);
         let mut weight_ct = DVector::<f32>::zeros(n_individuals);
@@ -162,6 +188,12 @@ pub fn collapse_pseudobulk(
                 .column_mut(ind_idx)
                 .add_assign(&stat.count_sum.column(src_col));
             weight_ct[ind_idx] += stat.cell_weight[src_col];
+        }
+
+        if let Some(w) = gene_weights {
+            for (g, &wg) in w.iter().enumerate() {
+                count_sum_ct.row_mut(g).scale_mut(wg);
+            }
         }
 
         let denom = DMatrix::from_fn(num_genes, n_individuals, |_g, i| weight_ct[i]);


### PR DESCRIPTION
## Summary

- New `cocoa spatial-diff`: per-topic within-stratum spatial differential expression. Stratifies cells by θ_k (HIGH/LOW/DROP), matches HIGH cells to spatial-kNN LOW neighbors, fits Gamma posteriors τ_high/τ_low, and reports `log τ_high − log τ_low` per (gene, topic) with a hybrid permutation+CLT null (Welford running stats → z, two-sided Gaussian p-value).
- New `cocoa simulate-spatial`: minimal spatial-DE simulator that emits the exact file layout (zarr + topic.parquet + coords.tsv.gz + indv.tsv.gz + ground_truth.tsv.gz) `spatial-diff` consumes, so validation is a one-liner against the same prefix.
- NB-Fisher housekeeping row-scaling in `collapse` / `diff` / `spatial-diff` via existing `data_beans_alg::gene_weighting` (opt out with `--no-adjust-housekeeping`).
- Refined multilevel pseudobulk assignment in `collapse` / `diff` through `collapse_columns_multilevel_vec` (senna's path) so cocoa's pseudobulks are DC-Poisson refined and coherent across tools.
- Exposed `stat::z_to_pvalue`, reused by `spatial-diff`.

## Why

Cocoa previously had no within-topic spatial contrast — topic identity confounds spatial location and expression, and modelling propensity in high-dimensional spatial features is poorly posed. Stratification + local kNN matching avoids that entirely. Housekeeping adjustment matches pinto and prevents ubiquitous genes from driving contrasts; refined pseudobulks unify cocoa with senna's `collapse_columns_multilevel_vec` path.

## Notes for reviewer

- `spatial_match.rs` relies on `KnnGraph.edges` being canonical `i < j` — verified against `matrix-util/src/knn_graph.rs`.
- `read_coords_file` accepts either name-keyed or row-order coords; fails loudly on partial name matches (no silent zero-fill).
- Accumulator batches LOW-neighbor sparse reads per HIGH-block so each backend call amortizes.
- Permutations shuffle HIGH/LOW within each individual (global shuffle when no indv labels).

## Test plan

- [x] `cargo fmt -p cocoa` — clean
- [x] `cargo clippy -p cocoa --tests` — clean (only pre-existing `too_many_args` warning in `collapse_cocoa_data.rs`)
- [x] `cargo test -p cocoa` — 3/3 pass, including end-to-end recovery test that confirms the marker gene tops its target-topic contrast and dominates other topics by ≥0.5 log units
- [ ] Run against a real Visium / MERFISH dataset with pinto's `.propensity.parquet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)