### PR TITLE
perf(senna/itopic): lazy-ρ optimizer, sparse eval path, drop anchor penalty

### DIFF
--- a/candle-util/src/candle_indexed_data_loader.rs
+++ b/candle-util/src/candle_indexed_data_loader.rs
@@ -3,6 +3,7 @@ use crate::candle_data_loader_util::Minibatches;
 use candle_core::{Device, Tensor};
 use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
 use matrix_util::traits::CandleDataLoaderOps;
+use nalgebra_sparse::CscMatrix;
 use rayon::prelude::*;
 use std::cell::RefCell;
 
@@ -57,6 +58,37 @@ pub struct IndexedMinibatchData {
     pub output_values_weight: Option<Tensor>,
     /// [1, S] f32 — log selection frequency at union positions
     pub output_log_q_s: Tensor,
+    /// [T] u32 — sorted-unique union of every feature id this minibatch
+    /// touches on *either* side (encoder per-cell ids ∪ decoder union).
+    /// These are exactly the rows of the shared ρ `[D, H]` table that
+    /// receive a nonzero gradient, so a lazy/sparse optimizer can restrict
+    /// its update to `touched_rho_indices` instead of sweeping all of D.
+    pub touched_rho_indices: Tensor,
+}
+
+impl IndexedMinibatchData {
+    /// Upload every tensor field to `dev`. Cached minibatches are built
+    /// host-side by `precompute_all_minibatches`; the training loop calls
+    /// this once per minibatch so a GPU run uploads incrementally instead
+    /// of holding the whole epoch resident on device. A no-op copy when
+    /// `dev` is already CPU.
+    pub fn to_device(&self, dev: &Device) -> anyhow::Result<IndexedMinibatchData> {
+        let opt = |t: &Option<Tensor>| -> anyhow::Result<Option<Tensor>> {
+            t.as_ref().map(|x| x.to_device(dev)).transpose().map_err(Into::into)
+        };
+        Ok(IndexedMinibatchData {
+            input_indices: self.input_indices.to_device(dev)?,
+            input_values: self.input_values.to_device(dev)?,
+            input_values_null: opt(&self.input_values_null)?,
+            input_values_mean: opt(&self.input_values_mean)?,
+            output_union_indices: self.output_union_indices.to_device(dev)?,
+            output_scatter_pos: self.output_scatter_pos.to_device(dev)?,
+            output_values: self.output_values.to_device(dev)?,
+            output_values_weight: opt(&self.output_values_weight)?,
+            output_log_q_s: self.output_log_q_s.to_device(dev)?,
+            touched_rho_indices: self.touched_rho_indices.to_device(dev)?,
+        })
+    }
 }
 
 /// Adaptive feature window data loader with decoupled encoder/decoder windows.
@@ -85,6 +117,11 @@ pub struct IndexedInMemoryData {
     /// Per-feature NB-Fisher weight (decoder side) gathered into
     /// `output_values_weight [N, K]` at minibatch build time.
     output_fisher_weights: Option<Vec<f32>>,
+    /// Sum of all `output_samples` values across every sample — the
+    /// per-epoch total decoder count, invariant to minibatch shuffling.
+    /// Cached so the training loop's llik/count trace doesn't re-sum
+    /// `output_values` on every minibatch.
+    total_output_count: f32,
     minibatches: Minibatches,
     cached_batches: Vec<IndexedMinibatchData>,
 }
