### PR TITLE
faba gem: simpler inputs (drop sidecar, auto-strip, auto-regions) + progress bar & log cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "faba"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -2599,7 +2599,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graph-embedding-util"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "auxiliary-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "faba"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "approx",

--- a/faba/Cargo.toml
+++ b/faba/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 
-version = "0.5.1"
+version = "0.5.2"
 
 [lib]
 # The library surface exists so `gem`'s integration tests (tests/) can reach

--- a/faba/Cargo.toml
+++ b/faba/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 
-version = "0.5.0"
+version = "0.5.1"
 
 [lib]
 # The library surface exists so `gem`'s integration tests (tests/) can reach

--- a/faba/src/gem/args.rs
+++ b/faba/src/gem/args.rs
@@ -52,35 +52,6 @@ pub struct GemArgs {
     )]
     pub apa: Option<Vec<Box<str>>>,
 
-    ////////////////////////////////////////
-    // Component annotations (region binning)
-    //
-    // The `*_components.parquet` sidecars emitted by `faba m6a` / `faba
-    // atoi` carry each GMM component's `mu` and `gene_length`. They feed
-    // the transcript-position region bin (`u = mu/gene_length`) used by
-    // the model's γ_{m,r,:} offset. The modality is inferred from the
-    // flag, matching the row's `{gene}/{modality}/{component}` name.
-    // Optional: a missing sidecar collapses that modality's γ to a
-    // single region.
-    ////////////////////////////////////////
-    #[arg(
-        long,
-        help = "`m6a_components.parquet` for the `--dartseq` (m6A) modality"
-    )]
-    pub dartseq_components: Option<Box<str>>,
-
-    #[arg(
-        long,
-        help = "`atoi_components.parquet` for the `--atoi` (A2I) modality"
-    )]
-    pub atoi_components: Option<Box<str>>,
-
-    #[arg(
-        long,
-        help = "Component annotation parquet for the `--apa` (pA) modality"
-    )]
-    pub apa_components: Option<Box<str>>,
-
     #[arg(
         short = 'b',
         long,
@@ -117,14 +88,14 @@ pub struct GemArgs {
 
     #[arg(
         long = "num-regions",
-        default_value_t = 5,
-        help = "Number of transcript-position region bins R for the additive γ_{m,r,:} offset",
-        long_help = "Number of transcript-position region bins R for the additive\n\
-                     γ_{m,r,:} offset. Components are binned by normalized 5'-relative\n\
-                     position `u = mu/gene_length`. R=1 collapses γ to one per-modality\n\
-                     offset (no positional resolution)."
+        help = "γ slot count R per modality (default: auto = max(component_idx) + 1 across satellites)",
+        long_help = "Number of γ_{m, r, :} slots R per satellite modality. With the\n\
+                     sidecar input gone, R indexes a per-component slot within\n\
+                     (gene, modality) — components beyond R-1 clamp to slot R-1.\n\
+                     Default: auto-inferred from the satellite row names as\n\
+                     `max(component_idx) + 1`, so every component gets its own slot."
     )]
-    pub n_regions: usize,
+    pub n_regions: Option<usize>,
 
     ////////////////////////////////////////
     // Pseudobulk collapse

--- a/faba/src/gem/cell_solve.rs
+++ b/faba/src/gem/cell_solve.rs
@@ -54,12 +54,21 @@ pub fn solve_cell_embeddings(
     let (ids, per_cell) = collect_identities(pools, n_cells);
     // 2. Frozen feature embeddings (one batched device pass → CPU).
     let (frozen_e, frozen_b) = embed_identities(model, &ids, h)?;
-    // 3. Parallel per-cell Poisson-MAP projection (shared solver).
+    // 3. Parallel per-cell Poisson-MAP projection (shared solver), with a
+    //    per-cell progress bar over the rayon fan-out.
     let lambda = args.phase2_ridge.max(0.0) as f64;
+    let pb = graph_embedding_util::progress::new_progress_bar(n_cells as u64);
+    pb.set_message("cell projection");
     // gem scores with a per-cell bias (b_cell), so keep the fitted b_c.
     let (e_flat, b_flat) = graph_embedding_util::cell_projection::project_cells(
-        &frozen_e, &frozen_b, &per_cell, h, lambda,
+        &frozen_e,
+        &frozen_b,
+        &per_cell,
+        h,
+        lambda,
+        Some(&pb),
     );
+    pb.finish_and_clear();
     // 4. L2-normalise (depth → b_cell) + write back into the model vars.
     finalize_e_cell(model, e_flat, b_flat)
 }
@@ -294,6 +303,11 @@ pub fn solve_cell_embeddings_streaming(
     let mut e_flat = vec![0f32; n_cells * h];
     let mut b_flat = vec![0f32; n_cells];
 
+    // One bar across every chunk (sized to the full cell count), incremented
+    // per solved cell inside `project_cells`.
+    let pb = graph_embedding_util::progress::new_progress_bar(n_cells as u64);
+    pb.set_message("cell projection");
+
     for chunk_start in (0..n_cells).step_by(chunk_cells) {
         let chunk_end = (chunk_start + chunk_cells).min(n_cells);
         let nlocal = chunk_end - chunk_start;
@@ -362,11 +376,17 @@ pub fn solve_cell_embeddings_streaming(
         }
 
         let (e_chunk, b_chunk) = graph_embedding_util::cell_projection::project_cells(
-            &frozen_e, &frozen_b, &per_cell, h, lambda,
+            &frozen_e,
+            &frozen_b,
+            &per_cell,
+            h,
+            lambda,
+            Some(&pb),
         );
         e_flat[chunk_start * h..chunk_end * h].copy_from_slice(&e_chunk);
         b_flat[chunk_start..chunk_end].copy_from_slice(&b_chunk);
     }
+    pb.finish_and_clear();
 
     finalize_e_cell(model, e_flat, b_flat)
 }

