### PR TITLE
feat(senna): plot-strand Watson/Crick genomic-activity ideograms

### DIFF
--- a/genomic-data/src/coordinates.rs
+++ b/genomic-data/src/coordinates.rs
@@ -1,5 +1,6 @@
 use crate::gff::GeneId;
 use crate::sam::Strand;
+use std::collections::HashMap;
 
 /// Compare chromosome names ignoring optional "chr" prefix.
 ///
@@ -26,6 +27,17 @@ pub struct PeakCoord {
 pub struct GeneTss {
     pub chr: Box<str>,
     pub tss: i64,
+}
+
+/// Gene TSS position **with strand** parsed from GFF. Like [`GeneTss`]
+/// but retains the strand so callers (e.g. strand-resolved genomic
+/// pileups) can split forward (Watson) from backward (Crick) genes.
+#[derive(Debug, Clone)]
+pub struct GeneLoc {
+    pub chr: Box<str>,
+    /// Transcription start site (start on `+`, stop on `-`).
+    pub tss: i64,
+    pub strand: Strand,
 }
 
 /// Gene annotation simplified for eQTL and cis-regulatory analysis.
@@ -147,18 +159,39 @@ pub fn find_cis_peaks(
         .collect()
 }
 
-/// Load gene TSS positions from a GFF/GTF file.
+/// Load gene TSS positions from a GFF/GTF file, aligned to `gene_names`
+/// by exact symbol match. Strand-discarding projection of
+/// [`load_gene_loci`].
 pub fn load_gene_tss(
     gff_file: &str,
     gene_names: &[Box<str>],
 ) -> anyhow::Result<Vec<Option<GeneTss>>> {
+    Ok(load_gene_loci(gff_file, gene_names)?
+        .into_iter()
+        .map(|loc| {
+            loc.map(|l| GeneTss {
+                chr: l.chr,
+                tss: l.tss,
+            })
+        })
+        .collect())
+}
+
+/// Load a `gene-symbol → (chr, TSS, strand)` map from a GFF/GTF file.
+///
+/// Only `gene` features are kept; each gene is keyed by its symbol,
+/// falling back to the Ensembl id when the symbol is missing. Unlike
+/// [`load_gene_tss`], the strand is retained so callers can split
+/// forward/Watson genes from backward/Crick genes. Keys are the raw GFF
+/// symbols — callers that need alias-tolerant matching (e.g.
+/// `ENSG…_SYMBOL` row names) should canonicalize both sides themselves.
+pub fn load_gene_loci_map(gff_file: &str) -> anyhow::Result<HashMap<Box<str>, GeneLoc>> {
     use crate::gff::{read_gff_record_vec, FeatureType, GeneSymbol};
     use log::info;
-    use rustc_hash::FxHashMap as HashMap;
 
     let records = read_gff_record_vec(gff_file)?;
 
-    let mut tss_map: HashMap<Box<str>, GeneTss> = Default::default();
+    let mut loc_map: HashMap<Box<str>, GeneLoc> = HashMap::new();
     for rec in &records {
         if rec.feature_type != FeatureType::Gene {
             continue;
@@ -174,32 +207,70 @@ pub fn load_gene_tss(
                 id
             }
         };
-        tss_map.insert(
+        loc_map.insert(
             key,
-            GeneTss {
+            GeneLoc {
                 chr: rec.seqname.clone(),
                 tss,
+                strand: rec.strand,
             },
         );
     }
 
-    info!(
-        "Loaded {} gene positions from GFF, matching against {} genes",
-        tss_map.len(),
-        gene_names.len()
-    );
+    info!("Loaded {} gene loci from GFF", loc_map.len());
+    Ok(loc_map)
+}
 
-    let result: Vec<Option<GeneTss>> = gene_names
+/// Load gene TSS positions **and strand** from a GFF/GTF file, aligned
+/// to `gene_names` by exact symbol match (`None` where a name has no
+/// matching `gene` record). For alias-tolerant matching, prefer
+/// [`load_gene_loci_map`] + a caller-side canonicalizer.
+pub fn load_gene_loci(
+    gff_file: &str,
+    gene_names: &[Box<str>],
+) -> anyhow::Result<Vec<Option<GeneLoc>>> {
+    use log::info;
+
+    let loc_map = load_gene_loci_map(gff_file)?;
+
+    let result: Vec<Option<GeneLoc>> = gene_names
         .iter()
-        .map(|name| tss_map.get(name).cloned())
+        .map(|name| loc_map.get(name).cloned())
         .collect();
 
     let matched = result.iter().filter(|x| x.is_some()).count();
-    info!(
-        "Matched {}/{} genes to GFF positions",
-        matched,
-        gene_names.len()
-    );
+    info!("Matched {}/{} genes to GFF loci", matched, gene_names.len());
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_gene_loci_keeps_strand_and_tss() {
+        // Two genes: AAA on +, BBB on -. TSS = start on +, stop on -.
+        let gtf = "\
+chr1\tHAVANA\tgene\t100\t200\t.\t+\t.\tgene_id \"ENSG001\"; gene_name \"AAA\"; gene_type \"protein_coding\"
+chr1\tHAVANA\tgene\t400\t600\t.\t-\t.\tgene_id \"ENSG002\"; gene_name \"BBB\"; gene_type \"protein_coding\"
+chr1\tHAVANA\texon\t100\t150\t.\t+\t.\tgene_id \"ENSG001\"; gene_name \"AAA\"
+";
+        let path = std::env::temp_dir().join(format!("genloci_{}.gtf", std::process::id()));
+        std::fs::write(&path, gtf).unwrap();
+        let names: Vec<Box<str>> = vec!["AAA".into(), "BBB".into(), "MISSING".into()];
+        let loci = load_gene_loci(path.to_str().unwrap(), &names).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        let aaa = loci[0].as_ref().expect("AAA present");
+        assert!(matches!(aaa.strand, Strand::Forward));
+        assert_eq!(aaa.tss, 100);
+        assert_eq!(chr_stripped(&aaa.chr), "1");
+
+        let bbb = loci[1].as_ref().expect("BBB present");
+        assert!(matches!(bbb.strand, Strand::Backward));
+        assert_eq!(bbb.tss, 600);
+
+        assert!(loci[2].is_none());
+    }
 }

--- a/senna/src/main.rs
+++ b/senna/src/main.rs
@@ -362,6 +362,20 @@ enum Commands {
         visible_alias = "pt"
     )]
     PlotTopic(PlotTopicArgs),
+
+    #[command(
+        about = "Watson/Crick mirrored genomic-activity ideograms (Strand-seq style).",
+        long_about = "For each cell type, draw per-chromosome gene activity split by strand:\n\
+                      forward/Watson genes as a filled pileup rising upward, reverse/Crick\n\
+                      genes mirrored downward around a shared chromosome axis.\n\n\
+                      Usage: senna plot-strand --from run.senna.json --gtf gencode.gtf\n\n\
+                      Activity defaults to a gene × cell-type matrix derived from\n\
+                      `senna annotate` outputs; override with --activity. One figure per\n\
+                      cell type (chromosomes stacked) plus an optional consensus, under\n\
+                      {out}.strand/. PDF only by default; pass --svg / --png.",
+        visible_alias = "ps"
+    )]
+    PlotStrand(PlotStrandArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -452,6 +466,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::PlotTopic(args) => {
             fit_plot_topic(args)?;
+        }
+        Commands::PlotStrand(args) => {
+            fit_plot_strand(args)?;
         }
     }
 