@@ -166,17 +203,32 @@ pub fn top_k_indices(row: &[f32], k: usize) -> (Vec<u32>, Vec<f32>) {
 /// observed.
 pub fn top_k_indices_weighted(row: &[f32], weights: &[f32], k: usize) -> (Vec<u32>, Vec<f32>) {
     debug_assert_eq!(row.len(), weights.len());
+    top_k_from_entries(
+        row.iter()
+            .zip(weights.iter())
+            .enumerate()
+            .map(|(i, (&v, &w))| (i as u32, v, w)),
+        k,
+    )
+}
 
-    let mut scored: Vec<(f32, u32)> = row
-        .iter()
-        .zip(weights.iter())
-        .enumerate()
-        .filter_map(|(i, (&v, &w))| {
-            // log1p on the score, not the value — keeps the per-cell K
-            // raw values untouched while the *ranking* compresses
-            // dynamic range so high-mean genes don't auto-win.
+/// Shared top-K core for [`top_k_indices_weighted`] and the sparse
+/// [`csc_columns_to_indexed_samples`].
+///
+/// `entries` yields `(feature_id, raw_value, weight)` triples — for the
+/// sparse path only the column's stored nonzeros need be supplied.
+/// Selection ranks by `log1p(value) · weight` (see
+/// [`top_k_indices_weighted`] for why `log1p` is on the score), drops
+/// non-positive scores, keeps the top `k`, and returns indices sorted
+/// ascending with their **raw** values.
+fn top_k_from_entries<I>(entries: I, k: usize) -> (Vec<u32>, Vec<f32>)
+where
+    I: Iterator<Item = (u32, f32, f32)>,
+{
+    let mut scored: Vec<(f32, u32, f32)> = entries
+        .filter_map(|(i, v, w)| {
             let score = v.max(0.0).ln_1p() * w;
-            (score > 0.0).then_some((score, i as u32))
+            (score > 0.0).then_some((score, i, v))
         })
         .collect();
 
@@ -189,11 +241,41 @@ pub fn top_k_indices_weighted(row: &[f32], weights: &[f32], k: usize) -> (Vec<u3
         b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let mut idx: Vec<u32> = scored[..k].iter().map(|&(_, i)| i).collect();
-    idx.sort_unstable();
+    let mut top: Vec<(u32, f32)> = scored[..k].iter().map(|&(_, i, v)| (i, v)).collect();
+    top.sort_unstable_by_key(|&(i, _)| i);
 
-    let values: Vec<f32> = idx.iter().map(|&i| row[i as usize]).collect();
+    let idx: Vec<u32> = top.iter().map(|&(i, _)| i).collect();
+    let values: Vec<f32> = top.iter().map(|&(_, v)| v).collect();
     (idx, values)
+}
+
+/// Build [`IndexedSample`]s straight from a sparse `[D, N]` CSC matrix —
+/// columns are samples (cells), rows are features. Each column's stored
+/// nonzeros are scored with `log1p(value) · weight` and the top
+/// `context_size` are kept. Avoids ever materializing the dense `[N, D]`
+/// matrix the dense path needs.
+///
+/// Sequential over columns by design: the caller (`evaluate_indexed_block`)
+/// already runs inside a block-level rayon map, so a nested par_iter here
+/// would only add task-splitting overhead.
+pub fn csc_columns_to_indexed_samples(
+    x_dn: &CscMatrix<f32>,
+    shortlist_weights: &[f32],
+    context_size: usize,
+) -> Vec<IndexedSample> {
+    debug_assert_eq!(x_dn.nrows(), shortlist_weights.len());
+    (0..x_dn.ncols())
+        .map(|j| {
+            let col = x_dn.col(j);
+            let entries = col
+                .row_indices()
+                .iter()
+                .zip(col.values().iter())
+                .map(|(&r, &v)| (r as u32, v, shortlist_weights[r]));
+            let (indices, values) = top_k_from_entries(entries, context_size);
+            IndexedSample { indices, values }
+        })
+        .collect()
 }
 
 /// Per-feature lookup slot. `gen` carries the call generation that wrote
@@ -426,6 +508,15 @@ fn compute_log_selection_freq(samples: &[IndexedSample], n_features: usize) -> V
         .collect()
 }
 
+/// Sum of every value across all samples — the per-epoch decoder count
+/// total. Invariant to minibatch shuffling, so it can be cached once.
+fn sum_sample_values(samples: &[IndexedSample]) -> f32 {
+    samples
+        .par_iter()
+        .map(|s| s.values.iter().sum::<f32>())
+        .sum()
+}
+
 impl IndexedInMemoryData {
     /// Build indexed data from dense matrices.
     ///
@@ -455,6 +546,7 @@ impl IndexedInMemoryData {
         );
 
         let output_log_q = compute_log_selection_freq(&output_samples, n_output_features);
+        let total_output_count = sum_sample_values(&output_samples);
 
         // Pre-extract null rows in parallel
         let null_rows: Option<Vec<Vec<f32>>> = args.input_null.map(|d| {
@@ -501,6 +593,7 @@ impl IndexedInMemoryData {
             output_log_q,
             input_mean,
             output_fisher_weights,
+            total_output_count,
             minibatches: Minibatches {
                 samples: rows,
                 chunks: vec![],
@@ -522,6 +615,7 @@ impl IndexedInMemoryData {
         let output_samples = samples;
         let input_samples = output_samples.clone();
         let output_log_q = compute_log_selection_freq(&output_samples, n_features);
+        let total_output_count = sum_sample_values(&output_samples);
         IndexedInMemoryData {
             input_samples,
             input_null_rows: None,
@@ -533,6 +627,7 @@ impl IndexedInMemoryData {
             output_log_q,
             input_mean: None,
             output_fisher_weights: None,
+            total_output_count,
             minibatches: Minibatches {
                 samples: rows,
                 chunks: vec![],
@@ -550,7 +645,12 @@ impl IndexedInMemoryData {
     ///
     /// Call this once after `shuffle_minibatch` to avoid rebuilding
     /// union+scatter on every `minibatch_cached` call within an epoch.
-    pub fn precompute_all_minibatches(&mut self, target_device: &Device) -> anyhow::Result<()> {
+    ///
+    /// Cached batches are always built host-side (`Device::Cpu`). The
+    /// consumer uploads each minibatch to its compute device on demand
+    /// via [`IndexedMinibatchData::to_device`], so a GPU run never holds
+    /// the whole epoch resident on device at once.
+    pub fn precompute_all_minibatches(&mut self) -> anyhow::Result<()> {
         let n_chunks = self.minibatches.chunks.len() as u64;
         let prog_bar = labeled_bar("Minibatch precompute", n_chunks);
         self.cached_batches = self
@@ -558,7 +658,7 @@ impl IndexedInMemoryData {
             .chunks
             .par_iter()
             .progress_with(prog_bar.clone())
-            .map(|sample_indices| self.build_minibatch(sample_indices, target_device))
+            .map(|sample_indices| self.build_minibatch(sample_indices, &Device::Cpu))
             .collect::<anyhow::Result<Vec<_>>>()?;
         prog_bar.finish_and_clear();
         Ok(())
@@ -592,6 +692,12 @@ impl IndexedInMemoryData {
 
     pub fn n_output_features(&self) -> usize {
         self.n_output_features
+    }
+
+    /// Sum of all decoder-side values across every sample — the per-epoch
+    /// count total, invariant to minibatch shuffling.
+    pub fn total_output_count(&self) -> f32 {
+        self.total_output_count
     }
 
     /// Build a packed minibatch.
@@ -698,6 +804,20 @@ impl IndexedInMemoryData {
         let s_out = output_union_vec.len();
         let output_log_q_s = Tensor::from_vec(log_q_s, (1, s_out), target_device)?;
 
+        // Rows of the shared ρ table touched this minibatch: encoder
+        // per-cell ids ∪ decoder union. Sorted-unique so a lazy optimizer
+        // can `index_select`/`index_add` against it directly.
+        let mut touched_set: std::collections::BTreeSet<u32> =
+            output_union_vec.iter().copied().collect();
+        for &si in sample_indices {
+            for &idx in &self.input_samples[si].indices {
+                touched_set.insert(idx);
+            }
+        }
+        let touched_vec: Vec<u32> = touched_set.into_iter().collect();
+        let n_touched = touched_vec.len();
+        let touched_rho_indices = Tensor::from_vec(touched_vec, (n_touched,), target_device)?;
+
         Ok(IndexedMinibatchData {
             input_indices,
             input_values,
@@ -708,6 +828,7 @@ impl IndexedInMemoryData {
             output_values,
             output_values_weight,
             output_log_q_s,
+            touched_rho_indices,
         })
     }
 
@@ -819,6 +940,39 @@ mod tests {
         let (idx_wz, val_wz) = top_k_indices_weighted(&row_wz, &w_wz, 3);
         assert_eq!(idx_wz, vec![1]);
         assert_eq!(val_wz, vec![0.7]);
+    }
+
+    #[test]
+    fn test_csc_columns_match_dense_top_k() {
+        // Dense [N, D] reference; CSC is [D, N] (cols = samples).
+        let n = 4;
+        let d = 6;
+        let dense = [
+            [0.1f32, 0.5, 0.3, 0.9, 0.2, 0.7],
+            [0.8, 0.1, 0.6, 0.2, 0.9, 0.3],
+            [0.0, 0.7, 0.0, 0.4, 0.6, 0.0],
+            [0.2, 0.3, 0.8, 0.1, 0.5, 0.9],
+        ];
+        let weights = vec![1.0f32, 0.1, 1.0, 0.01, 1.0, 0.05];
+
+        // Build CSC [D, N] from a COO of the nonzeros.
+        let mut coo = nalgebra_sparse::CooMatrix::<f32>::new(d, n);
+        for (j, row) in dense.iter().enumerate() {
+            for (i, &v) in row.iter().enumerate() {
+                if v != 0.0 {
+                    coo.push(i, j, v);
+                }
+            }
+        }
+        let csc = CscMatrix::from(&coo);
+
+        let from_csc = csc_columns_to_indexed_samples(&csc, &weights, 3);
+        assert_eq!(from_csc.len(), n);
+        for (j, row) in dense.iter().enumerate() {
+            let (exp_idx, exp_val) = top_k_indices_weighted(row, &weights, 3);
+            assert_eq!(from_csc[j].indices, exp_idx, "sample {j} indices");
+            assert_eq!(from_csc[j].values, exp_val, "sample {j} values");
+        }
     }
 
     #[test]

--- a/senna/src/fit_indexed_topic.rs
+++ b/senna/src/fit_indexed_topic.rs
@@ -282,10 +282,12 @@ pub struct IndexedTopicArgs {
 
     #[arg(
         long,
-        default_value_t = 1.0,
-        help = "Cross-entropy penalty λ on β toward anchor prior (0 = off)"
+        default_value_t = false,
+        help = "Use dense AdamW over the full ρ [D,H] table every \
+                minibatch instead of the lazy touched-row-only optimizer. \
+                Slower at large embedding dim; kept for A/B benchmarking."
     )]
-    anchor_penalty: f32,
+    dense_rho_update: bool,
 
     #[arg(
         long,
@@ -586,6 +588,16 @@ pub fn fit_indexed_topic_model(args: &IndexedTopicArgs) -> anyhow::Result<()> {
         param_builder.pp("enc"),
     )?;
 
+    // Resolve the ρ `Var` backing the encoder's feature-embedding table —
+    // matched by tensor id in the VarMap — so the lazy optimizer can step
+    // it sparsely and the stock AdamW can exclude it.
+    let rho_tid = base_encoder.feature_embeddings().id();
+    let rho_var = parameters
+        .all_vars()
+        .into_iter()
+        .find(|v| v.id() == rho_tid)
+        .ok_or_else(|| anyhow::anyhow!("ρ feature-embedding Var not found in VarMap"))?;
+
     // Per-level decoders: all at D_full, levels differ in N (sample coarsening).
     // ETM-factorized — each decoder shares the encoder's feature embeddings ρ,
     // and learns only its own topic embeddings α_{level} [K, H].
@@ -629,19 +641,6 @@ pub fn fit_indexed_topic_model(args: &IndexedTopicArgs) -> anyhow::Result<()> {
     );
 
     let gene_names = data_vec.row_names()?;
-
-    // Indexed decoders run at D_full, so no finest-level coarsening.
-    info!("Building anchor prior (K={n_topics}) from pseudobulks");
-    let anchor_prior =
-        crate::topic::anchor_prior::AnchorPrior::from_pseudobulk(finest_collapsed, n_topics, None)?;
-
-    // Per-level anchor tensors. Indexed decoders all run at D_full, so
-    // no feature coarsening applies — one `None` per level.
-    let level_coarsenings_none: Vec<Option<FeatureCoarsening>> =
-        (0..num_levels).map(|_| None).collect();
-    let anchor_tensors = anchor_prior.per_level_device_tensors(&level_coarsenings_none, &dev)?;
-    // β init from anchor prior disabled — random init + anchor penalty
-    // during training avoids locking the dictionary too early.
 
     // Read bulk data aligned to SC genes
     let bulk = args
@@ -732,13 +731,13 @@ pub fn fit_indexed_topic_model(args: &IndexedTopicArgs) -> anyhow::Result<()> {
         enc_context_size: args.context_size,
         dec_context_size,
         stop: &stop,
-        anchor_prior_per_level: Some(&anchor_tensors),
-        anchor_penalty: args.anchor_penalty,
         shortlist_weights: &shortlist_weights,
         feature_mean: &feature_mean,
         feature_fisher_weights: &feature_fisher_weights,
         grad_clip: args.grad_clip,
         graph_warmup_epochs: args.graph_warmup_epochs,
+        rho_var: &rho_var,
+        lazy_rho: !args.dense_rho_update,
     };
 
     let bulk_with_deltas: Option<(&Mat, &[GammaMatrix])> = match (&bulk_nd_full, &bulk_deltas) {

--- a/senna/src/topic/anchor_prior.rs
+++ b/senna/src/topic/anchor_prior.rs
@@ -6,14 +6,10 @@
 //! both for β initialization and as an optional training-time cross-entropy
 //! penalty.
 //!
-//! **Two penalty paths**:
-//! - [`anchor_penalty_at_level`] looks up `dec_{level}.dictionary.logits` by
-//!   name and is used by softmax-linear decoders (dense `senna topic`).
-//!   Silently no-ops for decoders that don't register that Var (e.g. vMF).
-//! - [`anchor_penalty_at_level_with_logits`] takes the `[K, D]` logits
-//!   tensor directly — for decoders that compute β on the fly without
-//!   storing the logits as a single Var (e.g. ETM-factorized
-//!   `indexed-topic`, where `[K, D] = α · ρᵀ`).
+//! **Penalty path**: [`anchor_penalty_at_level`] looks up
+//! `dec_{level}.dictionary.logits` by name and is used by softmax-linear
+//! decoders (dense `senna topic`). Silently no-ops for decoders that
+//! don't register that Var (e.g. vMF).
 
 use crate::anchor_common::{gram_schmidt_anchors, softmax_col_into, zscore_columns};
 use crate::embed_common::*;
@@ -228,28 +224,6 @@ pub(crate) fn anchor_penalty_at_level(
         &decoder_logits_var_path(level),
         1,
     )
-}
-
-/// Variant of [`anchor_penalty_at_level`] that takes the decoder's full
-/// `[K, D]` logits tensor directly. Use this for decoders that factorize
-/// the dictionary (ETM-style β = log_softmax(α · ρᵀ)) where there is no
-/// single Var to look up by name — the caller computes the logits via
-/// `decoder.full_logits_kd()` and hands them here. No-op when the prior
-/// isn't attached or `λ ≤ 0`.
-pub(crate) fn anchor_penalty_at_level_with_logits(
-    loss: Tensor,
-    logits_kd: &Tensor,
-    anchor_prior_per_level: Option<&[Tensor]>,
-    lambda: f32,
-    level: usize,
-) -> anyhow::Result<Tensor> {
-    let Some(priors) = anchor_prior_per_level else {
-        return Ok(loss);
-    };
-    if lambda <= 0.0 {
-        return Ok(loss);
-    }
-    apply_ce_penalty(loss, logits_kd, &priors[level], lambda, 1)
 }
 
 // ---------------------------------------------------------------------------

--- a/senna/src/topic/eval_indexed.rs
+++ b/senna/src/topic/eval_indexed.rs
@@ -3,7 +3,9 @@ use crate::embed_common::*;
 
 use candle_core::{Device, Tensor, Var};
 use candle_nn::ops;
-use candle_util::candle_indexed_data_loader::top_k_indices_weighted;
+use candle_util::candle_indexed_data_loader::{
+    csc_columns_to_indexed_samples, top_k_indices_weighted,
+};
 use candle_util::candle_indexed_model_traits::*;
 use candle_util::candle_topic_refinement::TopicRefinementConfig;
 use std::collections::{BTreeSet, HashMap};
@@ -84,21 +86,74 @@ fn dense_rows_to_indexed(
     ctx: PerGeneContext<'_>,
     dev: &Device,
 ) -> anyhow::Result<IndexedPack> {
-    let n_batch = rows.len();
     let k = if rows.is_empty() {
         context_size
     } else {
         context_size.min(rows[0].len())
     };
 
+    // Sequential per-row: `dense_rows_to_indexed`'s callers
+    // (`evaluate_indexed_block`) already run inside `process_blocks`'
+    // block-level rayon map, so a nested par_iter here would just add
+    // task-splitting overhead.
+    let all_top_k: Vec<(Vec<u32>, Vec<f32>)> = rows
+        .iter()
+        .map(|row| top_k_indices_weighted(row, shortlist_weights, context_size))
+        .collect();
+
+    pack_top_k_to_indexed(&all_top_k, k, ctx, dev)
+}
+
+/// Build an [`IndexedPack`] directly from a sparse `[D, N]` CSC matrix —
+/// columns are cells. Skips the dense `[N, D]` materialization the
+/// `dense_*` helpers need; only the stored nonzeros are visited.
+pub(crate) fn csc_to_indexed(
+    x_dn: &nalgebra_sparse::CscMatrix<f32>,
+    context_size: usize,
+    shortlist_weights: &[f32],
+    ctx: PerGeneContext<'_>,
+    dev: &Device,
+) -> anyhow::Result<IndexedPack> {
+    let k = context_size.min(x_dn.nrows());
+    let samples = csc_columns_to_indexed_samples(x_dn, shortlist_weights, context_size);
+    let all_top_k: Vec<(Vec<u32>, Vec<f32>)> = samples
+        .into_iter()
+        .map(|s| (s.indices, s.values))
+        .collect();
+    pack_top_k_to_indexed(&all_top_k, k, ctx, dev)
+}
+
+/// Like [`csc_to_indexed`] but produces both encoder and decoder windows
+/// from a single sparse pass' worth of column scans.
+pub(crate) fn csc_to_indexed_pair(
+    x_dn: &nalgebra_sparse::CscMatrix<f32>,
+    enc_context_size: usize,
+    dec_context_size: usize,
+    shortlist_weights: &[f32],
+    ctx: PerGeneContext<'_>,
+    dev: &Device,
+) -> anyhow::Result<(IndexedPack, IndexedPack)> {
+    let enc = csc_to_indexed(x_dn, enc_context_size, shortlist_weights, ctx, dev)?;
+    let dec = csc_to_indexed(x_dn, dec_context_size, shortlist_weights, ctx, dev)?;
+    Ok((enc, dec))
+}
+
+/// Pack per-cell top-K `(indices, values)` into the `[N, K]` / `[S]`
+/// tensors of an [`IndexedPack`]. Shared by the dense and sparse
+/// front-ends.
+fn pack_top_k_to_indexed(
+    all_top_k: &[(Vec<u32>, Vec<f32>)],
+    k: usize,
+    ctx: PerGeneContext<'_>,
+    dev: &Device,
+) -> anyhow::Result<IndexedPack> {
+    let n_batch = all_top_k.len();
+
     let mut union_set = BTreeSet::new();
-    let mut all_top_k: Vec<(Vec<u32>, Vec<f32>)> = Vec::with_capacity(n_batch);
-    for row in rows {
-        let (indices, values) = top_k_indices_weighted(row, shortlist_weights, context_size);
-        for &idx in &indices {
+    for (indices, _) in all_top_k {
+        for &idx in indices {
             union_set.insert(idx);
         }
-        all_top_k.push((indices, values));
     }
 
     let union_vec: Vec<u32> = union_set.into_iter().collect();
@@ -279,9 +334,10 @@ where
 {
     let (lb, ub) = block;
 
-    // Read sparse -> dense [D, N], all at full D (no feature coarsening)
+    // Read sparse [D, N] at full D (no feature coarsening). Kept sparse:
+    // the top-K packer only ever visits stored nonzeros, so the dense
+    // `[N, D]` matrix is never materialized.
     let x_dn = data_vec.read_columns_csc(lb..ub)?;
-    let x_nd = x_dn.to_tensor(config.dev)?.transpose(0, 1)?;
 
     // Get batch/residual correction if available
     let x0_nd = config
@@ -291,16 +347,15 @@ where
         })
         .transpose()?;
 
-    // Convert dense to packed top-K. Single host copy when refinement also
-    // needs decoder packing.
+    // Convert sparse columns to packed top-K directly.
     let ctx = PerGeneContext {
         feature_mean: Some(config.feature_mean),
         feature_fisher_weights: Some(config.feature_fisher_weights),
     };
     let need_decoder = config.refine_config.is_some();
     let (enc_pack, dec_pack) = if need_decoder {
-        let (enc, dec) = dense_to_indexed_pair(
-            &x_nd,
+        let (enc, dec) = csc_to_indexed_pair(
+            &x_dn,
             config.enc_context_size,
             config.dec_context_size,
             config.shortlist_weights,
@@ -309,8 +364,8 @@ where
         )?;
         (enc, Some(dec))
     } else {
-        let enc = dense_to_indexed(
-            &x_nd,
+        let enc = csc_to_indexed(
+            &x_dn,
             config.enc_context_size,
             config.shortlist_weights,
             ctx,

--- a/senna/src/topic/train_indexed.rs
+++ b/senna/src/topic/train_indexed.rs
@@ -4,8 +4,8 @@ use crate::embed_common::*;
 use crate::logging::new_progress_bar;
 
 use super::graph_likelihood::{graph_loss, PoissonGraphConfig};
-use candle_core::{Device, Tensor};
-use candle_nn::AdamW;
+use candle_core::{Device, Tensor, Var};
+use candle_nn::{AdamW, Optimizer, ParamsAdamW};
 use candle_util::candle_decoder_embedded_topic::EmbeddedTopicDecoder;
 use candle_util::candle_encoder_indexed::IndexedEmbeddingEncoder;
 use candle_util::candle_indexed_data_loader::*;
@@ -13,6 +13,48 @@ use candle_util::candle_indexed_model_traits::*;
 use candle_util::candle_topic_refinement::TopicRefinementConfig;
 use matrix_param::dmatrix_gamma::GammaMatrix;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+/// Wall-clock breakdown of the indexed-topic training hot loop.
+///
+/// Candle's CPU backend is eager, so an `Instant` straddling each phase
+/// attributes time accurately (no async kernels to sync). Used to decide
+/// empirically whether the large-`H` bottleneck is the forward pass
+/// (→ pooling restructure) or the optimizer step (→ lazy ρ update).
+#[derive(Default)]
+struct PhaseTimers {
+    precompute: Duration,
+    encoder_fwd: Duration,
+    decoder_fwd: Duration,
+    backward: Duration,
+    optimize: Duration,
+}
+
+impl PhaseTimers {
+    fn log_summary(&self) {
+        let total = self.precompute
+            + self.encoder_fwd
+            + self.decoder_fwd
+            + self.backward
+            + self.optimize;
+        let total_s = total.as_secs_f64().max(1e-9);
+        let pct = |d: Duration| 100.0 * d.as_secs_f64() / total_s;
+        info!(
+            "phase timing — precompute {:.1}s ({:.0}%), encoder_fwd {:.1}s ({:.0}%), \
+             decoder_fwd {:.1}s ({:.0}%), backward {:.1}s ({:.0}%), opt_step {:.1}s ({:.0}%)",
+            self.precompute.as_secs_f64(),
+            pct(self.precompute),
+            self.encoder_fwd.as_secs_f64(),
+            pct(self.encoder_fwd),
+            self.decoder_fwd.as_secs_f64(),
+            pct(self.decoder_fwd),
+            self.backward.as_secs_f64(),
+            pct(self.backward),
+            self.optimize.as_secs_f64(),
+            pct(self.optimize),
+        );
+    }
+}
 
 pub(crate) struct IndexedTrainConfig<'a> {
     pub parameters: &'a candle_nn::VarMap,
@@ -24,10 +66,6 @@ pub(crate) struct IndexedTrainConfig<'a> {
     pub enc_context_size: usize,
     pub dec_context_size: usize,
     pub stop: &'a AtomicBool,
-    /// Per-level `[K, D_l]` anchor β prior tensors (pre-transposed, on device).
-    pub anchor_prior_per_level: Option<&'a [Tensor]>,
-    /// Cross-entropy penalty strength λ applied per minibatch.
-    pub anchor_penalty: f32,
     /// Per-gene weights used to *score* candidates during top-K shortlist
     /// selection (encoder + decoder). Stored values remain raw counts.
     pub shortlist_weights: &'a [f32],
@@ -47,35 +85,212 @@ pub(crate) struct IndexedTrainConfig<'a> {
     /// Run the BKN graph likelihood only for the first N epochs, then drop
     /// it. 0 = never drop (graph term stays active for all epochs).
     pub graph_warmup_epochs: usize,
+    /// The shared ρ `[D, H]` feature-embedding `Var`. When `lazy_rho` is
+    /// set, ρ is pulled out of the stock `AdamW` and stepped sparsely via
+    /// [`LazyRhoAdamW`] over each minibatch's touched rows.
+    pub rho_var: &'a Var,
+    /// Use the lazy (touched-row-only) optimizer for ρ. Disable to fall
+    /// back to dense `AdamW` over all of ρ — for A/B benchmarking.
+    pub lazy_rho: bool,
 }
 
-impl IndexedTrainConfig<'_> {
-    /// Anchor-prior CE penalty for the ETM-factorized indexed decoder. The
-    /// full `[K, D]` logits don't live as a single Var — they're
-    /// `α · ρᵀ` — so the caller passes the decoder and we materialize the
-    /// logits once per minibatch.
-    #[inline]
-    fn add_anchor_penalty(
-        &self,
-        loss: Tensor,
-        decoder: &EmbeddedTopicDecoder,
-        level: usize,
-    ) -> anyhow::Result<Tensor> {
-        // Skip `full_logits_kd()` ([K, H]·[H, D] matmul on the AD tape)
-        // when there's no penalty to apply. `anchor_penalty_at_level_with_logits`
-        // re-checks defensively, but this guard is the load-bearing one.
-        if self.anchor_prior_per_level.is_none() || self.anchor_penalty <= 0.0 {
-            return Ok(loss);
-        }
-        let logits_kd = decoder.full_logits_kd()?;
-        crate::topic::anchor_prior::anchor_penalty_at_level_with_logits(
-            loss,
-            &logits_kd,
-            self.anchor_prior_per_level,
-            self.anchor_penalty,
-            level,
-        )
+/// Lazy (sparse) AdamW for the shared ρ `[D, H]` embedding table.
+///
+/// Stock `AdamW` rewrites all of ρ — plus two `[D, H]` moment buffers —
+/// every minibatch, even though only the `touched_rho_indices` rows carry
+/// a nonzero gradient. This applies the identical AdamW update math to
+/// just the touched rows via `index_select` → update → `index_add`,
+/// turning the per-step cost from O(D·H) to O(T·H), T = touched rows.
+///
+/// Differences from dense `AdamW` (both standard for sparse-embedding
+/// optimizers — cf. PyTorch `SparseAdam` / TF `LazyAdam`):
+///  - untouched rows are not weight-decayed this step (embedding tables
+///    are conventionally excluded from weight decay anyway);
+///  - momentum on untouched rows is not advanced — no `beta^gap`
+///    catch-up — so a long-dormant row carries slightly larger momentum
+///    when next touched. Negligible for rows touched every few steps.
+struct LazyRhoAdamW {
+    rho: Var,
+    first_moment: Tensor,
+    second_moment: Tensor,
+    step_t: usize,
+    params: ParamsAdamW,
+}
+
+impl LazyRhoAdamW {
+    fn new(rho: Var, learning_rate: f32) -> anyhow::Result<Self> {
+        let first_moment = Tensor::zeros(rho.shape(), rho.dtype(), rho.device())?;
+        let second_moment = Tensor::zeros(rho.shape(), rho.dtype(), rho.device())?;
+        let params = ParamsAdamW {
+            lr: f64::from(learning_rate),
+            ..Default::default()
+        };
+        Ok(Self {
+            rho,
+            first_moment,
+            second_moment,
+            step_t: 0,
+            params,
+        })
     }
+
+    /// Apply one AdamW step to the rows of ρ named by `touched`, using
+    /// `grad_rho` (the dense `[D, H]` gradient from `backward()`, mostly
+    /// zero) scaled by the scalar `clip_scale` from the global-norm clip.
+    fn step_touched(
+        &mut self,
+        grad_rho: &Tensor,
+        touched: &Tensor,
+        clip_scale: &Tensor,
+    ) -> anyhow::Result<()> {
+        self.step_t += 1;
+        let p = &self.params;
+        let scale_m = 1.0 / (1.0 - p.beta1.powi(self.step_t as i32));
+        let scale_v = 1.0 / (1.0 - p.beta2.powi(self.step_t as i32));
+        let lr_lambda = p.lr * p.weight_decay;
+
+        let g = grad_rho
+            .index_select(touched, 0)?
+            .broadcast_mul(clip_scale)?; // [T, H]
+        let m_t = self.first_moment.index_select(touched, 0)?;
+        let v_t = self.second_moment.index_select(touched, 0)?;
+        let theta_t = self.rho.as_tensor().index_select(touched, 0)?;
+
+        let next_m = (m_t.affine(p.beta1, 0.0)? + g.affine(1.0 - p.beta1, 0.0)?)?;
+        let next_v = (v_t.affine(p.beta2, 0.0)? + g.sqr()?.affine(1.0 - p.beta2, 0.0)?)?;
+        let m_hat = next_m.affine(scale_m, 0.0)?;
+        let v_hat = next_v.affine(scale_v, 0.0)?;
+        let adjusted = (m_hat / v_hat.sqrt()?.affine(1.0, p.eps)?)?;
+        let next_theta =
+            (theta_t.affine(1.0 - lr_lambda, 0.0)? - adjusted.affine(p.lr, 0.0)?)?;
+
+        // Scatter per-row deltas back into the full [D, H] tensors.
+        // `detach()` is load-bearing: the moments are plain tensors, so
+        // without it each `index_add` would chain onto the previous step's
+        // graph and the autograd tape would grow unboundedly across the
+        // run. ρ is a `Var` — `set` copies in-place, so it stays a leaf.
+        self.first_moment = self
+            .first_moment
+            .index_add(touched, &(next_m - &m_t)?, 0)?
+            .detach();
+        self.second_moment = self
+            .second_moment
+            .index_add(touched, &(next_v - &v_t)?, 0)?
+            .detach();
+        let rho_next = self
+            .rho
+            .as_tensor()
+            .index_add(touched, &(next_theta - &theta_t)?, 0)?;
+        self.rho.set(&rho_next)?;
+        Ok(())
+    }
+}
+
+/// Global-L2-norm clip + dense `AdamW` step from a precomputed `GradStore`.
+/// Mirrors [`crate::embed_common::clip_grads_and_step`] but takes the
+/// already-computed grads so the caller can time `backward()` separately.
+fn clip_and_step_dense(
+    adam: &mut AdamW,
+    mut grads: candle_core::backprop::GradStore,
+    max_norm: f64,
+) -> anyhow::Result<()> {
+    if max_norm <= 0.0 {
+        adam.step(&grads)?;
+        return Ok(());
+    }
+    let ids: Vec<_> = grads.get_ids().copied().collect();
+    let mut sumsq: Option<Tensor> = None;
+    for id in &ids {
+        if let Some(g) = grads.get_id(*id) {
+            let s = g.sqr()?.sum_all()?;
+            sumsq = Some(match sumsq {
+                None => s,
+                Some(prev) => (prev + s)?,
+            });
+        }
+    }
+    let Some(sumsq) = sumsq else {
+        return Ok(());
+    };
+    let inv_norm = sumsq.sqrt()?.affine(1.0, 1e-6)?.powf(-1.0)?;
+    let scale = inv_norm.affine(max_norm, 0.0)?.clamp(0.0_f64, 1.0_f64)?;
+    for id in &ids {
+        if let Some(g) = grads.get_id(*id) {
+            let scaled = g.broadcast_mul(&scale)?;
+            grads.insert_id(*id, scaled);
+        }
+    }
+    adam.step(&grads)?;
+    Ok(())
+}
+
+/// Global-L2-norm clip + step from a precomputed `GradStore`, with ρ
+/// handled by `LazyRhoAdamW`.
+///
+/// ρ is excluded from `adam`'s var set; its gradient is pulled from the
+/// `GradStore` and stepped lazily over `touched`. The global grad norm
+/// still includes ρ's contribution, computed from the touched rows only
+/// (`O(T·H)`) — the untouched rows of ρ's dense grad are exactly zero, so
+/// the sum-of-squares is identical to the dense computation.
+fn clip_and_step_lazy_rho(
+    adam: &mut AdamW,
+    lazy_rho: &mut LazyRhoAdamW,
+    mut grads: candle_core::backprop::GradStore,
+    max_norm: f64,
+    touched: &Tensor,
+) -> anyhow::Result<()> {
+    let rho_id = lazy_rho.rho.id();
+    let rho_grad = grads.get_id(rho_id).cloned();
+    let dev = lazy_rho.rho.device().clone();
+    let ids: Vec<_> = grads.get_ids().copied().collect();
+
+    // Global sum-of-squares: dense for non-ρ params, touched-only for ρ.
+    let mut sumsq: Option<Tensor> = None;
+    for id in &ids {
+        if *id == rho_id {
+            continue;
+        }
+        if let Some(g) = grads.get_id(*id) {
+            let s = g.sqr()?.sum_all()?;
+            sumsq = Some(match sumsq {
+                None => s,
+                Some(prev) => (prev + s)?,
+            });
+        }
+    }
+    if let Some(ref rg) = rho_grad {
+        let s = rg.index_select(touched, 0)?.sqr()?.sum_all()?;
+        sumsq = Some(match sumsq {
+            None => s,
+            Some(prev) => (prev + s)?,
+        });
+    }
+
+    // Clip scale = min(1, max_norm / (‖g‖ + eps)); 1 when clipping is off.
+    let scale = match (max_norm > 0.0, &sumsq) {
+        (true, Some(sumsq)) => {
+            let inv = sumsq.sqrt()?.affine(1.0, 1e-6)?.powf(-1.0)?;
+            inv.affine(max_norm, 0.0)?.clamp(0.0_f64, 1.0_f64)?
+        }
+        _ => Tensor::ones((), candle_core::DType::F32, &dev)?,
+    };
+
+    // Scale non-ρ grads in place, then step the stock optimizer.
+    for id in &ids {
+        if *id == rho_id {
+            continue;
+        }
+        if let Some(g) = grads.get_id(*id) {
+            let scaled = g.broadcast_mul(&scale)?;
+            grads.insert_id(*id, scaled);
+        }
+    }
+    adam.step(&grads)?;
+
+    if let Some(rg) = rho_grad {
+        lazy_rho.step_touched(&rg, touched, &scale)?;
+    }
+    Ok(())
 }
 
 /// Estimate bulk-vs-SC bias as a `GammaMatrix` [`D_sc`, 1].
@@ -139,10 +354,9 @@ fn build_indexed_loaders(
 fn shuffle_and_precompute(
     loader: &mut IndexedInMemoryData,
     minibatch_size: usize,
-    dev: &Device,
 ) -> anyhow::Result<()> {
     loader.shuffle_minibatch(minibatch_size);
-    loader.precompute_all_minibatches(dev)
+    loader.precompute_all_minibatches()
 }
 
 
@@ -169,14 +383,41 @@ pub(crate) fn train_mixed(
 
     info!("Mixed multi-level training: {num_levels} levels, {total_epochs} epochs");
 
-    let mut adam = AdamW::new_lr(
-        config.parameters.all_vars(),
-        f64::from(config.learning_rate),
-    )?;
+    // ρ is stepped by `LazyRhoAdamW` when `lazy_rho` is set, so it must be
+    // excluded from the stock optimizer's var set to avoid a double update.
+    let rho_id = config.rho_var.id();
+    let adam_vars: Vec<Var> = if config.lazy_rho {
+        config
+            .parameters
+            .all_vars()
+            .into_iter()
+            .filter(|v| v.id() != rho_id)
+            .collect()
+    } else {
+        config.parameters.all_vars()
+    };
+    let mut adam = AdamW::new_lr(adam_vars, f64::from(config.learning_rate))?;
+    let mut lazy_rho = if config.lazy_rho {
+        Some(LazyRhoAdamW::new(
+            config.rho_var.clone(),
+            config.learning_rate,
+        )?)
+    } else {
+        None
+    };
+    info!(
+        "ρ optimizer: {}",
+        if config.lazy_rho {
+            "lazy (touched-row sparse AdamW)"
+        } else {
+            "dense AdamW"
+        }
+    );
     let prog_bar = new_progress_bar(total_epochs as u64);
 
     let mut llik_trace = Vec::with_capacity(total_epochs);
     let mut kl_trace = Vec::with_capacity(total_epochs);
+    let mut timers = PhaseTimers::default();
 
     let level_data = build_level_data(collapsed_levels)?;
     let mut data_loaders = build_indexed_loaders(&level_data, config)?;
@@ -205,12 +446,14 @@ pub(crate) fn train_mixed(
         };
 
     for epoch in 0..total_epochs {
+        let t_pre = Instant::now();
         for loader in data_loaders.iter_mut() {
-            shuffle_and_precompute(loader, config.minibatch_size, config.dev)?;
+            shuffle_and_precompute(loader, config.minibatch_size)?;
         }
         if let Some(bulk_loader) = bulk_loader.as_mut() {
-            shuffle_and_precompute(bulk_loader, config.minibatch_size, config.dev)?;
+            shuffle_and_precompute(bulk_loader, config.minibatch_size)?;
         }
+        timers.precompute += t_pre.elapsed();
 
         let mut llik_tot = 0f32;
         let mut kl_tot = 0f32;
@@ -220,10 +463,26 @@ pub(crate) fn train_mixed(
         for (level, loader) in data_loaders.iter().enumerate() {
             let decoder = &decoders[level];
             n_tot += loader.num_data();
+            count_tot += loader.total_output_count();
+
+            // One-time diagnostic: how large is the per-minibatch touched
+            // ρ-row set relative to D? Determines the lazy-optimizer ceiling.
+            if epoch == 0 && loader.num_minibatch() > 0 {
+                let t = loader.minibatch_cached(0).touched_rho_indices.dim(0)?;
+                let d = config.rho_var.dim(0)?;
+                info!(
+                    "level {} mb0: touched {} / {} ρ rows ({:.0}%)",
+                    level + 1,
+                    t,
+                    d,
+                    100.0 * t as f64 / d as f64
+                );
+            }
 
             for b in 0..loader.num_minibatch() {
-                let mb = loader.minibatch_cached(b);
+                let mb = loader.minibatch_cached(b).to_device(config.dev)?;
 
+                let t_enc = Instant::now();
                 let (log_z_nk, kl) = encoder.forward_indexed_t(
                     &mb.input_indices,
                     &mb.input_values,
@@ -232,7 +491,9 @@ pub(crate) fn train_mixed(
                     true,
                 )?;
                 let log_z_nk = smooth_topics(log_z_nk, config.topic_smoothing)?;
+                timers.encoder_fwd += t_enc.elapsed();
 
+                let t_dec = Instant::now();
                 let llik = decoder.forward_indexed(
                     &log_z_nk,
                     &mb.output_union_indices,
@@ -242,13 +503,27 @@ pub(crate) fn train_mixed(
                     &mb.output_log_q_s,
                 )?;
                 let loss = (&kl - &llik)?.mean_all()?;
-                let loss = config.add_anchor_penalty(loss, decoder, level)?;
+                timers.decoder_fwd += t_dec.elapsed();
 
-                clip_grads_and_step(&mut adam, &loss, f64::from(config.grad_clip))?;
+                let t_bwd = Instant::now();
+                let grads = loss.backward()?;
+                timers.backward += t_bwd.elapsed();
+
+                let t_opt = Instant::now();
+                match lazy_rho.as_mut() {
+                    Some(lr) => clip_and_step_lazy_rho(
+                        &mut adam,
+                        lr,
+                        grads,
+                        f64::from(config.grad_clip),
+                        &mb.touched_rho_indices,
+                    )?,
+                    None => clip_and_step_dense(&mut adam, grads, f64::from(config.grad_clip))?,
+                }
+                timers.optimize += t_opt.elapsed();
 
                 llik_tot += llik.sum_all()?.to_scalar::<f32>()?;
                 kl_tot += kl.sum_all()?.to_scalar::<f32>()?;
-                count_tot += mb.output_values.sum_all()?.to_scalar::<f32>()?;
 
                 if config.stop.load(Ordering::Relaxed) {
                     break;
@@ -260,9 +535,11 @@ pub(crate) fn train_mixed(
         if let Some(bulk_loader) = bulk_loader.as_ref() {
             let finest_idx = num_levels - 1;
             let finest_decoder = &decoders[finest_idx];
+            count_tot += bulk_loader.total_output_count();
 
             for b in 0..bulk_loader.num_minibatch() {
-                let mb = bulk_loader.minibatch_cached(b);
+                let mb = bulk_loader.minibatch_cached(b).to_device(config.dev)?;
+                let t_enc = Instant::now();
                 let (log_z_nk, kl) = encoder.forward_indexed_t(
                     &mb.input_indices,
                     &mb.input_values,
@@ -271,6 +548,9 @@ pub(crate) fn train_mixed(
                     true,
                 )?;
                 let log_z_nk = smooth_topics(log_z_nk, config.topic_smoothing)?;
+                timers.encoder_fwd += t_enc.elapsed();
+
+                let t_dec = Instant::now();
                 let llik = finest_decoder.forward_indexed(
                     &log_z_nk,
                     &mb.output_union_indices,
@@ -280,12 +560,27 @@ pub(crate) fn train_mixed(
                     &mb.output_log_q_s,
                 )?;
                 let loss = (&kl - &llik)?.mean_all()?;
-                let loss = config.add_anchor_penalty(loss, finest_decoder, finest_idx)?;
-                clip_grads_and_step(&mut adam, &loss, f64::from(config.grad_clip))?;
+                timers.decoder_fwd += t_dec.elapsed();
+
+                let t_bwd = Instant::now();
+                let grads = loss.backward()?;
+                timers.backward += t_bwd.elapsed();
+
+                let t_opt = Instant::now();
+                match lazy_rho.as_mut() {
+                    Some(lr) => clip_and_step_lazy_rho(
+                        &mut adam,
+                        lr,
+                        grads,
+                        f64::from(config.grad_clip),
+                        &mb.touched_rho_indices,
+                    )?,
+                    None => clip_and_step_dense(&mut adam, grads, f64::from(config.grad_clip))?,
+                }
+                timers.optimize += t_opt.elapsed();
 
                 llik_tot += llik.sum_all()?.to_scalar::<f32>()?;
                 kl_tot += kl.sum_all()?.to_scalar::<f32>()?;
-                count_tot += mb.output_values.sum_all()?.to_scalar::<f32>()?;
 
                 if config.stop.load(Ordering::Relaxed) {
                     break;
@@ -339,6 +634,7 @@ pub(crate) fn train_mixed(
         if config.stop.load(Ordering::SeqCst) {
             prog_bar.finish_and_clear();
             info!("Stopping early at epoch {epoch}");
+            timers.log_summary();
             return Ok(TrainScores {
                 llik: llik_trace,
                 kl: kl_trace,
@@ -348,6 +644,7 @@ pub(crate) fn train_mixed(
 
     prog_bar.finish_and_clear();
     info!("done mixed multi-level training");
+    timers.log_summary();
     Ok(TrainScores {
         llik: llik_trace,
         kl: kl_trace,


### PR DESCRIPTION
## Summary

Optimization pass on `senna indexed-topic`, focused on the large-embedding-dim (`H`) bottleneck.

- **`LazyRhoAdamW`** — touched-row-only AdamW for the shared ρ `[D,H]` embedding table, default-on (`--dense-rho-update` opts out). The loader now carries `touched_rho_indices` per minibatch (union of encoder + decoder feature ids); the global grad-norm clip computes ρ's contribution from the touched rows only.
- **`PhaseTimers`** — per-phase wall-clock breakdown of the training hot loop (precompute / encoder_fwd / decoder_fwd / backward / opt_step), logged once at end of training.
- **Sparse eval path** — `evaluate_indexed_block` now goes CSC → indexed directly via `csc_columns_to_indexed_samples`, skipping the dense `[N,D]` materialization.
- **Loader cleanup** — `total_output_count` cached once instead of re-summed per minibatch; minibatch precompute moved host-side with per-minibatch `to_device`.
- **Drop anchor-prior CE penalty** from indexed-topic (it was unused cost — `full_logits_kd()` matmul + softmax every minibatch) and the now-orphan `anchor_penalty_at_level_with_logits`.

## Why

At large `H`, phase timing showed `backward` (~38%) and `opt_step` (~46%) dominate, with the optimizer step over the full `[D,H]` ρ table being the largest single cost. `LazyRhoAdamW` restricts the ρ update + grad-clip to the rows actually touched each minibatch.

## Reviewer notes

- **lazy-ρ's win is config-dependent.** It pays off when the per-minibatch touched ρ-row set is sparse. `indexed-topic` trains on *pseudobulk* samples, which are dense — touched fraction is ~9/25/47% across the three PB levels — so lazy-ρ is roughly a wash at the default `ctx=512/mb=100` (~5% wall), but 3.7× on `opt_step` when minibatches are genuinely sparse (`ctx=128/mb=25` → 3–7% touched). It is never *slower* than dense and accuracy is unaffected (llik slightly better in A/B). The `epoch==0 mb0` touched-% diagnostic line reports this per run.
- Math is identical to dense `AdamW` on touched rows; differences are the standard sparse-embedding-optimizer ones (untouched rows not weight-decayed, no `beta^gap` momentum catch-up) — negligible for rows touched every few steps.
- `indexed-topic` behavior is unchanged by default except the dropped anchor penalty (which was effectively inert) and the faster eval path (CSC equivalence is unit-tested).
- Build / clippy / `candle-util` data-loader tests all clean.

## Test plan

- [x] `cargo build -p senna -p candle-util`
- [x] `cargo clippy -p senna -p candle-util --all-targets`
- [x] `cargo test -p candle-util --lib candle_indexed_data_loader` (incl. new CSC↔dense equivalence test)
- [x] Smoke test: `senna indexed-topic` on 10k BMMNC (8313 cells × 36591 genes) — runs clean, 12/12 topics active, llik converges
- [x] A/B lazy vs dense ρ at multiple `ctx`/`mb` configs — confirmed correctness + speedup characterization