--- a/faba/src/gem/feature_table.rs
+++ b/faba/src/gem/feature_table.rs
@@ -266,7 +266,7 @@ impl TableBuilder {
                 RowStratum::ModifierComp => {
                     let modality_id = self.modality_id(&key.modality);
                     let component = parse_component_idx(&key.detail);
-                    let region = regions.lookup(&key.gene, &key.modality, component.unwrap_or(0));
+                    let region = regions.lookup(component.unwrap_or(0));
                     self.strata.push(Some(RowStratum::ModifierComp));
                     self.row_gene.push(Some(gene_id));
                     self.row_modality.push(Some(modality_id));
@@ -470,7 +470,7 @@ impl FeatureTable {
                 }
                 RowStratum::ModifierComp => {
                     let comp = parse_component_idx(&key.detail);
-                    let reg = regions.lookup(&key.gene, &key.modality, comp.unwrap_or(0));
+                    let reg = regions.lookup(comp.unwrap_or(0));
                     stratum.push(Some(RowStratum::ModifierComp));
                     gene.push(Some(gid));
                     modality.push(modality_to_id.get(&*key.modality).copied());

--- a/faba/src/gem/region.rs
+++ b/faba/src/gem/region.rs
@@ -1,401 +1,44 @@
-//! Transcript-position region binning for modifier components.
+//! Region map: per-component slot index used to key the additive offset
+//! `γ_{m, r, :}` in the gem embedding model.
 //!
-//! Per locked decision #1, a satellite feature row `{gene}/{m}/{k}` is
-//! assigned a **region** from the normalized 5'-relative position of its
-//! GMM component: `u = μ / gene_length ∈ [0, 1)`, binned into `R` fixed
-//! fractional bins. The region keys the additive offset `γ_{m,r,:}` in
-//! the model's log-deviation gate, so two same-gene/same-modality
-//! components sitting in different regions get distinguishable
-//! embeddings (multi-site resolution).
-//!
-//! True CDS/UTR regions are a later refinement; APA can use a UTR-local
-//! `α` once that lands.
-//!
-//! The region lookup is keyed by `(gene_name, modality_name,
-//! component_idx)` — the same three coordinates that name a modifier
-//! row. `μ` and `gene_length` come from the per-modality
-//! `*_components.parquet` annotation emitted by
-//! `editing::mixture_pipeline` (`MixtureComponentAnnotation`).
+//! A modifier feature row is named `{gene}/{m}/{k}`, where `k` is the
+//! component index within that gene+modality. After dropping the
+//! transcript-position sidecar input, `region` is no longer a
+//! transcript-position bin shared across genes; it is simply the
+//! per-component slot, clamped to `n_regions − 1`. That keeps same-gene
+//! components structurally distinguishable in the embedding (each picks up
+//! its own `γ` offset) without needing any external annotation.
 
-use anyhow::{Context, Result};
-use rustc_hash::FxHashMap;
-
-/// Read a `*_components.parquet` sidecar and tag every record with the
-/// given modality name. The modality label must match the one in the
-/// modifier row names (`m6A`, `A2I`, `pA`) so the `(gene, modality,
-/// component)` lookup lines up with `FeatureTable`'s parsed rows.
-///
-/// Two sidecar schemas are accepted — they share the **same** matrix row
-/// convention `{gene}/{modality}/{k}`, so the component index `k` always
-/// lines up; only the sidecar layout differs:
-///
-/// * **GMM** (`faba m6a` / `atoi`, via `editing::mixture_pipeline`):
-///   `gene_name`, `component_idx` (any integer type), `mu`, `gene_length`.
-///   Position `u = μ / gene_length`.
-/// * **APA** (`faba apa`, via `apa::pipeline`): `site_id`
-///   (`{gene}/pA/{k}`), `expected_tail_length`, `utr_length`. The gene and
-///   component `k` are parsed from `site_id` (matching the matrix row),
-///   and the 5'→3' UTR position is recovered as
-///   `u = 1 − expected_tail_length / utr_length` — encoded here as
-///   `mu = utr_length − expected_tail_length`, `gene_length = utr_length`
-///   so the shared `u = μ / gene_length` binning needs no special case.
-pub fn load_component_annotations(path: &str, modality: &str) -> Result<Vec<ComponentAnnotation>> {
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-
-    let file = std::fs::File::open(path).with_context(|| format!("opening {path}"))?;
-    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
-        .with_context(|| format!("parquet reader for {path}"))?
-        .build()?;
-
-    let modality: Box<str> = modality.into();
-    let mut out = Vec::new();
-    for batch in reader {
-        let batch = batch?;
-        // Sniff the schema by a distinguishing column, then dispatch.
-        if batch.column_by_name("component_idx").is_some() {
-            load_gmm_batch(&batch, &modality, path, &mut out)?;
-        } else if batch.column_by_name("site_id").is_some() {
-            load_apa_batch(&batch, &modality, path, &mut out)?;
-        } else {
-            anyhow::bail!(
-                "{path}: unrecognized component sidecar schema — \
-                 need 'component_idx' (GMM) or 'site_id' (apa)"
-            );
-        }
-    }
-    Ok(out)
-}
-
-/// GMM sidecar batch (m6A / A2I): `gene_name` + `component_idx` + `mu` +
-/// `gene_length`, position `u = μ / gene_length`.
-fn load_gmm_batch(
-    batch: &arrow::record_batch::RecordBatch,
-    modality: &str,
-    path: &str,
-    out: &mut Vec<ComponentAnnotation>,
-) -> Result<()> {
-    use arrow::array::StringArray;
-    let gene_col = batch
-        .column_by_name("gene_name")
-        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
-        .ok_or_else(|| anyhow::anyhow!("{path}: missing/!string 'gene_name'"))?;
-    let comp = read_u32_col(batch, "component_idx", path)?;
-    let mu_col = f32_col(batch, "mu", path)?;
-    let len_col = f32_col(batch, "gene_length", path)?;
-    for (i, &component_idx) in comp.iter().enumerate() {
-        out.push(ComponentAnnotation {
-            gene_name: gene_col.value(i).into(),
-            modality: modality.into(),
-            component_idx,
-            mu: mu_col.value(i),
-            gene_length: len_col.value(i),
-        });
-    }
-    Ok(())
-}
-
-/// APA sidecar batch: `site_id` (`{gene}/pA/{k}`), `expected_tail_length`,
-/// `utr_length`. Gene and component `k` are parsed from `site_id`
-/// (matching the matrix row), and the 5'→3' UTR position is recovered as
-/// `u = 1 − etl/utr` — encoded as `mu = utr − etl`, `gene_length = utr` so
-/// the shared `u = μ / gene_length` binning needs no special case.
-fn load_apa_batch(
-    batch: &arrow::record_batch::RecordBatch,
-    modality: &str,
-    path: &str,
-    out: &mut Vec<ComponentAnnotation>,
-) -> Result<()> {
-    use arrow::array::StringArray;
-    let site_col = batch
-        .column_by_name("site_id")
-        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
-        .ok_or_else(|| anyhow::anyhow!("{path}: missing/!string 'site_id'"))?;
-    let etl_col = f32_col(batch, "expected_tail_length", path)?;
-    let utr = read_u32_col(batch, "utr_length", path)?;
-    for (i, &utr_raw) in utr.iter().enumerate() {
-        let Some((gene, comp)) = parse_site_id(site_col.value(i)) else {
-            continue; // unparseable site_id → no matching matrix row
-        };
-        let utr_len = utr_raw as f32;
-        out.push(ComponentAnnotation {
-            gene_name: gene,
-            modality: modality.into(),
-            component_idx: comp,
-            mu: utr_len - etl_col.value(i),
-            gene_length: utr_len,
-        });
-    }
-    Ok(())
-}
-
-/// Downcast a named column to `Float32Array` (cheap Arc clone of the
-/// backing buffer).
-fn f32_col(
-    batch: &arrow::record_batch::RecordBatch,
-    name: &str,
-    path: &str,
-) -> Result<arrow::array::Float32Array> {
-    batch
-        .column_by_name(name)
-        .and_then(|c| c.as_any().downcast_ref::<arrow::array::Float32Array>())
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("{path}: missing/!f32 '{name}'"))
-}
-
-/// Read an integer arrow column as `Vec<u32>`, accepting any of the common
-/// integer widths (`u64`/`u32`/`i64`/`i32`). Relaxing the type lets the
-/// GMM sidecar's `u64 component_idx` and the apa sidecar's `u32
-/// utr_length` flow through one path. Negative values clamp to 0.
-fn read_u32_col(
-    batch: &arrow::record_batch::RecordBatch,
-    name: &str,
-    path: &str,
-) -> Result<Vec<u32>> {
-    use arrow::array::{Int32Array, Int64Array, UInt32Array, UInt64Array};
-    let col = batch
-        .column_by_name(name)
-        .ok_or_else(|| anyhow::anyhow!("{path}: missing integer column '{name}'"))?;
-    let any = col.as_any();
-    if let Some(a) = any.downcast_ref::<UInt64Array>() {
-        Ok((0..a.len()).map(|i| a.value(i) as u32).collect())
-    } else if let Some(a) = any.downcast_ref::<UInt32Array>() {
-        Ok((0..a.len()).map(|i| a.value(i)).collect())
-    } else if let Some(a) = any.downcast_ref::<Int64Array>() {
-        Ok((0..a.len()).map(|i| a.value(i).max(0) as u32).collect())
-    } else if let Some(a) = any.downcast_ref::<Int32Array>() {
-        Ok((0..a.len()).map(|i| a.value(i).max(0) as u32).collect())
-    } else {
-        anyhow::bail!("{path}: column '{name}' is not an integer type")
-    }
-}
-
-/// Parse an apa `site_id` (`{gene}/pA/{k}`) into `(gene, component_idx)` by
-/// reusing the matrix row-name grammar (`feature_table::parse_feature_name`
-/// then `parse_component_idx`), so the region key can never drift from how
-/// the matrix row is parsed. Returns `None` if the shape or the integer `k`
-/// doesn't parse.
-fn parse_site_id(site_id: &str) -> Option<(Box<str>, u32)> {
-    let key = super::feature_table::parse_feature_name(site_id)?;
-    let k = super::feature_table::parse_component_idx(&key.detail)?;
-    Some((key.gene, k))
-}
-
-/// One annotation record, modality-tagged. Mirrors the columns of a
-/// `*_components.parquet` (`gene_name`, `component_idx`, `mu`,
-/// `gene_length`) plus the modality the file belongs to.
-#[derive(Clone, Debug)]
-pub struct ComponentAnnotation {
-    pub gene_name: Box<str>,
-    pub modality: Box<str>,
-    pub component_idx: u32,
-    pub mu: f32,
-    pub gene_length: f32,
-}
-
-/// `(gene_name, modality_name, component_idx) → region_id`. Built once
-/// from the annotation records, consulted by `FeatureTable::build` while
-/// classifying modifier rows.
+/// Per-modality slot count and lookup. Owns only `n_regions`; the slot
+/// assignment is derived directly from the component index at lookup time.
 pub struct RegionMap {
-    /// Number of fractional bins R. `region_id ∈ 0..n_regions`.
+    /// Number of γ slots R. `region_id ∈ 0..R`.
     pub n_regions: usize,
-    by_key: FxHashMap<(Box<str>, Box<str>, u32), u32>,
 }
 
 impl RegionMap {
-    /// Build the region lookup from annotation records. A record with a
-    /// non-finite or non-positive `gene_length`, or a non-finite `mu`,
-    /// is skipped (the row falls back to region 0 at lookup time). The
-    /// normalized position `u = μ / gene_length` is clamped to
-    /// `[0, 1)` before binning so off-end components still land in a
-    /// valid bin rather than overflowing `R`.
-    pub fn from_records(records: &[ComponentAnnotation], n_regions: usize) -> Self {
-        let n_regions = n_regions.max(1);
-        let mut by_key: FxHashMap<(Box<str>, Box<str>, u32), u32> = FxHashMap::default();
-        for rec in records {
-            let region = match region_for(rec.mu, rec.gene_length, n_regions) {
-                Some(r) => r,
-                None => continue,
-            };
-            by_key.insert(
-                (
-                    rec.gene_name.clone(),
-                    rec.modality.clone(),
-                    rec.component_idx,
-                ),
-                region,
-            );
-        }
-        Self { n_regions, by_key }
-    }
-
-    /// Empty map (no annotations): every lookup falls back to region 0.
-    /// Equivalent to `from_records(&[], n_regions)`; the production path
-    /// uses that form, so this is a test-only convenience.
-    #[cfg(test)]
-    pub fn empty(n_regions: usize) -> Self {
+    /// Build a map with `R = max(n_regions, 1)`. Zero is silently bumped to
+    /// one so the model always has a valid γ axis.
+    pub fn new(n_regions: usize) -> Self {
         Self {
             n_regions: n_regions.max(1),
-            by_key: FxHashMap::default(),
         }
     }
 
-    /// Region for `(gene, modality, component)`. Falls back to region 0
-    /// when the triple was not annotated (count-comp details, missing
-    /// files, or components dropped from the sidecar).
-    pub fn lookup(&self, gene: &str, modality: &str, component: u32) -> u32 {
-        self.by_key
-            .get(&(gene.into(), modality.into(), component))
-            .copied()
-            .unwrap_or(0)
+    /// Slot for a modifier `component`: per-component within its
+    /// (gene, modality), clamped to `n_regions − 1`. Same component index →
+    /// same slot regardless of gene/modality.
+    pub fn lookup(&self, component: u32) -> u32 {
+        component.min(self.n_regions as u32 - 1)
     }
-}
 
-/// Bin `u = μ / gene_length` into one of `n_regions` fixed fractional
-/// bins. Returns `None` for un-binnable inputs (non-finite μ, non-finite
-/// or non-positive gene_length).
-fn region_for(mu: f32, gene_length: f32, n_regions: usize) -> Option<u32> {
-    if !mu.is_finite() || !gene_length.is_finite() || gene_length <= 0.0 {
-        return None;
+    /// Test-only constructor mirroring the old API. Same semantics as
+    /// `new(n_regions)`.
+    #[cfg(test)]
+    pub fn empty(n_regions: usize) -> Self {
+        Self::new(n_regions)
     }
-    let u = (mu / gene_length).clamp(0.0, 1.0 - f32::EPSILON);
-    let r = (u * n_regions as f32).floor() as i64;
-    let r = r.clamp(0, n_regions as i64 - 1);
-    Some(r as u32)
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bins_normalized_position() {
-        // R=5 fractional bins over u ∈ [0,1).
-        assert_eq!(region_for(0.0, 100.0, 5), Some(0)); // u=0
-        assert_eq!(region_for(10.0, 100.0, 5), Some(0)); // u=0.1 → bin 0
-        assert_eq!(region_for(25.0, 100.0, 5), Some(1)); // u=0.25 → bin 1
-        assert_eq!(region_for(99.0, 100.0, 5), Some(4)); // u≈0.99 → bin 4
-        assert_eq!(region_for(150.0, 100.0, 5), Some(4)); // off-end clamps
-    }
-
-    #[test]
-    fn rejects_bad_inputs() {
-        assert_eq!(region_for(f32::NAN, 100.0, 5), None);
-        assert_eq!(region_for(10.0, 0.0, 5), None);
-        assert_eq!(region_for(10.0, f32::NAN, 5), None);
-    }
-
-    #[test]
-    fn lookup_falls_back_to_zero() {
-        let recs = vec![ComponentAnnotation {
-            gene_name: "geneA".into(),
-            modality: "m6A".into(),
-            component_idx: 0,
-            mu: 80.0,
-            gene_length: 100.0,
-        }];
-        let map = RegionMap::from_records(&recs, 5);
-        assert_eq!(map.lookup("geneA", "m6A", 0), 4); // u=0.8 → bin 4
-        assert_eq!(map.lookup("geneA", "m6A", 1), 0); // unannotated → 0
-        assert_eq!(map.lookup("geneB", "m6A", 0), 0); // unknown gene → 0
-    }
-
-    #[test]
-    fn parses_site_id() {
-        assert_eq!(parse_site_id("ENSG_X/pA/0"), Some(("ENSG_X".into(), 0)));
-        assert_eq!(parse_site_id("G/pA/11"), Some(("G".into(), 11))); // multi-digit k
-        assert_eq!(parse_site_id("G/pA/x"), None); // non-integer k
-        assert_eq!(parse_site_id("/pA/0"), None); // empty gene
-        assert_eq!(parse_site_id("nope"), None); // wrong shape
-    }
-
-    fn write_parquet(path: &std::path::Path, batch: &arrow::record_batch::RecordBatch) {
-        use parquet::arrow::ArrowWriter;
-        use parquet::file::properties::WriterProperties;
-        let file = std::fs::File::create(path).unwrap();
-        let props = WriterProperties::builder().build();
-        let mut w = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
-        w.write(batch).unwrap();
-        w.close().unwrap();
-    }
-
-    #[test]
-    fn loads_apa_schema() {
-        use arrow::array::{ArrayRef, Float32Array, StringArray, UInt32Array};
-        use arrow::datatypes::{DataType, Field, Schema};
-        use arrow::record_batch::RecordBatch;
-        use std::sync::Arc;
-
-        // APA sidecar: site_id (`{gene}/pA/{k}`) + expected_tail_length +
-        // utr_length. Position u = 1 − etl/utr: comp0 → 0.8, comp2 → 0.1.
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("site_id", DataType::Utf8, false),
-            Field::new("gene_name", DataType::Utf8, false),
-            Field::new("expected_tail_length", DataType::Float32, false),
-            Field::new("utr_length", DataType::UInt32, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(StringArray::from(vec!["GENEA/pA/0", "GENEA/pA/2"])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["GENEA", "GENEA"])) as ArrayRef,
-                Arc::new(Float32Array::from(vec![200.0_f32, 900.0])) as ArrayRef,
-                Arc::new(UInt32Array::from(vec![1000_u32, 1000])) as ArrayRef,
-            ],
-        )
-        .unwrap();
-        let path = std::env::temp_dir().join(format!("faba_apa_{}.parquet", std::process::id()));
-        write_parquet(&path, &batch);
-        let recs = load_component_annotations(path.to_str().unwrap(), "pA").unwrap();
-        std::fs::remove_file(&path).ok();
-
-        assert_eq!(recs.len(), 2);
-        // gene + component parsed from site_id (not the gene_name column).
-        assert!(recs
-            .iter()
-            .any(|r| &*r.gene_name == "GENEA" && r.component_idx == 0));
-        assert!(recs
-            .iter()
-            .any(|r| &*r.gene_name == "GENEA" && r.component_idx == 2));
-        // u = 1 − etl/utr → region bins via the shared μ/gene_length path.
-        let map = RegionMap::from_records(&recs, 5);
-        assert_eq!(map.lookup("GENEA", "pA", 0), 4); // u=0.8 → bin 4
-        assert_eq!(map.lookup("GENEA", "pA", 2), 0); // u=0.1 → bin 0
-    }
-
-    #[test]
-    fn loads_gmm_relaxed_int_type() {
-        use arrow::array::{ArrayRef, Float32Array, Int64Array, StringArray};
-        use arrow::datatypes::{DataType, Field, Schema};
-        use arrow::record_batch::RecordBatch;
-        use std::sync::Arc;
-
-        // GMM sidecar with component_idx as i64 (not the canonical u64) —
-        // the relaxed integer reader must still accept it.
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("gene_name", DataType::Utf8, false),
-            Field::new("component_idx", DataType::Int64, false),
-            Field::new("mu", DataType::Float32, false),
-            Field::new("gene_length", DataType::Float32, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(StringArray::from(vec!["GENEB"])) as ArrayRef,
-                Arc::new(Int64Array::from(vec![3_i64])) as ArrayRef,
-                Arc::new(Float32Array::from(vec![80.0_f32])) as ArrayRef,
-                Arc::new(Float32Array::from(vec![100.0_f32])) as ArrayRef,
-            ],
-        )
-        .unwrap();
-        let path = std::env::temp_dir().join(format!("faba_gmm_{}.parquet", std::process::id()));
-        write_parquet(&path, &batch);
-        let recs = load_component_annotations(path.to_str().unwrap(), "m6A").unwrap();
-        std::fs::remove_file(&path).ok();
-
-        assert_eq!(recs.len(), 1);
-        assert_eq!(recs[0].component_idx, 3); // i64 read through
-        assert_eq!(recs[0].gene_name.as_ref(), "GENEB");
-        let map = RegionMap::from_records(&recs, 5);
-        assert_eq!(map.lookup("GENEB", "m6A", 3), 4); // u=0.8 → bin 4
-    }
-}
+mod tests;

--- a/faba/src/gem/region/tests.rs
+++ b/faba/src/gem/region/tests.rs
@@ -1,0 +1,23 @@
+//! Unit tests for [`super::RegionMap`] — per-component slot lookup + clamping.
+
+use super::*;
+
+#[test]
+fn lookup_clamps_to_n_regions_minus_one() {
+    let map = RegionMap::new(5);
+    // Within-range components return their own index.
+    assert_eq!(map.lookup(0), 0);
+    assert_eq!(map.lookup(1), 1);
+    assert_eq!(map.lookup(4), 4);
+    // Beyond-range components clamp to R - 1.
+    assert_eq!(map.lookup(5), 4);
+    assert_eq!(map.lookup(100), 4);
+}
+
+#[test]
+fn zero_n_regions_clamped_to_one() {
+    let map = RegionMap::new(0);
+    assert_eq!(map.n_regions, 1);
+    assert_eq!(map.lookup(0), 0);
+    assert_eq!(map.lookup(7), 0);
+}

--- a/faba/src/gem/train.rs
+++ b/faba/src/gem/train.rs
@@ -241,11 +241,20 @@ fn run_phase(
         // off the autograd graph, so each minibatch's forward graph is still
         // released immediately (no GPU-memory blow-up) while we avoid the
         // ~axes×batches GPU→CPU stalls the old per-minibatch logging incurred.
+        // Log ~10 evenly-spaced progress lines (plus first + last) rather than
+        // one per epoch — a 1000-epoch phase otherwise floods the log with
+        // 1000 near-identical lines. Throttling also skips the per-epoch
+        // GPU→CPU scalar sync on quiet epochs.
+        let log_stride = epochs.div_ceil(10).max(1);
         let emit = |epoch: usize,
                     total_acc: &Option<Tensor>,
                     per_axis_acc: &[Option<Tensor>],
                     n_batches: usize| {
             if n_batches == 0 {
+                return;
+            }
+            let is_last = epoch + 1 == epochs;
+            if epoch != 0 && !is_last && !(epoch + 1).is_multiple_of(log_stride) {
                 return;
             }
             let n = n_batches as f32;

--- a/faba/src/run_gem_embedding.rs
+++ b/faba/src/run_gem_embedding.rs
@@ -12,15 +12,17 @@ use matrix_util::dmatrix_io::DMatrix;
 use matrix_util::traits::RunningStatOps;
 use matrix_util::utils::median;
 use rayon::ThreadPoolBuilder;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use faba::gem::args::GemArgs;
 use faba::gem::cell_solve::{CellStreamCtx, SatStream};
-use faba::gem::feature_table::{BackendRowMap, FeatureTable};
+use faba::gem::feature_table::{
+    classify, parse_component_idx, parse_feature_name, BackendRowMap, FeatureTable, RowStratum,
+};
 use faba::gem::manifest::{write_outputs, CellQcOutputs};
 use faba::gem::model::GemModel;
 use faba::gem::pseudobulk::{build_pseudobulk, spliced_backend_rows, SatelliteData};
-use faba::gem::region::{load_component_annotations, ComponentAnnotation, RegionMap};
+use faba::gem::region::RegionMap;
 use faba::gem::train::train;
 use graph_embedding_util::null_call::embedding_mixture_empty_call;
 
@@ -249,6 +251,76 @@ pub fn run_gem_embedding(args: &GemArgs) -> anyhow::Result<()> {
         info!("tagging barcodes with per-file @sample id (stripped basename) for cross-modality matching");
     }
 
+    // Basenames per modality, computed once and reused for all strip
+    // inference below (avoids re-deriving them inside each helper).
+    let basenames_of = |files: Option<&[Box<str>]>| -> anyhow::Result<Vec<Box<str>>> {
+        files.unwrap_or(&[]).iter().map(|f| basename(f)).collect()
+    };
+    let genes_bn = basenames_of(Some(&args.genes))?;
+    let dartseq_bn = basenames_of(args.dartseq.as_deref())?;
+    let atoi_bn = basenames_of(args.atoi.as_deref())?;
+    let apa_bn = basenames_of(args.apa.as_deref())?;
+    // All satellite basenames, used to recover the genes sample id in the
+    // single-genes-file case below.
+    let sat_basenames: Vec<Box<str>> = dartseq_bn
+        .iter()
+        .chain(&atoi_bn)
+        .chain(&apa_bn)
+        .cloned()
+        .collect();
+
+    // Resolve per-modality strip suffixes (only relevant when tagging).
+    // genes: ≥2 files → LCS at `_` across genes basenames; exactly 1 file →
+    // the `_`-prefix it shares with the satellites (so a single genes file can
+    // still be matched). Satellites: LCS first, else per-file LCP against the
+    // genes sample-id set, hard-erroring if nothing lines up — that's the
+    // silent-modality-drop bug surfaced. Explicit user strips always win.
+    let genes_strip: Box<str> = if !args.genes_sample_strip.is_empty() {
+        args.genes_sample_strip.clone()
+    } else if !do_tag {
+        "".into()
+    } else if genes_bn.len() >= 2 {
+        let s = longest_common_underscore_suffix(&genes_bn);
+        if !s.is_empty() {
+            info!("auto-strip: --genes-sample-strip = {:?}", s.as_ref());
+        }
+        s
+    } else if !sat_basenames.is_empty() {
+        // Single genes file + satellites: the sample id is the longest
+        // `_`-prefix the genes basename shares with every satellite; the tail
+        // after it is the strip (e.g. `rep1_wt_genes` vs `rep1_wt_m6a_mixture`
+        // → strip `_genes`). No shared prefix → leave unstripped and let the
+        // satellite call raise the clear no-overlap error.
+        let genes_bn0 = genes_bn[0].as_ref();
+        let s: Box<str> = match longest_shared_underscore_prefix(genes_bn0, &sat_basenames) {
+            Some(prefix) if prefix.len() < genes_bn0.len() => genes_bn0[prefix.len()..].into(),
+            _ => "".into(),
+        };
+        if !s.is_empty() {
+            info!("auto-strip: --genes-sample-strip = {:?}", s.as_ref());
+        }
+        s
+    } else {
+        "".into()
+    };
+    let genes_ids: FxHashSet<Box<str>> = genes_bn
+        .iter()
+        .map(|b| strip_sample_id(b.as_ref(), &genes_strip))
+        .collect();
+
+    let resolve_sat =
+        |bn: &[Box<str>], user_strip: &str, label: &str| -> anyhow::Result<Box<str>> {
+            if bn.is_empty() || !do_tag || !user_strip.is_empty() {
+                return Ok(user_strip.into());
+            }
+            let s = infer_satellite_strip(bn, &genes_ids, label)?;
+            info!("auto-strip: --{label}-sample-strip = {:?}", s.as_ref());
+            Ok(s)
+        };
+    let dartseq_strip = resolve_sat(&dartseq_bn, &args.dartseq_sample_strip, "dartseq")?;
+    let atoi_strip = resolve_sat(&atoi_bn, &args.atoi_sample_strip, "atoi")?;
+    let apa_strip = resolve_sat(&apa_bn, &args.apa_sample_strip, "apa")?;
+
     info!(
         "loading {} genes file(s) (feature_kind={:?}, preload={})",
         args.genes.len(),
@@ -257,7 +329,7 @@ pub fn run_gem_embedding(args: &GemArgs) -> anyhow::Result<()> {
     );
     let mut unified = load_modality(
         &args.genes,
-        &args.genes_sample_strip,
+        &genes_strip,
         do_tag,
         batch_files,
         feature_kind.clone(),
@@ -283,19 +355,15 @@ pub fn run_gem_embedding(args: &GemArgs) -> anyhow::Result<()> {
     let satellite_specs: [(&[Box<str>], &str, &str); 3] = [
         (
             args.dartseq.as_deref().unwrap_or(&[]),
-            args.dartseq_sample_strip.as_ref(),
+            dartseq_strip.as_ref(),
             "m6A",
         ),
         (
             args.atoi.as_deref().unwrap_or(&[]),
-            args.atoi_sample_strip.as_ref(),
+            atoi_strip.as_ref(),
             "A2I",
         ),
-        (
-            args.apa.as_deref().unwrap_or(&[]),
-            args.apa_sample_strip.as_ref(),
-            "pA",
-        ),
+        (args.apa.as_deref().unwrap_or(&[]), apa_strip.as_ref(), "pA"),
     ];
     let mut satellites: Vec<SatelliteBackend> = Vec::new();
     for (files, strip, label) in satellite_specs {
@@ -336,7 +404,19 @@ pub fn run_gem_embedding(args: &GemArgs) -> anyhow::Result<()> {
     // been cleaned. Full modelling over every modality then runs in pass 2 on
     // the QC-passed subset (see `run_refine_pass`). Without `--refine` the lone
     // pass uses all modalities. `satellites` stays alive either way for pass 2.
-    let region_map = build_region_map(args)?;
+    // Resolve `n_regions` once: explicit arg if given, else
+    // `max(component_idx) + 1` scanned from satellite row names so each
+    // component gets its own γ slot. `RegionMap` then keys per-component
+    // (clamped to n_regions − 1).
+    let n_regions: usize = match args.n_regions {
+        Some(n) => n,
+        None => {
+            let n = infer_n_regions(&satellites, 1);
+            info!("auto-regions: --num-regions = {n} (max component_idx + 1)");
+            n
+        }
+    };
+    let region_map = RegionMap::new(n_regions);
     let pass1_sats: &[SatelliteBackend] = if args.refine() { &[] } else { &satellites };
     let sat_name_lists: Vec<&[Box<str>]> = pass1_sats
         .iter()
@@ -407,14 +487,20 @@ pub fn run_gem_embedding(args: &GemArgs) -> anyhow::Result<()> {
     }
     // Per-cell spliced nnz for the kept cells (re-applied in the refine pass).
     let cell_nnz: Vec<f32> = kept.iter().map(|&c| cell_nnz_full[c]).collect();
-    info!(
-        "cell QC (spliced non-zeros): kept {} / {} cells at cutoff {} (dropped {}) \
-         [conservative; refine empty-call makes the real cut]",
-        kept.len(),
-        n_cells_full,
-        cell_cutoff,
-        n_cells_full - kept.len(),
-    );
+    // Only surface this line when it actually filtered something — the refine
+    // empty-call is what makes the real cut; an "kept N/N (dropped 0)" line is
+    // pure noise. The dropped path keeps the conservative reminder.
+    let n_dropped = n_cells_full - kept.len();
+    if n_dropped > 0 {
+        info!(
+            "cell QC (spliced non-zeros): kept {} / {} cells at cutoff {} (dropped {}) \
+             [conservative; refine empty-call makes the real cut]",
+            kept.len(),
+            n_cells_full,
+            cell_cutoff,
+            n_dropped,
+        );
+    }
     // After the up-front subset every remaining cell is written out.
     let keep_idx: Vec<usize> = (0..unified.n_cells()).collect();
 
@@ -967,47 +1053,194 @@ fn run_refine_pass(
     })
 }
 
-/// Per-file sample id: the file's basename (sparse-data extension stripped)
-/// with the per-flag `strip` suffix removed. `rep1_wt_genes.zarr.zip` with
-/// `strip = "_genes"` → `rep1_wt`. Empty `strip` (or a non-matching one)
-/// keeps the full basename, so two modality files of one sample merge only
-/// when their stripped basenames agree.
-fn file_sample_id(file: &str, strip: &str) -> anyhow::Result<Box<str>> {
-    let base = basename(file)?;
-    let sid = if strip.is_empty() {
-        base.as_ref()
+/// Strip the per-flag `strip` suffix from an already-computed basename.
+/// Empty (or non-matching) `strip` keeps the full basename, so two modality
+/// files of one sample merge only when their stripped basenames agree.
+fn strip_sample_id(base: &str, strip: &str) -> Box<str> {
+    if strip.is_empty() {
+        base.into()
     } else {
-        base.as_ref().strip_suffix(strip).unwrap_or(base.as_ref())
-    };
-    Ok(sid.into())
+        base.strip_suffix(strip).unwrap_or(base).into()
+    }
 }
 
-/// Load any supplied `*_components.parquet` sidecars and build the
-/// transcript-position `RegionMap`. Each sidecar is tagged with the
-/// modality label that matches its modifier row names (`m6A`, `A2I`,
-/// `pA`). With no sidecars the map is empty and every satellite falls
-/// back to region 0 (γ collapses to one per-modality offset).
-fn build_region_map(args: &GemArgs) -> anyhow::Result<RegionMap> {
-    let sidecars: [(&Option<Box<str>>, &str); 3] = [
-        (&args.dartseq_components, "m6A"),
-        (&args.atoi_components, "A2I"),
-        (&args.apa_components, "pA"),
-    ];
-    let mut records: Vec<ComponentAnnotation> = Vec::new();
-    for (path, modality) in sidecars {
-        if let Some(path) = path.as_ref() {
-            let recs = load_component_annotations(path, modality)
-                .with_context(|| format!("loading {modality} component annotations from {path}"))?;
-            info!(
-                "region: {} {} component annotations from {}",
-                recs.len(),
-                modality,
-                path
-            );
-            records.extend(recs);
+/// Per-file sample id: the file's basename (sparse-data extension stripped)
+/// with the per-flag `strip` suffix removed. `rep1_wt_genes.zarr.zip` with
+/// `strip = "_genes"` → `rep1_wt`.
+fn file_sample_id(file: &str, strip: &str) -> anyhow::Result<Box<str>> {
+    Ok(strip_sample_id(basename(file)?.as_ref(), strip))
+}
+
+/// Scan modifier-comp rows of every loaded satellite, return
+/// `max(component_idx) + 1`. Falls back to `default_n` if no parseable
+/// modifier-comp row is found (e.g. only the genes backend was loaded, or
+/// the satellites carry only `chr:pos` site rows).
+fn infer_n_regions(satellites: &[SatelliteBackend], default_n: usize) -> usize {
+    let mut max_c: u32 = 0;
+    let mut any = false;
+    for sat in satellites {
+        for name in &sat.unified.feature_names {
+            let Some(key) = parse_feature_name(name) else {
+                continue;
+            };
+            if !matches!(classify(&key), RowStratum::ModifierComp) {
+                continue;
+            }
+            if let Some(c) = parse_component_idx(&key.detail) {
+                max_c = max_c.max(c);
+                any = true;
+            }
         }
     }
-    Ok(RegionMap::from_records(&records, args.n_regions))
+    if any {
+        (max_c as usize) + 1
+    } else {
+        default_n
+    }
+}
+
+/// Longest `_`-aligned suffix shared by every basename in `names`.
+/// Returns "" with fewer than two inputs, or when no `_`-prefixed suffix
+/// (e.g. `_genes`, `_m6a_mixture`) is common to all. Greedy from the
+/// longest candidate down — picks the longest `_`-prefixed suffix of
+/// `names[0]` that's a suffix of every other entry.
+fn longest_common_underscore_suffix(names: &[Box<str>]) -> Box<str> {
+    if names.len() < 2 {
+        return "".into();
+    }
+    // Candidate `_`-aligned suffixes of the first basename, longest first.
+    let first = names[0].as_ref();
+    let mut candidates: Vec<&str> = first.match_indices('_').map(|(i, _)| &first[i..]).collect();
+    candidates.sort_by_key(|s| std::cmp::Reverse(s.len()));
+    for cand in candidates {
+        if names[1..].iter().all(|n| n.ends_with(cand)) {
+            return cand.into();
+        }
+    }
+    "".into()
+}
+
+/// Longest `_`-aligned prefix of `name` that is a member of `candidates`.
+/// The match is `_`-bounded: a candidate `rep1_wt` matches
+/// `rep1_wt_m6a_mixture` (because the char after the prefix is `_`) but
+/// does NOT match `rep1_wtX_...`. Returns `None` when no candidate aligns.
+fn longest_underscore_prefix_in(name: &str, candidates: &FxHashSet<Box<str>>) -> Option<Box<str>> {
+    let mut best: Option<&str> = None;
+    for sid in candidates.iter() {
+        let s = sid.as_ref();
+        if !name.starts_with(s) {
+            continue;
+        }
+        // Boundary: full equality or next char is `_`.
+        if name.len() != s.len() && !name[s.len()..].starts_with('_') {
+            continue;
+        }
+        if best.is_none_or(|b| s.len() > b.len()) {
+            best = Some(s);
+        }
+    }
+    best.map(|s| s.into())
+}
+
+/// Longest `_`-aligned prefix of `name` that is also a `_`-aligned prefix
+/// of *every* entry in `others`. `_`-aligned = the prefix is the whole
+/// string or is immediately followed by `_`. Returns `None` when not even
+/// the first `_`-segment is shared. Used to recover a **single** genes
+/// file's sample id from the satellite basenames it must co-sample with
+/// (e.g. `rep1_wt_genes` + `rep1_wt_m6a_mixture` → `rep1_wt`), so the genes
+/// strip can be inferred without a second genes file to diff against.
+fn longest_shared_underscore_prefix(name: &str, others: &[Box<str>]) -> Option<Box<str>> {
+    // `_`-aligned prefixes of `name`, longest first: the whole name, then
+    // each truncation at a `_`.
+    let mut cands: Vec<&str> = std::iter::once(name)
+        .chain(name.match_indices('_').map(|(i, _)| &name[..i]))
+        .collect();
+    cands.sort_by_key(|s| std::cmp::Reverse(s.len()));
+    let aligned =
+        |hay: &str, p: &str| hay == p || hay.strip_prefix(p).is_some_and(|r| r.starts_with('_'));
+    cands
+        .into_iter()
+        .find(|p| others.iter().all(|o| aligned(o.as_ref(), p)))
+        .map(|p| p.into())
+}
+
+/// Infer the strip suffix for one satellite modality from its `basenames`.
+///
+/// Algorithm:
+///   1. If ≥2 files: try LCS-at-`_` across this modality's basenames.
+///      Accept when every stripped name is a known genes sample id.
+///   2. Else (1 file, or LCS failed): per file, find the longest
+///      `_`-aligned prefix in `genes_ids` and take the tail as the strip.
+///      Accept when every file yields the *same* tail.
+///   3. Otherwise: hard error with both sample-id sets surfaced so the
+///      user can set `--{label}-sample-strip` explicitly.
+fn infer_satellite_strip(
+    basenames: &[Box<str>],
+    genes_ids: &FxHashSet<Box<str>>,
+    label: &str,
+) -> anyhow::Result<Box<str>> {
+    // No files → no strip (the caller already short-circuits empty modalities;
+    // this keeps the `tails[0]` access below sound for any future caller).
+    if basenames.is_empty() {
+        return Ok("".into());
+    }
+
+    // Genes ids, sorted, for any error message (the source is a HashSet, so
+    // sort to keep the diagnostic deterministic run-to-run / test-stable).
+    let sorted_genes_ids = || {
+        let mut v: Vec<&str> = genes_ids.iter().map(|s| s.as_ref()).collect();
+        v.sort_unstable();
+        v
+    };
+
+    // Path 1: LCS across this modality's basenames, validated against genes ids.
+    if basenames.len() >= 2 {
+        let lcs = longest_common_underscore_suffix(basenames);
+        if !lcs.is_empty() {
+            let ok = basenames.iter().all(|b| {
+                b.as_ref()
+                    .strip_suffix(lcs.as_ref())
+                    .is_some_and(|s| genes_ids.contains(s))
+            });
+            if ok {
+                return Ok(lcs);
+            }
+        }
+    }
+
+    // Path 2: per-file LCP against genes ids; tails must agree.
+    let mut tails: Vec<Box<str>> = Vec::with_capacity(basenames.len());
+    for b in basenames {
+        match longest_underscore_prefix_in(b.as_ref(), genes_ids) {
+            Some(sid) => {
+                let tail = &b.as_ref()[sid.len()..];
+                tails.push(tail.into());
+            }
+            None => {
+                anyhow::bail!(
+                    "{label} sample ids don't overlap with genes sample ids.\n  \
+                     genes sample ids: {:?}\n  \
+                     {label} basenames: {:?}\n  \
+                     No `_`-aligned suffix or prefix lines up. Set --genes-sample-strip \
+                     and/or --{label}-sample-strip so both reduce to the same sample id.",
+                    sorted_genes_ids(),
+                    basenames.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                );
+            }
+        }
+    }
+    let first = tails[0].clone();
+    if tails.iter().all(|t| *t == first) {
+        return Ok(first);
+    }
+    anyhow::bail!(
+        "{label} files imply inconsistent sample-id strips.\n  \
+         genes sample ids: {:?}\n  \
+         per-file inferred strips: {:?}\n  \
+         Pass --{label}-sample-strip <SUFFIX> to override.",
+        sorted_genes_ids(),
+        tails.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+    );
 }
 
 /// Argument-level sanity checks before any I/O or training. Surfaces
@@ -1025,11 +1258,9 @@ fn validate_args(args: &GemArgs) -> anyhow::Result<()> {
         "--num-programs must be > 0 (got {})",
         args.n_programs
     );
-    anyhow::ensure!(
-        args.n_regions > 0,
-        "--num-regions must be > 0 (got {})",
-        args.n_regions
-    );
+    if let Some(n) = args.n_regions {
+        anyhow::ensure!(n > 0, "--num-regions must be > 0 (got {n})");
+    }
     anyhow::ensure!(
         args.tau.is_finite() && (0.0..=1.0).contains(&args.tau),
         "--tau must be a finite value in [0, 1] (got {})",
@@ -1086,3 +1317,6 @@ fn validate_args(args: &GemArgs) -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/faba/src/run_gem_embedding/tests.rs
+++ b/faba/src/run_gem_embedding/tests.rs
@@ -1,0 +1,121 @@
+//! Unit tests for the filename → sample-id strip inference helpers in
+//! [`super`] (`longest_common_underscore_suffix`,
+//! `longest_underscore_prefix_in`, `longest_shared_underscore_prefix`,
+//! `infer_satellite_strip`).
+
+use super::*;
+
+fn bx(s: &[&str]) -> Vec<Box<str>> {
+    s.iter().map(|x| (*x).into()).collect()
+}
+
+fn ids(s: &[&str]) -> FxHashSet<Box<str>> {
+    s.iter().map(|x| (*x).into()).collect()
+}
+
+#[test]
+fn lcs_picks_longest_aligned_suffix() {
+    // Two genes files → shared `_genes` suffix.
+    assert_eq!(
+        &*longest_common_underscore_suffix(&bx(&["rep1_wt_genes", "rep1_mut_genes"])),
+        "_genes"
+    );
+    // Shared deeper suffix wins (greedy longest).
+    assert_eq!(
+        &*longest_common_underscore_suffix(&bx(&["a_rep1_genes", "b_rep1_genes"])),
+        "_rep1_genes"
+    );
+    // Single input → no suffix to diff against.
+    assert_eq!(
+        &*longest_common_underscore_suffix(&bx(&["rep1_wt_genes"])),
+        ""
+    );
+    // No shared `_`-suffix.
+    assert_eq!(
+        &*longest_common_underscore_suffix(&bx(&["foo_a", "bar_b"])),
+        ""
+    );
+}
+
+#[test]
+fn prefix_match_is_underscore_bounded() {
+    let cand = ids(&["rep1_wt", "rep1_mut"]);
+    assert_eq!(
+        longest_underscore_prefix_in("rep1_wt_m6a_mixture", &cand).as_deref(),
+        Some("rep1_wt")
+    );
+    // No partial-token match: `rep1_wtX` must not match `rep1_wt`.
+    assert_eq!(longest_underscore_prefix_in("rep1_wtX_m6a", &cand), None);
+    // Longest candidate wins when several align.
+    let nested = ids(&["rep1", "rep1_wt"]);
+    assert_eq!(
+        longest_underscore_prefix_in("rep1_wt_m6a", &nested).as_deref(),
+        Some("rep1_wt")
+    );
+}
+
+#[test]
+fn shared_prefix_recovers_single_genes_sample_id() {
+    // The single-genes-file case: recover `rep1_wt` from the satellite.
+    assert_eq!(
+        longest_shared_underscore_prefix("rep1_wt_genes", &bx(&["rep1_wt_m6a_mixture"])).as_deref(),
+        Some("rep1_wt")
+    );
+    // Multiple satellites must all share the prefix.
+    assert_eq!(
+        longest_shared_underscore_prefix(
+            "rep1_wt_genes",
+            &bx(&["rep1_wt_m6a_mixture", "rep1_wt_apa_mixture"])
+        )
+        .as_deref(),
+        Some("rep1_wt")
+    );
+    // No shared `_`-segment at all → None.
+    assert_eq!(
+        longest_shared_underscore_prefix("rep1_wt_genes", &bx(&["other_m6a"])),
+        None
+    );
+}
+
+#[test]
+fn satellite_strip_single_file_against_two_genes_samples() {
+    // The user's real layout: genes {rep1_wt, rep1_mut}, one m6A file.
+    let genes_ids = ids(&["rep1_wt", "rep1_mut"]);
+    let strip =
+        infer_satellite_strip(&bx(&["rep1_wt_m6a_mixture"]), &genes_ids, "dartseq").unwrap();
+    assert_eq!(&*strip, "_m6a_mixture");
+}
+
+#[test]
+fn satellite_strip_multi_file_lcs_path() {
+    // Two m6A files, one per genes sample → LCS path returns `_m6a_mixture`.
+    let genes_ids = ids(&["rep1_wt", "rep1_mut"]);
+    let strip = infer_satellite_strip(
+        &bx(&["rep1_wt_m6a_mixture", "rep1_mut_m6a_mixture"]),
+        &genes_ids,
+        "dartseq",
+    )
+    .unwrap();
+    assert_eq!(&*strip, "_m6a_mixture");
+}
+
+#[test]
+fn satellite_strip_errors_on_no_overlap() {
+    let genes_ids = ids(&["rep1_wt", "rep1_mut"]);
+    let err = infer_satellite_strip(&bx(&["sampleZ_m6a_mixture"]), &genes_ids, "dartseq")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("don't overlap"), "got: {err}");
+    // Mentions both flags so the fix is actionable.
+    assert!(err.contains("--genes-sample-strip"), "got: {err}");
+    assert!(err.contains("--dartseq-sample-strip"), "got: {err}");
+}
+
+#[test]
+fn satellite_strip_empty_files_is_noop() {
+    let genes_ids = ids(&["rep1_wt"]);
+    assert_eq!(
+        &*infer_satellite_strip(&[], &genes_ids, "dartseq").unwrap(),
+        ""
+    );
+}

--- a/faba/tests/gem_embedding.rs
+++ b/faba/tests/gem_embedding.rs
@@ -138,14 +138,11 @@ fn test_args() -> GemArgs {
         dartseq: None,
         atoi: None,
         apa: None,
-        dartseq_components: None,
-        atoi_components: None,
-        apa_components: None,
         batch_files: None,
         out: "".into(),
         embedding_dim: H,
         n_programs: K,
-        n_regions: R,
+        n_regions: Some(R),
         num_levels: 0,
         sort_dim: 10,
         knn_pb: 10,
@@ -156,7 +153,6 @@ fn test_args() -> GemArgs {
         dartseq_sample_strip: "".into(),
         atoi_sample_strip: "".into(),
         apa_sample_strip: "".into(),
-        auto_cell_cutoff: false,
         no_cell_axis: false,
         // This fixture trains on the cell axis only (zero pb levels), so keep
         // the full cell axis in phase 1 (k ≥ n_cells = legacy all-cells).
@@ -232,7 +228,7 @@ fn satellite_embed(model: &GemModel, g: u32, region: u32) -> Vec<f32> {
 #[test]
 fn recovers_region_resolved_deviation() {
     let dev = Device::Cpu;
-    let table = FeatureTable::build(&feature_names(), &RegionMap::from_records(&[], R));
+    let table = FeatureTable::build(&feature_names(), &RegionMap::new(R));
     assert_eq!(table.n_genes(), N_GENES);
     assert_eq!(table.n_regions, R);
 
@@ -413,17 +409,14 @@ fn count_embed(model: &GemModel, g: u32, modality: u32) -> Vec<f32> {
 fn recovers_splice_direction() {
     let dev = Device::Cpu;
     let r_splice = 1usize; // splice satellites have no transcript regions
-    let table = FeatureTable::build(
-        &splice_feature_names(),
-        &RegionMap::from_records(&[], r_splice),
-    );
+    let table = FeatureTable::build(&splice_feature_names(), &RegionMap::new(r_splice));
     assert_eq!(table.n_genes(), N_GENES);
     // spliced / unspliced are distinct count modalities (≥1), not slot 0.
     assert_eq!(table.count_modality_ids, vec![SPL, UNSPL]);
 
     let pb = build_splice_pseudobulk();
     let mut args = test_args();
-    args.n_regions = r_splice;
+    args.n_regions = Some(r_splice);
     args.f_agg = 0.3;
     args.f_count = 0.6; // actually draw spliced/unspliced positives
     args.epochs = 120;

--- a/graph-embedding-util/Cargo.toml
+++ b/graph-embedding-util/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.2.0"
+version = "0.2.1"
 
 [lib]
 name = "graph_embedding_util"

--- a/graph-embedding-util/src/cell_projection.rs
+++ b/graph-embedding-util/src/cell_projection.rs
@@ -46,17 +46,28 @@ const CONVERGE_TOL: f64 = 1e-5;
 /// row-major, b_cell [n_cells])`. The per-cell bias `b_c` is **always**
 /// fitted (it absorbs library size, keeping `e_c` depth-corrected and
 /// well-scaled) and kept by both callers (bge and gem).
+///
+/// `progress`, when `Some`, is incremented by one per solved cell — pass a
+/// bar pre-sized to the *total* cell count so a caller that invokes this
+/// once per chunk gets a single bar spanning all chunks.
 pub fn project_cells(
     frozen_e: &[f32],
     frozen_b: &[f32],
     per_cell: &[Vec<(u32, f32)>],
     h: usize,
     lambda: f64,
+    progress: Option<&indicatif::ProgressBar>,
 ) -> (Vec<f32>, Vec<f32>) {
     let n_cells = per_cell.len();
     let solved: Vec<(Vec<f32>, f32)> = per_cell
         .par_iter()
-        .map(|feats| solve_one_cell(feats, frozen_e, frozen_b, h, lambda))
+        .map(|feats| {
+            let solved = solve_one_cell(feats, frozen_e, frozen_b, h, lambda);
+            if let Some(pb) = progress {
+                pb.inc(1);
+            }
+            solved
+        })
         .collect();
     let mut e = vec![0f32; n_cells * h];
     let mut b = vec![0f32; n_cells];
@@ -191,7 +202,7 @@ mod tests {
         let e = vec![1.0f32, 0.0, 0.0, 1.0]; // 2 features
         let b = vec![0.0f32, 0.0];
         let per_cell = vec![vec![(0u32, 2.0f32)], vec![(1u32, 3.0f32)]];
-        let (ec, bc) = project_cells(&e, &b, &per_cell, 2, 1.0);
+        let (ec, bc) = project_cells(&e, &b, &per_cell, 2, 1.0, None);
         assert_eq!(ec.len(), 4); // 2 cells × h=2
         assert_eq!(bc.len(), 2);
     }

--- a/graph-embedding-util/src/training.rs
+++ b/graph-embedding-util/src/training.rs
@@ -25,9 +25,9 @@ use crate::loss::{
     StratifiedSampler,
 };
 use crate::model::JointEmbedModel;
+use crate::progress::new_progress_bar;
 use candle_util::candle_core::{Device, Tensor};
 use candle_util::candle_nn::AdamW;
-use indicatif::{ProgressBar, ProgressStyle};
 use log::info;
 use rand::{rngs::StdRng, RngExt, SeedableRng};
 use rand_distr::weighted::WeightedIndex;
@@ -201,12 +201,9 @@ pub fn train_composite(
 ) -> anyhow::Result<()> {
     assert!(!ctx.axes.is_empty(), "composite training needs >= 1 axis");
 
-    let prog_bar = ProgressBar::new(params.epochs as u64);
-    prog_bar.set_style(
-        ProgressStyle::with_template("{bar:30} {pos}/{len} {msg}")
-            .unwrap()
-            .progress_chars("##-"),
-    );
+    // Shared style — consistent with every other faba/senna progress bar
+    // (`[elapsed] bar pos/len (eta) msg`).
+    let prog_bar = new_progress_bar(params.epochs as u64);
 
     let mut rng = StdRng::seed_from_u64(params.seed);
     let refresh_every = smoother.as_ref().map(|s| s.refresh_epochs).unwrap_or(0);


### PR DESCRIPTION
## Summary

Makes `faba gem` straightforward to run on multi-modality data — you pass the file paths and (in the common case) nothing else. Also fixes phase-2 progress visibility and log noise.

### Inputs
- **Drop the `*_components.parquet` sidecar input** (`--dartseq/atoi/apa-components` removed). `RegionMap` now keys the γ offset by per-component slot within `(gene, modality)`, clamped to `n_regions-1`, so same-gene components stay distinguishable without any external annotation. The emit side of `faba m6a/atoi/apa` is unchanged.
- **Auto-infer `--*-sample-strip`** from filename overlap: genes via shared `_`-suffix across ≥2 files, or shared `_`-prefix with the satellites for a single genes file; satellites via suffix-LCS then per-file prefix match against the genes sample ids. **Hard-errors** with both sample-id sets when nothing lines up — previously this silently dropped the whole modality (0 cells matched). Explicit flags still win.
- **Auto-infer `--num-regions`** as `max(component_idx)+1` from satellite row names; the flag is now optional.

### Progress & logging
- **Progress bar on the analytical phase-2 cell projection** (the parallel rayon per-cell Poisson-MAP solve) — one bar sized to the full cell count, shared across chunks in the streaming solver.
- **Throttle phase-1 epoch logging** to ~10 evenly-spaced lines (was one INFO line per epoch). A 1000-epoch run dropped from ~1000 log lines/phase to ~11; also skips the per-epoch GPU→CPU loss sync on quiet epochs.
- **Unify progress-bar style** — every faba/senna/graph-embedding-util bar now routes through `new_progress_bar` with the same `[elapsed] bar pos/len (eta) msg` template (the gem-util training loop was the one outlier).

### Behavior change
- Genes-only multi-file runs now get stripped sample-id batch labels (e.g. `rep1_wt` rather than `rep1_wt_genes`).

## Testing
- New unit tests for the strip-inference helpers (extracted into sibling `tests.rs` files) + per-component region lookup.
- `cargo clippy -p faba -p graph-embedding-util -p senna --all-targets` — zero warnings.
- Verified end-to-end on rep1 (single- and two-genes-file layouts, full default 1000-epoch + refine + topics): m6A links into the model, cell QC separates real cells (median nnz ~5800) from empty droplets (~40) cleanly, topics resolve, clean completion. Logs 154 lines (was 2139).

## Versions
- faba 0.5.0 → 0.5.2
- graph-embedding-util 0.2.0 → 0.2.1