--- a/senna/src/postprocess/mod.rs
+++ b/senna/src/postprocess/mod.rs
@@ -11,4 +11,5 @@ pub use fit_layout_tree::*;
 pub use fit_layout_tsne::*;
 pub use fit_layout_umap::*;
 pub use plot::scatter::*;
+pub use plot::strand::*;
 pub use plot::topic::*;

--- a/senna/src/postprocess/plot/mod.rs
+++ b/senna/src/postprocess/plot/mod.rs
@@ -1,4 +1,16 @@
 pub mod scatter;
+pub mod strand;
 pub mod topic;
 
 pub use plot_utils::{hull, palette, rasterize, svg_emit};
+
+/// Map a label (cell type, batch, …) to a filesystem-safe basename:
+/// keep ASCII alphanumerics and `-_.`, replace everything else with `_`.
+pub(crate) fn sanitize_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '.' => c,
+            _ => '_',
+        })
+        .collect()
+}

--- a/senna/src/postprocess/plot/strand/mod.rs
+++ b/senna/src/postprocess/plot/strand/mod.rs
@@ -1,0 +1,515 @@
+//! `senna plot-strand` — Watson/Crick mirrored genomic-activity
+//! ideograms.
+//!
+//! Motivated by the CD34+ bone-marrow "silent sister" hypothesis: for
+//! each cell type, draw per-chromosome gene **activity split by strand**
+//! — forward/Watson genes as a filled pileup rising *upward*,
+//! reverse/Crick genes *mirrored downward* around a shared horizontal
+//! chromosome axis (cf. Strand-seq ideograms).
+//!
+//! Inputs come from a trained-then-annotated run:
+//!   - gene × cell-type activity, derived from `senna annotate`'s
+//!     `cluster_expression.parquet` (gene × cluster) collapsed to cell
+//!     types via `cluster_celltype_q.parquet` (cluster × cell-type), or
+//!     any gene × group matrix passed with `--activity`.
+//!   - gene coordinates + strand from a GTF/GFF (`--gtf`), matched to the
+//!     activity row names with the same alias-tolerant rule the topic
+//!     models use (`auxiliary_data::feature_names`).
+//!
+//! Output: one figure per cell type (chromosomes stacked vertically),
+//! plus an optional consensus figure. We hand-build the SVG and render
+//! it through the shared `plot_utils` resvg/svg2pdf path — no new
+//! plotting primitives. Placement/binning live in [`place`]; SVG
+//! assembly in [`render`].
+
+mod place;
+mod render;
+
+use crate::embed_common::*;
+use crate::run_manifest::{self, RunManifest};
+use place::{bin_group, place_genes, robust_max, sum_grids, BinGrid};
+use rayon::prelude::*;
+use render::render_one;
+use rustc_hash::FxHashMap;
+use std::path::Path;
+
+////////////////////////////////////////////////////////////////////////
+// CLI
+////////////////////////////////////////////////////////////////////////
+
+#[derive(Args, Debug)]
+pub struct PlotStrandArgs {
+    #[arg(
+        long,
+        short = 'f',
+        help = "Run manifest JSON from `senna {topic,...}` enriched by `senna annotate`",
+        long_help = "Fills --activity (from annotate.cluster_expression + \
+                     annotate.cluster_celltype_q) and --out (from the manifest \
+                     prefix). Explicit CLI flags still win. Paths inside the \
+                     manifest resolve relative to its own directory."
+    )]
+    pub from: Option<Box<str>>,
+
+    #[arg(
+        long,
+        help = "GTF/GFF with gene coordinates + strand (GENCODE-style). Required."
+    )]
+    pub gtf: Box<str>,
+
+    #[arg(
+        long,
+        help = "Override the gene × group activity matrix (parquet, gene-name rows). \
+                Default: derived gene × cell-type matrix from the manifest's annotate outputs."
+    )]
+    pub activity: Option<Box<str>>,
+
+    #[arg(
+        long,
+        short = 'o',
+        help = "Output prefix (defaults to the manifest `prefix`). Writes {out}.strand/<celltype>.pdf"
+    )]
+    pub out: Option<Box<str>>,
+
+    #[arg(
+        long,
+        value_delimiter = ',',
+        help = "Restrict to these chromosomes (comma-separated, 'chr' prefix optional). \
+                Default: all autosomes + X/Y/M present in the GTF, in karyotype order."
+    )]
+    pub chromosomes: Option<Vec<Box<str>>>,
+
+    #[arg(
+        long,
+        default_value_t = 400,
+        help = "Number of genomic bins across the longest chromosome (others scale by length)"
+    )]
+    pub bins: usize,
+
+    #[arg(
+        long,
+        default_value_t = 0,
+        help = "Label the top-N genes (by activity) per chromosome/cell-type (0 = off)"
+    )]
+    pub top_genes: usize,
+
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = HeightScale::Sqrt,
+        help = "Pileup-height scale for the binned activity (default: sqrt). Compresses spikes so low-level signal stays visible."
+    )]
+    pub scale: HeightScale,
+
+    #[arg(
+        long,
+        default_value_t = true,
+        help = "Also emit a consensus figure summing activity across all cell types",
+        action = clap::ArgAction::Set
+    )]
+    pub consensus: bool,
+
+    #[arg(
+        long,
+        default_value = "#E69F00",
+        help = "Watson (forward) fill colour, drawn upward"
+    )]
+    pub watson_color: Box<str>,
+
+    #[arg(
+        long,
+        default_value = "#0F8B8D",
+        help = "Crick (reverse) fill colour, drawn downward"
+    )]
+    pub crick_color: Box<str>,
+
+    #[arg(
+        long,
+        default_value = "#7A7A7A",
+        help = "Consensus fill colour (both strands), matching the Strand-seq consensus track"
+    )]
+    pub consensus_color: Box<str>,
+
+    #[arg(long, default_value_t = 7.0, help = "Figure width (inches)")]
+    pub width: f32,
+
+    #[arg(
+        long,
+        default_value_t = 0.30,
+        help = "Per-chromosome track height (inches; split half Watson / half Crick)"
+    )]
+    pub track_height: f32,
+
+    #[arg(long, default_value_t = 300, help = "Output DPI")]
+    pub dpi: u32,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Also emit SVG (default: PDF only)"
+    )]
+    pub svg: bool,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Also emit PNG (default: PDF only)"
+    )]
+    pub png: bool,
+
+    #[arg(long, default_value_t = false, help = "Skip PDF output")]
+    pub no_pdf: bool,
+}
+
+/// Up (Watson) / down (Crick) fill colours for a single figure.
+#[derive(Clone, Copy)]
+pub(super) struct Strands<'a> {
+    pub(super) up: &'a str,
+    pub(super) down: &'a str,
+}
+
+/// Non-linear remap applied to bin heights before normalization, so a
+/// few high-expression spikes don't flatten everything else.
+#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[clap(rename_all = "kebab-case")]
+pub enum HeightScale {
+    /// Raw activity.
+    Linear,
+    /// `sqrt(v)` — the default; gentle spike compression.
+    #[default]
+    Sqrt,
+    /// `ln(1 + v)` — stronger compression.
+    Log,
+}
+
+impl HeightScale {
+    /// Monotonic, maps 0 → 0; applied to both value and scale so the
+    /// normalized fraction stays in `[0, 1]`.
+    pub(super) fn apply(self, v: f32) -> f32 {
+        let v = v.max(0.0);
+        match self {
+            HeightScale::Linear => v,
+            HeightScale::Sqrt => v.sqrt(),
+            HeightScale::Log => v.ln_1p(),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Entry point
+////////////////////////////////////////////////////////////////////////
+
+pub fn fit_plot_strand(args: &PlotStrandArgs) -> anyhow::Result<()> {
+    // ----- Resolve inputs (manifest defaults, CLI wins) -----
+    let (activity_path, out_prefix) = resolve_inputs(args)?;
+
+    // ----- Load gene × group activity -----
+    let Activity {
+        mat,
+        gene_names,
+        group_names,
+    } = load_activity(&activity_path)?;
+    info!(
+        "Activity matrix: {} genes × {} groups",
+        gene_names.len(),
+        group_names.len()
+    );
+
+    // ----- Attach genomic coordinates + strand (alias-tolerant) -----
+    let placements = place_genes(&gene_names, &args.gtf, args)?;
+    anyhow::ensure!(
+        !placements.chromosomes.is_empty(),
+        "no genes matched the GTF on the requested chromosomes"
+    );
+    info!(
+        "Placed {} genes across {} chromosomes",
+        placements.placed.len(),
+        placements.chromosomes.len()
+    );
+
+    // ----- Bin every group, then a global robust scale -----
+    let grids: Vec<BinGrid> = (0..group_names.len())
+        .into_par_iter()
+        .map(|c| bin_group(&mat, c, &placements))
+        .collect();
+
+    let consensus_grid = args.consensus.then(|| sum_grids(&grids, &placements));
+
+    let robust_max = robust_max(
+        grids
+            .iter()
+            .chain(consensus_grid.iter())
+            .flat_map(|g| g.iter_values()),
+    );
+    anyhow::ensure!(
+        robust_max > 0.0,
+        "all activity values are zero/negative — nothing to draw"
+    );
+
+    // ----- Render one figure per group (+ consensus) -----
+    let out_dir = format!("{out_prefix}.strand");
+    std::fs::create_dir_all(&out_dir)?;
+
+    let mut jobs: Vec<(String, &BinGrid, Strands)> = group_names
+        .iter()
+        .zip(grids.iter())
+        .map(|(name, grid)| {
+            (
+                name.to_string(),
+                grid,
+                Strands {
+                    up: args.watson_color.as_ref(),
+                    down: args.crick_color.as_ref(),
+                },
+            )
+        })
+        .collect();
+    if let Some(grid) = consensus_grid.as_ref() {
+        jobs.push((
+            "_consensus".to_string(),
+            grid,
+            Strands {
+                up: args.consensus_color.as_ref(),
+                down: args.consensus_color.as_ref(),
+            },
+        ));
+    }
+
+    let written: usize = jobs
+        .par_iter()
+        .map(|(name, grid, strands)| {
+            render_one(
+                name,
+                grid,
+                *strands,
+                robust_max,
+                &placements,
+                &out_dir,
+                args,
+            )
+        })
+        .collect::<anyhow::Result<Vec<usize>>>()?
+        .iter()
+        .sum();
+    info!("Wrote {written} files under {out_dir}/");
+
+    Ok(())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Input resolution
+////////////////////////////////////////////////////////////////////////
+
+/// Returns `(activity_parquet_path, out_prefix)`.
+fn resolve_inputs(args: &PlotStrandArgs) -> anyhow::Result<(String, String)> {
+    // No --from: --activity and --out are both required.
+    let Some(from) = args.from.as_deref() else {
+        let activity = args.activity.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("--activity PATH is required when --from is not given")
+        })?;
+        let out = args
+            .out
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("--out PREFIX is required when --from is not given"))?;
+        return Ok((activity.to_string(), out.to_string()));
+    };
+
+    let (m, dir) = RunManifest::load(Path::new(from))?;
+    info!("Loaded run manifest {from} (kind: {})", m.kind);
+    let resolve = |s: &str| {
+        run_manifest::resolve(&dir, s)
+            .to_string_lossy()
+            .into_owned()
+    };
+
+    // Out prefix first (CLI wins) — the derived activity is written next
+    // to it, not next to `m.prefix`, which may be an absolute path from
+    // the machine the run was trained on.
+    let out = args
+        .out
+        .as_deref()
+        .map(String::from)
+        .unwrap_or_else(|| m.prefix.clone());
+
+    // --activity wins; else derive a gene × cell-type matrix from annotate.
+    let activity = if let Some(p) = args.activity.as_deref() {
+        p.to_string()
+    } else {
+        let cluster_expr = m.annotate.cluster_expression.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "manifest {from} has no annotate.cluster_expression; run `senna annotate` \
+                 first, or pass --activity with a gene × group parquet"
+            )
+        })?;
+        let q = m.annotate.cluster_celltype_q.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "manifest {from} has no annotate.cluster_celltype_q; run `senna annotate` first"
+            )
+        })?;
+        let derived = format!("{out}.celltype_expression.parquet");
+        mkdir_parent(&derived)?;
+        derive_celltype_activity(&resolve(cluster_expr), &resolve(q), &derived)?;
+        derived
+    };
+
+    Ok((activity, out))
+}
+
+/// Collapse `cluster_expression` (gene × cluster) to gene × cell-type by
+/// assigning each cluster to its argmax cell type in `cluster_celltype_q`
+/// (cluster × cell-type) and averaging the clusters of each cell type.
+fn derive_celltype_activity(
+    cluster_expr_path: &str,
+    q_path: &str,
+    out_path: &str,
+) -> anyhow::Result<()> {
+    let MatWithNames {
+        rows: genes,
+        cols: clusters_e,
+        mat: profile_gk,
+    } = Mat::from_parquet(cluster_expr_path)?;
+    let MatWithNames {
+        rows: clusters_q,
+        cols: celltypes,
+        mat: q_kc,
+    } = Mat::from_parquet(q_path)?;
+
+    // cluster label -> argmax cell-type index
+    let mut cluster_to_ct: FxHashMap<&str, usize> = FxHashMap::default();
+    for (r, cl) in clusters_q.iter().enumerate() {
+        let mut best_j = 0usize;
+        let mut best_v = f32::NEG_INFINITY;
+        for j in 0..q_kc.ncols() {
+            let v = q_kc[(r, j)];
+            if v > best_v {
+                best_v = v;
+                best_j = j;
+            }
+        }
+        cluster_to_ct.insert(cl.as_ref(), best_j);
+    }
+
+    let n_ct = celltypes.len();
+    let mut out = Mat::zeros(genes.len(), n_ct);
+    let mut counts = vec![0u32; n_ct];
+    for (j, cl) in clusters_e.iter().enumerate() {
+        let Some(&ct) = cluster_to_ct.get(cl.as_ref()) else {
+            log::warn!(
+                "cluster {cl} in cluster_expression has no row in cluster_celltype_q — skipped"
+            );
+            continue;
+        };
+        counts[ct] += 1;
+        for g in 0..genes.len() {
+            out[(g, ct)] += profile_gk[(g, j)];
+        }
+    }
+    // Mean over the clusters assigned to each cell type.
+    for ct in 0..n_ct {
+        if counts[ct] > 1 {
+            let inv = 1.0 / counts[ct] as f32;
+            for g in 0..genes.len() {
+                out[(g, ct)] *= inv;
+            }
+        }
+    }
+    // Keep only cell types that received at least one cluster.
+    let keep: Vec<usize> = (0..n_ct).filter(|&ct| counts[ct] > 0).collect();
+    let kept_names: Vec<Box<str>> = keep.iter().map(|&ct| celltypes[ct].clone()).collect();
+    let mut kept = Mat::zeros(genes.len(), keep.len());
+    for (newc, &ct) in keep.iter().enumerate() {
+        for g in 0..genes.len() {
+            kept[(g, newc)] = out[(g, ct)];
+        }
+    }
+    kept.to_parquet_with_names(out_path, (Some(&genes), Some("gene")), Some(&kept_names))?;
+    info!(
+        "Derived gene × cell-type activity ({} cell types) → {out_path}",
+        kept_names.len()
+    );
+    Ok(())
+}
+
+struct Activity {
+    mat: Mat,
+    gene_names: Vec<Box<str>>,
+    group_names: Vec<Box<str>>,
+}
+
+fn load_activity(path: &str) -> anyhow::Result<Activity> {
+    let MatWithNames { rows, cols, mat } = Mat::from_parquet(path)?;
+    anyhow::ensure!(mat.ncols() >= 1, "{path}: activity matrix has no columns");
+    anyhow::ensure!(
+        rows.len() == mat.nrows(),
+        "{path}: row-name count {} != matrix rows {}",
+        rows.len(),
+        mat.nrows()
+    );
+    Ok(Activity {
+        mat,
+        gene_names: rows,
+        group_names: cols,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_util::traits::IoOps;
+
+    fn tmp(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("strand_{}_{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn derive_celltype_collapses_clusters_by_argmax_mean() {
+        // 2 genes × 3 clusters; clusters K0,K1 → celltype A, K2 → B.
+        let genes: Vec<Box<str>> = vec!["G0".into(), "G1".into()];
+        let clusters: Vec<Box<str>> = vec!["K0".into(), "K1".into(), "K2".into()];
+        let mut expr = Mat::zeros(2, 3);
+        expr[(0, 0)] = 2.0;
+        expr[(0, 1)] = 4.0; // gene0 in A clusters → mean 3
+        expr[(0, 2)] = 10.0; // gene0 in B → 10
+        expr[(1, 0)] = 1.0;
+        expr[(1, 1)] = 1.0; // gene1 in A → mean 1
+        expr[(1, 2)] = 5.0; // gene1 in B → 5
+        let expr_path = tmp("expr.parquet");
+        expr.to_parquet_with_names(
+            expr_path.to_str().unwrap(),
+            (Some(&genes), Some("gene")),
+            Some(&clusters),
+        )
+        .unwrap();
+
+        let celltypes: Vec<Box<str>> = vec!["A".into(), "B".into()];
+        let mut q = Mat::zeros(3, 2);
+        q[(0, 0)] = 0.9; // K0 → A
+        q[(1, 0)] = 0.8; // K1 → A
+        q[(2, 1)] = 0.7; // K2 → B
+        let q_path = tmp("q.parquet");
+        q.to_parquet_with_names(
+            q_path.to_str().unwrap(),
+            (Some(&clusters), Some("cluster")),
+            Some(&celltypes),
+        )
+        .unwrap();
+
+        let out_path = tmp("celltype.parquet");
+        derive_celltype_activity(
+            expr_path.to_str().unwrap(),
+            q_path.to_str().unwrap(),
+            out_path.to_str().unwrap(),
+        )
+        .unwrap();
+
+        let MatWithNames { cols, mat, .. } = Mat::from_parquet(out_path.to_str().unwrap()).unwrap();
+        for f in [&expr_path, &q_path, &out_path] {
+            std::fs::remove_file(f).ok();
+        }
+        assert_eq!(cols.len(), 2, "two cell types");
+        let a = cols.iter().position(|c| &**c == "A").unwrap();
+        let b = cols.iter().position(|c| &**c == "B").unwrap();
+        assert!((mat[(0, a)] - 3.0).abs() < 1e-5, "gene0 A = mean(2,4) = 3");
+        assert!((mat[(0, b)] - 10.0).abs() < 1e-5, "gene0 B = 10");
+        assert!((mat[(1, a)] - 1.0).abs() < 1e-5, "gene1 A = 1");
+    }
+}

--- a/senna/src/postprocess/plot/strand/place.rs
+++ b/senna/src/postprocess/plot/strand/place.rs
@@ -1,0 +1,354 @@
+//! Gene placement + per-strand binning for `senna plot-strand`.
+//!
+//! Resolves each activity-matrix gene to a (chromosome, bin, strand) via
+//! a GTF, then accumulates per-group activity into Watson(forward) and
+//! Crick(reverse) bin sums — the signal the renderer mirrors.
+
+use super::PlotStrandArgs;
+use crate::embed_common::Mat;
+use auxiliary_data::feature_names::FeatureNameKind;
+use genomic_data::coordinates::{chr_stripped, load_gene_loci_map, GeneLoc};
+use genomic_data::sam::Strand;
+use rustc_hash::FxHashMap;
+
+////////////////////////////////////////////////////////////////////////
+// Gene placement (coordinate + strand + bin geometry)
+////////////////////////////////////////////////////////////////////////
+
+/// Per-gene placement onto the (chromosome, bin) grid.
+pub(super) struct Placement {
+    pub(super) gene_idx: usize,
+    pub(super) chr_idx: usize,
+    pub(super) bin: usize,
+    pub(super) forward: bool,
+    pub(super) tss: i64,
+    /// HGNC symbol from the matched GTF `gene_name` (falls back to the
+    /// GENCODE clone name / Ensembl id when no symbol is annotated).
+    /// Used for labels so we show the canonical symbol, not the raw
+    /// `ENSG…_SYMBOL` row name.
+    pub(super) symbol: Box<str>,
+}
+
+/// One chromosome's binning geometry.
+pub(super) struct ChrGeom {
+    pub(super) name: Box<str>,
+    pub(super) min_pos: i64,
+    pub(super) span: i64,
+    pub(super) n_bins: usize,
+}
+
+pub(super) struct Placements {
+    pub(super) chromosomes: Vec<ChrGeom>,
+    pub(super) placed: Vec<Placement>,
+    /// Max chromosome span (bp) — drives proportional widths.
+    pub(super) max_span: i64,
+}
+
+/// A gene matched to the GTF: activity-matrix index + resolved location,
+/// before chromosome geometry (and thus bins) is known.
+struct Hit {
+    gene_idx: usize,
+    chr: Box<str>,
+    tss: i64,
+    forward: bool,
+    symbol: Box<str>,
+}
+
+pub(super) fn place_genes(
+    gene_names: &[Box<str>],
+    gtf: &str,
+    args: &PlotStrandArgs,
+) -> anyhow::Result<Placements> {
+    // GTF symbol -> (gtf_symbol, chr, tss, strand), canonicalized for
+    // alias-tolerant matching against the activity row names (e.g.
+    // ENSG…_TGFB1 → TGFB1). The original GTF `gene_name` is kept so labels
+    // can show the canonical HGNC symbol rather than the raw row name.
+    let raw_map = load_gene_loci_map(gtf)?;
+    let kind = FeatureNameKind::Gene { delim: '_' };
+    let mut canon_map: FxHashMap<Box<str>, (Box<str>, GeneLoc)> = FxHashMap::default();
+    for (sym, loc) in raw_map {
+        canon_map
+            .entry(kind.canonicalize(&sym))
+            .or_insert((sym, loc));
+    }
+
+    // Optional chromosome whitelist (strip "chr").
+    let allow: Option<Vec<Box<str>>> = args.chromosomes.as_ref().map(|v| {
+        v.iter()
+            .map(|c| chr_stripped(c).to_string().into_boxed_str())
+            .collect()
+    });
+    let allowed = |chr: &str| -> bool {
+        allow
+            .as_ref()
+            .map(|a| a.iter().any(|c| c.as_ref() == chr))
+            .unwrap_or(true)
+    };
+
+    // A matched gene: activity-matrix index + its resolved location.
+    let mut hits: Vec<Hit> = Vec::new();
+    for (gi, name) in gene_names.iter().enumerate() {
+        let Some((sym, loc)) = canon_map.get(&kind.canonicalize(name)) else {
+            continue;
+        };
+        let chr = chr_stripped(&loc.chr);
+        if !allowed(chr) {
+            continue;
+        }
+        hits.push(Hit {
+            gene_idx: gi,
+            chr: chr.to_string().into_boxed_str(),
+            tss: loc.tss,
+            forward: matches!(loc.strand, Strand::Forward),
+            symbol: sym.clone(),
+        });
+    }
+
+    // Per-chromosome min/max positions → spans.
+    let mut span_by_chr: FxHashMap<Box<str>, (i64, i64)> = FxHashMap::default();
+    for h in &hits {
+        let e = span_by_chr.entry(h.chr.clone()).or_insert((h.tss, h.tss));
+        e.0 = e.0.min(h.tss);
+        e.1 = e.1.max(h.tss);
+    }
+
+    // Karyotype ordering: 1..22, X, Y, M, then anything else lexically.
+    let mut chr_list: Vec<Box<str>> = span_by_chr.keys().cloned().collect();
+    chr_list.sort_by_key(|c| chr_sort_key(c));
+
+    let max_span = span_by_chr
+        .values()
+        .map(|(lo, hi)| (hi - lo).max(1))
+        .max()
+        .unwrap_or(1);
+    let bin_bp = (max_span as f64 / args.bins.max(1) as f64).max(1.0);
+
+    let mut chr_idx: FxHashMap<Box<str>, usize> = FxHashMap::default();
+    let mut chromosomes: Vec<ChrGeom> = Vec::with_capacity(chr_list.len());
+    for (ci, chr) in chr_list.iter().enumerate() {
+        let (lo, hi) = span_by_chr[chr];
+        let span = (hi - lo).max(1);
+        let n_bins = ((span as f64 / bin_bp).ceil() as usize).max(1);
+        chr_idx.insert(chr.clone(), ci);
+        chromosomes.push(ChrGeom {
+            name: chr.clone(),
+            min_pos: lo,
+            span,
+            n_bins,
+        });
+    }
+
+    let placed: Vec<Placement> = hits
+        .into_iter()
+        .map(|h| {
+            let ci = chr_idx[&h.chr];
+            let g = &chromosomes[ci];
+            let bin = (((h.tss - g.min_pos) as f64 / bin_bp).floor() as usize).min(g.n_bins - 1);
+            Placement {
+                gene_idx: h.gene_idx,
+                chr_idx: ci,
+                bin,
+                forward: h.forward,
+                tss: h.tss,
+                symbol: h.symbol,
+            }
+        })
+        .collect();
+
+    Ok(Placements {
+        chromosomes,
+        placed,
+        max_span,
+    })
+}
+
+/// Sort key: autosomes by number, then X, Y, M/MT, then other.
+fn chr_sort_key(chr: &str) -> (u8, u32, Box<str>) {
+    if let Ok(n) = chr.parse::<u32>() {
+        (0, n, chr.into())
+    } else {
+        match chr.to_ascii_uppercase().as_str() {
+            "X" => (1, 0, chr.into()),
+            "Y" => (1, 1, chr.into()),
+            "M" | "MT" => (1, 2, chr.into()),
+            _ => (2, 0, chr.into()),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Binning
+////////////////////////////////////////////////////////////////////////
+
+/// Per-chromosome Watson(up)/Crick(down) bin sums for one group.
+pub(super) struct BinGrid {
+    pub(super) watson: Vec<Vec<f32>>,
+    pub(super) crick: Vec<Vec<f32>>,
+}
+
+impl BinGrid {
+    fn empty(p: &Placements) -> BinGrid {
+        BinGrid {
+            watson: p.chromosomes.iter().map(|c| vec![0.0; c.n_bins]).collect(),
+            crick: p.chromosomes.iter().map(|c| vec![0.0; c.n_bins]).collect(),
+        }
+    }
+
+    pub(super) fn iter_values(&self) -> impl Iterator<Item = f32> + '_ {
+        self.watson
+            .iter()
+            .chain(self.crick.iter())
+            .flat_map(|v| v.iter().copied())
+    }
+
+    /// The bin vector for `pl`'s chromosome on its own strand.
+    fn strand(&self, pl: &Placement) -> &[f32] {
+        let s = if pl.forward {
+            &self.watson
+        } else {
+            &self.crick
+        };
+        &s[pl.chr_idx]
+    }
+
+    fn strand_mut(&mut self, pl: &Placement) -> &mut Vec<f32> {
+        let s = if pl.forward {
+            &mut self.watson
+        } else {
+            &mut self.crick
+        };
+        &mut s[pl.chr_idx]
+    }
+
+    /// Accumulate `other` into `self` bin-for-bin (same geometry).
+    fn add_assign(&mut self, other: &BinGrid) {
+        for (a, b) in self.watson.iter_mut().zip(&other.watson) {
+            a.iter_mut().zip(b).for_each(|(x, y)| *x += y);
+        }
+        for (a, b) in self.crick.iter_mut().zip(&other.crick) {
+            a.iter_mut().zip(b).for_each(|(x, y)| *x += y);
+        }
+    }
+}
+
+pub(super) fn bin_group(mat: &Mat, col: usize, p: &Placements) -> BinGrid {
+    let mut grid = BinGrid::empty(p);
+    for pl in &p.placed {
+        let v = mat[(pl.gene_idx, col)].max(0.0);
+        if v > 0.0 {
+            grid.strand_mut(pl)[pl.bin] += v;
+        }
+    }
+    grid
+}
+
+/// Consensus = activity summed across all cell types. Equal to the
+/// bin-wise sum of the per-group grids (binning is linear), so we fold
+/// the already-computed grids rather than re-scanning the matrix.
+pub(super) fn sum_grids(grids: &[BinGrid], p: &Placements) -> BinGrid {
+    let mut acc = BinGrid::empty(p);
+    for g in grids {
+        acc.add_assign(g);
+    }
+    acc
+}
+
+/// 99th-percentile of positive values — a spike-robust scale so one
+/// outlier bin doesn't flatten every panel. Quickselect (O(n)) rather
+/// than a full sort.
+pub(super) fn robust_max(values: impl Iterator<Item = f32>) -> f32 {
+    let mut v: Vec<f32> = values.filter(|x| *x > 0.0).collect();
+    if v.is_empty() {
+        return 0.0;
+    }
+    let idx = (((v.len() - 1) as f32) * 0.99).round() as usize;
+    *v.select_nth_unstable_by(idx, |a, b| a.partial_cmp(b).unwrap())
+        .1
+}
+
+/// Height of the bin a placement falls into, on its own strand.
+pub(super) fn bin_height(grid: &BinGrid, pl: &Placement) -> f32 {
+    grid.strand(pl).get(pl.bin).copied().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("strandplace_{}_{}", std::process::id(), name))
+    }
+
+    /// Minimal args for placement tests (bins=10, defaults otherwise).
+    fn args_with(gtf: &str) -> PlotStrandArgs {
+        PlotStrandArgs {
+            from: None,
+            gtf: gtf.into(),
+            activity: None,
+            out: None,
+            chromosomes: None,
+            bins: 10,
+            top_genes: 0,
+            scale: crate::postprocess::plot::strand::HeightScale::Sqrt,
+            consensus: true,
+            watson_color: "#E69F00".into(),
+            crick_color: "#0F8B8D".into(),
+            consensus_color: "#7A7A7A".into(),
+            width: 4.0,
+            track_height: 0.3,
+            dpi: 96,
+            svg: false,
+            png: false,
+            no_pdf: true,
+        }
+    }
+
+    /// chr1: G0 (+,100), G1 (-,300), G2 (+,500); chr2: G3 (+,100), G4 (-,400).
+    fn write_gtf() -> std::path::PathBuf {
+        let gtf = "\
+chr1\tT\tgene\t100\t150\t.\t+\t.\tgene_id \"E0\"; gene_name \"G0\"
+chr1\tT\tgene\t300\t350\t.\t-\t.\tgene_id \"E1\"; gene_name \"G1\"
+chr1\tT\tgene\t500\t550\t.\t+\t.\tgene_id \"E2\"; gene_name \"G2\"
+chr2\tT\tgene\t100\t150\t.\t+\t.\tgene_id \"E3\"; gene_name \"G3\"
+chr2\tT\tgene\t400\t450\t.\t-\t.\tgene_id \"E4\"; gene_name \"G4\"
+";
+        let p = tmp("genes.gtf");
+        std::fs::write(&p, gtf).unwrap();
+        p
+    }
+
+    #[test]
+    fn placement_and_binning_split_by_strand() {
+        let gtf = write_gtf();
+        // Activity gene names use the ENSG_SYMBOL alias form to exercise
+        // the canonicalizer (G0 → "ENSGX_G0").
+        let genes: Vec<Box<str>> = (0..5).map(|i| format!("ENSGX_G{i}").into()).collect();
+        // Single group; only forward genes G0,G2 (chr1) and G3 (chr2) get
+        // weight, reverse G1,G4 get zero.
+        let mut mat = Mat::zeros(5, 1);
+        mat[(0, 0)] = 5.0; // G0 + chr1
+        mat[(2, 0)] = 3.0; // G2 + chr1
+        mat[(3, 0)] = 7.0; // G3 + chr2
+
+        let args = args_with(gtf.to_str().unwrap());
+        let p = place_genes(&genes, gtf.to_str().unwrap(), &args).unwrap();
+        std::fs::remove_file(&gtf).ok();
+
+        assert_eq!(p.chromosomes.len(), 2, "two chromosomes");
+        assert_eq!(p.placed.len(), 5, "all five genes placed");
+
+        let grid = bin_group(&mat, 0, &p);
+        let chr1 = p.chromosomes.iter().position(|c| &*c.name == "1").unwrap();
+        let chr2 = p.chromosomes.iter().position(|c| &*c.name == "2").unwrap();
+
+        let w1: f32 = grid.watson[chr1].iter().sum();
+        let c1: f32 = grid.crick[chr1].iter().sum();
+        let w2: f32 = grid.watson[chr2].iter().sum();
+        let c2: f32 = grid.crick[chr2].iter().sum();
+
+        assert!((w1 - 8.0).abs() < 1e-5, "chr1 Watson = G0+G2 = 8");
+        assert_eq!(c1, 0.0, "chr1 Crick = 0 (G1 had no activity)");
+        assert!((w2 - 7.0).abs() < 1e-5, "chr2 Watson = G3 = 7");
+        assert_eq!(c2, 0.0, "chr2 Crick = 0 (G4 had no activity)");
+    }
+}

--- a/senna/src/postprocess/plot/strand/render.rs
+++ b/senna/src/postprocess/plot/strand/render.rs
@@ -1,0 +1,267 @@
+//! SVG assembly for `senna plot-strand`.
+//!
+//! One figure per cell type: chromosomes stacked vertically, each a
+//! mirrored Watson(up)/Crick(down) filled step-area around a shared
+//! axis. We hand-build the SVG string and render it to PDF/PNG through
+//! the shared `plot_utils` resvg/svg2pdf path.
+
+use super::place::{bin_height, BinGrid, ChrGeom, Placement, Placements};
+use super::{HeightScale, PlotStrandArgs, Strands};
+use crate::postprocess::plot::sanitize_filename as sanitize;
+use plot_utils::svg_emit::escape_xml;
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// Build + render one cell-type (or consensus) figure. Returns the
+/// number of files written.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn render_one(
+    name: &str,
+    grid: &BinGrid,
+    strands: Strands,
+    robust_max: f32,
+    p: &Placements,
+    out_dir: &str,
+    args: &PlotStrandArgs,
+) -> anyhow::Result<usize> {
+    let dpi = args.dpi as f32;
+    let w = (args.width * dpi).round();
+    let track_h = (args.track_height * dpi).round();
+    let gap = (track_h * 0.45).round();
+    let left = (1.0 * dpi).round();
+    let right = (0.25 * dpi).round();
+    let top = (0.55 * dpi).round();
+    let bottom = (0.3 * dpi).round();
+    let plot_w = (w - left - right).max(1.0);
+    let n_chr = p.chromosomes.len() as f32;
+    let h = top + bottom + n_chr * (track_h + gap);
+
+    let title_fs = 0.17 * dpi;
+    let chr_fs = 0.10 * dpi;
+    let gene_fs = 0.075 * dpi;
+    let half = (track_h / 2.0 - 1.0).max(1.0);
+
+    let mut svg = String::with_capacity(64 * 1024);
+    svg.push_str(&format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{w:.0}\" height=\"{h:.0}\" \
+         viewBox=\"0 0 {w:.0} {h:.0}\">",
+    ));
+    svg.push_str(&format!(
+        "<rect x=\"0\" y=\"0\" width=\"{w:.0}\" height=\"{h:.0}\" fill=\"white\"/>"
+    ));
+
+    // Title.
+    let title = if name == "_consensus" {
+        "Consensus  (Watson \u{2191} / Crick \u{2193})".to_string()
+    } else {
+        format!("{name}  (Watson \u{2191} / Crick \u{2193})")
+    };
+    svg.push_str(&format!(
+        "<text x=\"{:.1}\" y=\"{:.1}\" font-family=\"sans-serif\" font-size=\"{:.1}\" \
+         font-weight=\"bold\" fill=\"#222\">{}</text>",
+        left,
+        top * 0.6,
+        title_fs,
+        escape_xml(&title)
+    ));
+
+    for (ci, chr) in p.chromosomes.iter().enumerate() {
+        let y_mid = top + ci as f32 * (track_h + gap) + track_h / 2.0;
+        let chr_w = plot_w * (chr.span as f32 / p.max_span as f32);
+
+        // Chromosome label.
+        svg.push_str(&format!(
+            "<text x=\"{:.1}\" y=\"{:.1}\" text-anchor=\"end\" font-family=\"sans-serif\" \
+             font-size=\"{:.1}\" fill=\"#333\">chr{}</text>",
+            left - 0.08 * dpi,
+            y_mid + chr_fs * 0.35,
+            chr_fs,
+            escape_xml(&chr.name)
+        ));
+
+        // Watson (up) + Crick (down) filled step areas.
+        let binpx = chr_w / chr.n_bins as f32;
+        let geom = StrandPath {
+            x_left: left,
+            binpx,
+            y_mid,
+            half,
+            robust_max,
+            scale: args.scale,
+        };
+        svg.push_str(&strand_path(&geom, &grid.watson[ci], true, strands.up));
+        svg.push_str(&strand_path(&geom, &grid.crick[ci], false, strands.down));
+
+        // Midline (chromosome axis).
+        svg.push_str(&format!(
+            "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" stroke=\"#888\" \
+             stroke-width=\"{:.2}\"/>",
+            left,
+            y_mid,
+            left + chr_w,
+            y_mid,
+            (0.006 * dpi).max(0.5)
+        ));
+
+        // Optional top-gene labels.
+        if args.top_genes > 0 {
+            svg.push_str(&top_gene_labels(
+                ci, chr, left, binpx, y_mid, half, gene_fs, dpi, grid, p, args,
+            ));
+        }
+    }
+
+    svg.push_str("</svg>");
+
+    // ----- Render -----
+    let base = format!("{out_dir}/{}", sanitize(name));
+    let mut written = 0usize;
+    if args.svg {
+        let pth = format!("{base}.svg");
+        std::fs::write(&pth, svg.as_bytes())?;
+        written += 1;
+    }
+    let png_task = args.png.then(|| format!("{base}.png"));
+    let pdf_task = (!args.no_pdf).then(|| format!("{base}.pdf"));
+    let (png_res, pdf_res) = rayon::join(
+        || match &png_task {
+            Some(pth) => {
+                plot_utils::render_png(&svg, w as u32, h as u32, Path::new(pth)).map(|()| 1usize)
+            }
+            None => Ok(0),
+        },
+        || match &pdf_task {
+            Some(pth) => plot_utils::render_pdf(&svg, Path::new(pth)).map(|()| 1usize),
+            None => Ok(0),
+        },
+    );
+    written += png_res? + pdf_res?;
+    Ok(written)
+}
+
+/// Shared geometry + scaling for one chromosome's mirrored strand pair.
+struct StrandPath {
+    x_left: f32,
+    binpx: f32,
+    y_mid: f32,
+    half: f32,
+    robust_max: f32,
+    scale: HeightScale,
+}
+
+/// Build a filled step-area `<path>` for one strand of one chromosome.
+/// `up = true` draws above the midline (Watson), else mirrored below.
+/// Heights are remapped through `g.scale` (and the same scale is applied
+/// to `robust_max`) so the normalized fraction stays in `[0, 1]`.
+fn strand_path(g: &StrandPath, heights: &[f32], up: bool, color: &str) -> String {
+    if heights.iter().all(|&v| v <= 0.0) {
+        return String::new();
+    }
+    let denom = g.scale.apply(g.robust_max).max(f32::MIN_POSITIVE);
+    let mut d = String::with_capacity(heights.len() * 24);
+    let _ = write!(d, "M {:.2} {:.2} ", g.x_left, g.y_mid);
+    for (b, &v) in heights.iter().enumerate() {
+        let frac = (g.scale.apply(v) / denom).clamp(0.0, 1.0);
+        let hpx = frac * g.half;
+        let x0 = g.x_left + b as f32 * g.binpx;
+        let x1 = x0 + g.binpx;
+        let y = if up { g.y_mid - hpx } else { g.y_mid + hpx };
+        let _ = write!(d, "L {:.2} {:.2} L {:.2} {:.2} ", x0, y, x1, y);
+    }
+    let x_right = g.x_left + heights.len() as f32 * g.binpx;
+    let _ = write!(d, "L {:.2} {:.2} Z", x_right, g.y_mid);
+    format!("<path d=\"{d}\" fill=\"{color}\" fill-opacity=\"0.9\" stroke=\"none\"/>")
+}
+
+/// Tick + name labels for the top-N genes (by activity) on one
+/// chromosome of one group. Forward genes label above, reverse below.
+/// Labels are de-cluttered: once N are placed we stop, and a candidate
+/// too close (in x) to an already-placed label on the same strand is
+/// skipped so names stay legible.
+#[allow(clippy::too_many_arguments)]
+fn top_gene_labels(
+    ci: usize,
+    chr: &ChrGeom,
+    x_left: f32,
+    binpx: f32,
+    y_mid: f32,
+    half: f32,
+    gene_fs: f32,
+    dpi: f32,
+    grid: &BinGrid,
+    p: &Placements,
+    args: &PlotStrandArgs,
+) -> String {
+    // Rank this chromosome's placed genes by the binned height of their
+    // own strand (peak proximity), then label the top-N.
+    let mut on_chr: Vec<&Placement> = p.placed.iter().filter(|pl| pl.chr_idx == ci).collect();
+    on_chr.sort_by(|a, b| {
+        bin_height(grid, b)
+            .partial_cmp(&bin_height(grid, a))
+            .unwrap()
+    });
+    let chr_w = binpx * chr.n_bins as f32;
+    let min_gap = gene_fs * 4.0;
+    let mut placed_up: Vec<f32> = Vec::new();
+    let mut placed_down: Vec<f32> = Vec::new();
+    let mut out = String::new();
+    let mut n = 0usize;
+    for pl in on_chr {
+        if n >= args.top_genes || bin_height(grid, pl) <= 0.0 {
+            break;
+        }
+        let x = x_left + ((pl.tss - chr.min_pos) as f32 / chr.span as f32) * chr_w;
+        let placed = if pl.forward {
+            &mut placed_up
+        } else {
+            &mut placed_down
+        };
+        if placed.iter().any(|&px| (px - x).abs() < min_gap) {
+            continue; // would collide with an already-placed label
+        }
+        placed.push(x);
+        n += 1;
+
+        let (y_tick, y_text) = if pl.forward {
+            (y_mid - half, y_mid - half - 0.02 * dpi)
+        } else {
+            (y_mid + half, y_mid + half + gene_fs)
+        };
+        out.push_str(&format!(
+            "<line x1=\"{x:.1}\" y1=\"{y_mid:.1}\" x2=\"{x:.1}\" y2=\"{y_tick:.1}\" \
+             stroke=\"#444\" stroke-width=\"{:.2}\"/>",
+            (0.004 * dpi).max(0.4)
+        ));
+        out.push_str(&format!(
+            "<text x=\"{x:.1}\" y=\"{y_text:.1}\" text-anchor=\"middle\" \
+             font-family=\"sans-serif\" font-size=\"{gene_fs:.1}\" fill=\"#444\">{}</text>",
+            escape_xml(&pl.symbol)
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geom() -> StrandPath {
+        StrandPath {
+            x_left: 0.0,
+            binpx: 1.0,
+            y_mid: 10.0,
+            half: 5.0,
+            robust_max: 1.0,
+            scale: HeightScale::Linear,
+        }
+    }
+
+    #[test]
+    fn strand_path_empty_when_all_zero() {
+        let zero = strand_path(&geom(), &[0.0, 0.0], true, "#abc");
+        assert!(zero.is_empty());
+        let nonzero = strand_path(&geom(), &[0.0, 0.5], true, "#abc");
+        assert!(nonzero.contains("<path"));
+        assert!(nonzero.contains("#abc"));
+    }
+}

--- a/senna/src/postprocess/plot/topic/mod.rs
+++ b/senna/src/postprocess/plot/topic/mod.rs
@@ -22,6 +22,7 @@
 
 use crate::embed_common::*;
 use crate::run_manifest::{self, RunManifest};
+use auxiliary_data::feature_names::FeatureNameKind;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use plot_utils::palette::{self, Palette, Rgb};
@@ -1032,6 +1033,11 @@ fn render_dict_plot(
     let dict_topic_ids = try_parse_axis_ids(&dict_cols, "T")
         .unwrap_or_else(|| (0..n_topics as i64).collect::<Vec<_>>());
 
+    // Display gene labels as the canonical (HGNC) symbol when the axis is
+    // gene-like: `ENSG00000105329_TGFB1` → `TGFB1`. A no-op for axes that
+    // are already bare symbols or non-gene rows (auto-detected).
+    let name_kind = FeatureNameKind::auto_detect(&gene_names);
+
     // Submatrix (n_genes × n_topics) row-major in selected gene order.
     let mut sub: Vec<f32> = Vec::with_capacity(n_genes * n_topics);
     let mut sub_gene_names: Vec<Box<str>> = Vec::with_capacity(n_genes);
@@ -1039,7 +1045,7 @@ fn render_dict_plot(
         for j in 0..n_topics {
             sub.push(weights_gk[gi * n_topics + j]);
         }
-        sub_gene_names.push(gene_names[gi].clone());
+        sub_gene_names.push(name_kind.canonicalize(&gene_names[gi]));
     }
 
     let dict_dir = format!("{plot_root}/dict");
@@ -1509,11 +1515,4 @@ fn emit_outputs(svg: &str, w: u32, h: u32, base: &str, args: &PlotTopicArgs) -> 
     Ok(())
 }
 
-fn sanitize(s: &str) -> String {
-    s.chars()
-        .map(|c| match c {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '.' => c,
-            _ => '_',
-        })
-        .collect()
-}
+use super::sanitize_filename as sanitize;


### PR DESCRIPTION
Add `senna plot-strand` (alias `ps`): per-cell-type, per-chromosome gene activity split by strand — forward/Watson as an upward filled pileup, reverse/Crick mirrored downward around a shared chromosome axis (Strand-seq style). One figure per cell type (chromosomes stacked) plus an optional consensus, under {out}.strand/.

- Activity defaults to a gene x cell-type matrix derived from `senna annotate` (cluster_expression collapsed via cluster_celltype_q argmax); override with --activity. Gene coords+strand from --gtf.
- New genomic_data::coordinates::{GeneLoc, load_gene_loci_map, load_gene_loci}; load_gene_tss now delegates to it (strand-discarding projection).
- Alias-tolerant gene matching + HGNC-symbol labels via the GTF gene_name (auxiliary_data::feature_names for the activity-row side).
- --scale {linear,sqrt,log}, default sqrt, to compress pileup spikes.
- SVG hand-built and rendered through plot_utils render_pdf/png; no new plotting primitives.

Also: plot-topic dictionary now shows canonical (HGNC) gene symbols instead of raw ENSG..._SYMBOL row names; shared sanitize_filename hoisted into plot::.