### PR TITLE
Lineage-aware faba gem → lineage → annotate (velocity pb-DAG, root anchoring, trajectory annotation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "faba"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "faba"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "approx",
@@ -2659,7 +2659,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graph-embedding-util"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "auxiliary-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "data-beans-sim"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "faba"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -2659,7 +2659,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graph-embedding-util"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "auxiliary-data",
@@ -5080,7 +5080,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "senna"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "approx",

--- a/data-beans-sim/Cargo.toml
+++ b/data-beans-sim/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.3.2"
+version = "0.3.3"
 
 [[bin]]
 name = "data-beans-sim"

--- a/data-beans-sim/src/faba/latents.rs
+++ b/data-beans-sim/src/faba/latents.rs
@@ -36,6 +36,14 @@ pub struct Latents {
     pub alpha_per_mod: Vec<DMatrix<f32>>,
     /// Cell-state topic proportions (shared with writer/editor activity), [K_topic × N].
     pub theta_kn: DMatrix<f32>,
+    /// Trajectory mode only: the look-ahead (nascent) topic state θ(t+Δ), [K × N].
+    /// `None` in the standard Dirichlet mode. Drives the UNSPLICED count track so the
+    /// spliced→unspliced contrast encodes velocity along the trajectory tangent.
+    pub theta_future_kn: Option<DMatrix<f32>>,
+    /// Trajectory mode only: per-cell pseudotime `t ∈ [0,1]`. `None` otherwise.
+    pub pseudotime: Option<Vec<f32>>,
+    /// Trajectory mode only: per-cell branch id. `None` otherwise.
+    pub branch: Option<Vec<usize>>,
     /// Gene labels.
     pub gene_names: Vec<Box<str>>,
     /// Cell labels (shared across all per-modality matrices).
@@ -66,6 +74,20 @@ pub fn sample_all(args: &FabaArgs, pi_meas: &[f32], rng: &mut impl Rng) -> anyho
 
     anyhow::ensure!(k >= 1, "k-topics must be ≥ 1");
     anyhow::ensure!(c_mod >= 1, "components-per-modifier must be ≥ 1");
+    if args.trajectory {
+        anyhow::ensure!(args.n_branches >= 1, "trajectory: --n-branches must be ≥ 1");
+        anyhow::ensure!(
+            args.velocity_lookahead > 0.0 && args.velocity_lookahead <= 1.0,
+            "trajectory: --velocity-lookahead must be in (0, 1] (got {})",
+            args.velocity_lookahead
+        );
+        anyhow::ensure!(
+            k >= 2 + args.n_branches,
+            "trajectory: --k-topics ({}) must be ≥ 2 + --n-branches ({})",
+            k,
+            2 + args.n_branches
+        );
+    }
 
     let normal01 = Normal::new(0.0_f32, 1.0_f32).unwrap();
 
@@ -186,11 +208,40 @@ pub fn sample_all(args: &FabaArgs, pi_meas: &[f32], rng: &mut impl Rng) -> anyho
         alpha_per_mod.push(alpha);
     }
 
+    // Trajectory mode: force the count spliced/unspliced split to be EQUAL per gene.
+    // Otherwise the (random Dirichlet) α ratio is a large per-gene nuisance that
+    // dominates the spliced↔unspliced contrast and swamps the velocity signal. With
+    // an equal split the ONLY s/u difference is θ(t) vs θ(t+Δ) — pure, recoverable
+    // velocity (mirrors real RNA-velocity kinetics where u/s reflects dynamics).
+    // Overwritten AFTER the draw loop so the RNG stream (and every other latent) is
+    // unchanged relative to a same-seed non-count edit.
+    if args.trajectory {
+        let count = &mut alpha_per_mod[0];
+        for gi in 0..g {
+            count[(0, gi)] = 0.5;
+            count[(1, gi)] = 0.5;
+        }
+    }
+
     ////////////////////////////////////
     // θ_{k, n} cell-state topics //
     ////////////////////////////////////
-    let (theta_kn, _) =
-        sample_nested_topic_proportions(k, 1, n, args.pve_topic, 1.0, rng.next_u64());
+    // Trajectory mode replaces the Dirichlet cell states with a bifurcating
+    // pseudotime path and its look-ahead (nascent) state; the standard path is
+    // otherwise byte-identical (same RNG draws).
+    let (theta_kn, theta_future_kn, pseudotime, branch) = if args.trajectory {
+        let traj = sample_trajectory_topics(k, n, args.n_branches, args.velocity_lookahead, rng)?;
+        (
+            traj.theta,
+            Some(traj.theta_future),
+            Some(traj.pseudotime),
+            Some(traj.branch),
+        )
+    } else {
+        let (theta, _) =
+            sample_nested_topic_proportions(k, 1, n, args.pve_topic, 1.0, rng.next_u64());
+        (theta, None, None, None)
+    };
 
     ///////////////////////////
     // gene / cell names //
@@ -214,9 +265,84 @@ pub fn sample_all(args: &FabaArgs, pi_meas: &[f32], rng: &mut impl Rng) -> anyho
         base_gm,
         alpha_per_mod,
         theta_kn,
+        theta_future_kn,
+        pseudotime,
+        branch,
         gene_names,
         cell_names,
     })
+}
+
+/// Trajectory-mode cell states. Returned by [`sample_trajectory_topics`].
+struct TrajectoryTopics {
+    /// Mature (spliced) state θ(t), `[K × N]`.
+    theta: DMatrix<f32>,
+    /// Nascent (unspliced) look-ahead state θ(min(t+Δ, 1)), `[K × N]`.
+    theta_future: DMatrix<f32>,
+    /// Per-cell pseudotime `t ∈ [0,1]`.
+    pseudotime: Vec<f32>,
+    /// Per-cell branch id `∈ 0..n_branches`.
+    branch: Vec<usize>,
+}
+
+/// Sample bifurcating-trajectory cell states: each cell draws a pseudotime
+/// `t ~ U(0,1)` and a branch `b ~ U{0..B}`. The mature state is θ(t,b); the
+/// nascent state is the look-ahead θ(min(t+Δ,1), b), so the mature→nascent
+/// contrast points along the trajectory tangent (recoverable velocity). At the
+/// terminus (`t+Δ ≥ 1`) the look-ahead saturates, so velocity → 0.
+fn sample_trajectory_topics(
+    k: usize,
+    n: usize,
+    n_branches: usize,
+    lookahead: f32,
+    rng: &mut impl Rng,
+) -> anyhow::Result<TrajectoryTopics> {
+    let u01 = Uniform::new(0.0_f32, 1.0_f32)?;
+    let ubr = Uniform::new(0usize, n_branches)?;
+    let mut theta = DMatrix::<f32>::zeros(k, n);
+    let mut theta_future = DMatrix::<f32>::zeros(k, n);
+    let mut pseudotime = vec![0f32; n];
+    let mut branch = vec![0usize; n];
+    for j in 0..n {
+        let t: f32 = u01.sample(rng);
+        let b: usize = ubr.sample(rng);
+        pseudotime[j] = t;
+        branch[j] = b;
+        let cur = traj_theta(t, b, k);
+        let fut = traj_theta((t + lookahead).min(1.0), b, k);
+        for kk in 0..k {
+            theta[(kk, j)] = cur[kk];
+            theta_future[(kk, j)] = fut[kk];
+        }
+    }
+    Ok(TrajectoryTopics {
+        theta,
+        theta_future,
+        pseudotime,
+        branch,
+    })
+}
+
+/// θ(t, b) on the bifurcating path: root interpolates topic 0 → topic 1 for
+/// `t ≤ 0.5`, then branch `b` interpolates topic 1 → topic `2+b` for `t > 0.5`.
+/// A small uniform floor keeps every topic strictly positive (numerical safety),
+/// and the result stays a valid proportion (sums to 1).
+fn traj_theta(t: f32, b: usize, k: usize) -> Vec<f32> {
+    const FLOOR: f32 = 0.02;
+    let mut th = vec![0f32; k];
+    if t <= 0.5 {
+        let f = (t / 0.5).clamp(0.0, 1.0);
+        th[0] += 1.0 - f;
+        th[1] += f;
+    } else {
+        let f = ((t - 0.5) / 0.5).clamp(0.0, 1.0);
+        th[1] += 1.0 - f;
+        th[2 + b] += f;
+    }
+    for v in &mut th {
+        *v = (1.0 - FLOOR) * *v + FLOOR / k as f32;
+    }
+    th
 }
 
 /// Pick a held-out subset of substrate-positive (g, m) pairs. Only
@@ -293,6 +419,9 @@ fn sample_dirichlet(k: usize, alpha: f32, rng: &mut impl Rng) -> Vec<f32> {
     let dist = rand_distr::multi::Dirichlet::new(&alphas).expect("Dirichlet: alpha > 0, k > 0");
     dist.sample(rng).into_iter().map(|x| x as f32).collect()
 }
+
+#[cfg(test)]
+mod tests;
 
 /// Spike-and-slab matrix: each entry is `Bernoulli(π) · N(0, σ²)`.
 /// Shared between the writer/editor coupling `A` and the gene response

--- a/data-beans-sim/src/faba/latents/tests.rs
+++ b/data-beans-sim/src/faba/latents/tests.rs
@@ -1,0 +1,86 @@
+//! Unit tests for the trajectory (velocity) cell-state generator.
+
+use super::{sample_trajectory_topics, traj_theta};
+use rand::SeedableRng;
+
+/// θ(t, b) is always a valid proportion (non-negative, sums to 1).
+#[test]
+fn traj_theta_is_valid_proportion() {
+    let k = 6;
+    for &(t, b) in &[
+        (0.0, 0),
+        (0.25, 0),
+        (0.5, 1),
+        (0.75, 0),
+        (0.75, 1),
+        (1.0, 3),
+    ] {
+        let th = traj_theta(t, b, k);
+        assert_eq!(th.len(), k);
+        assert!(th.iter().all(|&v| v >= 0.0), "negative mass at t={t}");
+        let s: f32 = th.iter().sum();
+        assert!((s - 1.0).abs() < 1e-5, "θ sums to {s} at t={t}");
+    }
+}
+
+/// The path is monotone: the root builds topic-1 mass as t→0.5, and beyond the
+/// bifurcation each branch builds its terminal-vertex (2+b) mass as t→1.
+#[test]
+fn traj_theta_progresses_along_path() {
+    let k = 6;
+    // Root: topic 1 grows with t.
+    assert!(traj_theta(0.1, 0, k)[1] < traj_theta(0.4, 0, k)[1]);
+    // Branch b=0 → vertex 2, b=1 → vertex 3: terminal mass grows toward t=1.
+    assert!(traj_theta(0.6, 0, k)[2] < traj_theta(0.9, 0, k)[2]);
+    assert!(traj_theta(0.6, 1, k)[3] < traj_theta(0.9, 1, k)[3]);
+    // Each branch peaks on its own vertex at the terminus.
+    let e0 = traj_theta(1.0, 0, k);
+    let e1 = traj_theta(1.0, 1, k);
+    assert!(e0[2] > e0[3], "branch 0 should peak on vertex 2");
+    assert!(e1[3] > e1[2], "branch 1 should peak on vertex 3");
+}
+
+/// The look-ahead (nascent) state leads the mature state along the path, so the
+/// mature→nascent contrast is a forward velocity; at the terminus it saturates
+/// (future clamps to θ(1), so velocity shrinks).
+#[test]
+fn future_leads_current_and_saturates_at_terminus() {
+    let k = 6;
+    let n = 400;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+    let traj = sample_trajectory_topics(k, n, 2, 0.2, &mut rng).unwrap();
+
+    assert_eq!(traj.pseudotime.len(), n);
+    assert!(traj.pseudotime.iter().all(|&t| (0.0..=1.0).contains(&t)));
+    assert!(traj.branch.iter().all(|&b| b < 2));
+
+    // Velocity magnitude in topic space = ‖θ_future − θ‖. It should be non-trivial
+    // for mid-trajectory cells and ~0 for terminal cells (look-ahead saturated).
+    let mut mid_mag = 0.0f32;
+    let mut mid_n = 0;
+    let mut term_mag = 0.0f32;
+    let mut term_n = 0;
+    for j in 0..n {
+        let d: f32 = (0..k)
+            .map(|kk| {
+                let x = traj.theta_future[(kk, j)] - traj.theta[(kk, j)];
+                x * x
+            })
+            .sum::<f32>()
+            .sqrt();
+        if traj.pseudotime[j] > 0.9 {
+            term_mag += d;
+            term_n += 1;
+        } else if traj.pseudotime[j] < 0.7 {
+            mid_mag += d;
+            mid_n += 1;
+        }
+    }
+    let mid = mid_mag / mid_n.max(1) as f32;
+    let term = term_mag / term_n.max(1) as f32;
+    assert!(mid > 0.05, "mid-trajectory velocity too small ({mid})");
+    assert!(
+        term < mid,
+        "terminal velocity ({term}) should fade below mid ({mid})"
+    );
+}

--- a/data-beans-sim/src/faba/mod.rs
+++ b/data-beans-sim/src/faba/mod.rs
@@ -179,6 +179,37 @@ pub struct FabaArgs {
 
     #[arg(
         long,
+        default_value_t = false,
+        help = "Trajectory mode: cell states follow a branching pseudotime with a \
+                recoverable RNA velocity (nascent leads mature).",
+        long_help = "Trajectory mode (default off = the standard Dirichlet cell states).\n\
+                     Each cell gets a pseudotime t ∈ [0,1] and a branch; the topic state θ(t)\n\
+                     moves along a bifurcating path (root topics 0→1 for t≤0.5, then 1→(2+b)\n\
+                     for branch b). The SPLICED (mature) track uses θ(t); the UNSPLICED\n\
+                     (nascent) track uses the look-ahead θ(t+Δ), so gem's velocity δ points\n\
+                     along the trajectory tangent. Ground truth is written to\n\
+                     `{out}.pseudotime.parquet` (pseudotime + branch) and\n\
+                     `{out}.topic_proportions_future.parquet`. Requires K ≥ 2 + n-branches."
+    )]
+    pub trajectory: bool,
+
+    #[arg(
+        long,
+        default_value_t = 2,
+        help = "Trajectory mode: number of lineage branches from the common root"
+    )]
+    pub n_branches: usize,
+
+    #[arg(
+        long,
+        default_value_t = 0.1,
+        help = "Trajectory mode: velocity look-ahead Δ in pseudotime units — how far the \
+                nascent (unspliced) state leads the mature (spliced) state"
+    )]
+    pub velocity_lookahead: f32,
+
+    #[arg(
+        long,
         default_value_t = 0.1,
         help = "Fraction of substrate-positive (g, m) pairs held out (no rows emitted) \
                 for imputation evaluation"
@@ -280,11 +311,18 @@ pub fn run_faba(args: &FabaArgs) -> anyhow::Result<()> {
     // across the count and every modifier sampler call instead of
     // recomputed inside each.
     let log_topic = sample::precompute_log_topic(&lats);
+    // Trajectory mode: the look-ahead log-topic θ(t+Δ) driving the nascent
+    // (unspliced) track. `None` in the standard mode (unspliced reuses log_topic).
+    let log_topic_future = lats
+        .theta_future_kn
+        .as_ref()
+        .map(|tf| sample::precompute_log_topic_from(&lats.beta_topic_gk, tf));
 
     // Shared inputs for every per-modality sampler.
     let rate_ctx = sample::RateContext {
         lats: &lats,
         log_topic: &log_topic,
+        log_topic_future: log_topic_future.as_ref(),
         batch_membership: &batch_membership,
     };
 

--- a/data-beans-sim/src/faba/output.rs
+++ b/data-beans-sim/src/faba/output.rs
@@ -175,6 +175,36 @@ pub fn write_all(
         Some(&topic_names),
     )?;
 
+    // Trajectory ground truth (trajectory mode only): per-cell pseudotime + branch,
+    // and the look-ahead (nascent) topic state used to inject velocity. Together
+    // these let a harness score recovered pseudotime, branch topology, and velocity
+    // direction against the truth.
+    if let (Some(pt), Some(br)) = (&lats.pseudotime, &lats.branch) {
+        let mut pt_mat = DMatrix::<f32>::zeros(n, 2);
+        for j in 0..n {
+            pt_mat[(j, 0)] = pt[j];
+            pt_mat[(j, 1)] = br[j] as f32;
+        }
+        let pt_cols: [Box<str>; 2] = ["pseudotime".into(), "branch".into()];
+        write_dmatrix(
+            &format!("{}.pseudotime.parquet", args.out),
+            &pt_mat,
+            &lats.cell_names,
+            Some("cell"),
+            Some(&pt_cols),
+        )?;
+    }
+    if let Some(tf) = &lats.theta_future_kn {
+        let tf_nk = tf.transpose();
+        write_dmatrix(
+            &format!("{}.topic_proportions_future.parquet", args.out),
+            &tf_nk,
+            &lats.cell_names,
+            Some("cell"),
+            Some(&topic_names),
+        )?;
+    }
+
     // α mixture weights: one parquet per modality. Stored as [G × C_m].
     for (m, modality) in MODALITIES.iter().enumerate() {
         let alpha_gc = lats.alpha_per_mod[m].transpose();

--- a/data-beans-sim/src/faba/sample.rs
+++ b/data-beans-sim/src/faba/sample.rs
@@ -26,6 +26,10 @@ pub type RowKey = (usize, usize);
 pub struct RateContext<'a> {
     pub lats: &'a Latents,
     pub log_topic: &'a DMatrix<f32>,
+    /// Trajectory mode: the look-ahead `log((β_topic · θ(t+Δ)))` driving the
+    /// UNSPLICED count track. `None` ⇒ unspliced reuses `log_topic` (no velocity —
+    /// the standard, byte-identical behaviour).
+    pub log_topic_future: Option<&'a DMatrix<f32>>,
     pub batch_membership: &'a [usize],
 }
 
@@ -35,7 +39,17 @@ pub struct RateContext<'a> {
 /// gene-specific additive terms (β_g and δ_{g, B(j)}) are folded in
 /// inside `assemble_log_mu`.
 pub fn precompute_log_topic(lats: &Latents) -> DMatrix<f32> {
-    let lambda = &lats.beta_topic_gk * &lats.theta_kn;
+    precompute_log_topic_from(&lats.beta_topic_gk, &lats.theta_kn)
+}
+
+/// `log((β_topic · θ))` for an arbitrary topic-proportion matrix `θ` (`[K × N]`).
+/// Shared by the current (spliced) state and the trajectory look-ahead
+/// (unspliced) state, so both tracks reuse the same log-rate assembly.
+pub fn precompute_log_topic_from(
+    beta_topic_gk: &DMatrix<f32>,
+    theta_kn: &DMatrix<f32>,
+) -> DMatrix<f32> {
+    let lambda = beta_topic_gk * theta_kn;
     lambda.map(|v| v.max(EPS_LOG).ln())
 }
 
@@ -58,11 +72,23 @@ pub fn sample_count_modality(
     let n = lats.theta_kn.ncols();
     let depths = vec![depth_count as f32; n];
 
-    let log_mu = assemble_log_mu(ctx, ln_delta_count);
+    let log_mu_spliced = assemble_log_mu(ctx, ln_delta_count);
+    // Unspliced (nascent) uses the look-ahead state θ(t+Δ) in trajectory mode, so
+    // the spliced→unspliced contrast encodes velocity; otherwise it reuses the same
+    // log_mu (constant spliced/unspliced ratio ⇒ no velocity, the original behaviour).
+    let log_mu_unspliced = match ctx.log_topic_future {
+        Some(future) => assemble_log_mu_from(future, lats, ctx.batch_membership, ln_delta_count),
+        None => log_mu_spliced.clone(),
+    };
 
     // Stack [G × N] for spliced (c=0) and unspliced (c=1) vertically.
     let mut log_rate = DMatrix::<f32>::zeros(2 * g, n);
     for c in 0..2 {
+        let log_mu = if c == 0 {
+            &log_mu_spliced
+        } else {
+            &log_mu_unspliced
+        };
         for gi in 0..g {
             let row = c * g + gi;
             let log_alpha = (lats.alpha_per_mod[0][(c, gi)] + EPS_LOG).ln();
@@ -144,14 +170,25 @@ pub fn sample_modifier_modality(
 /// [G × K] · [K × N] matmul runs once per `run_faba`, not once per
 /// modality. Returned shape: `[G × N]`.
 fn assemble_log_mu(ctx: &RateContext, ln_delta: &DMatrix<f32>) -> DMatrix<f32> {
-    let lats = ctx.lats;
+    assemble_log_mu_from(ctx.log_topic, ctx.lats, ctx.batch_membership, ln_delta)
+}
+
+/// [`assemble_log_mu`] for an explicit `log_topic` matrix — the current (spliced)
+/// or look-ahead (unspliced) state — folding in `β_g` and the per-modality batch
+/// effect. Shared so both count tracks assemble identically off their own topic state.
+fn assemble_log_mu_from(
+    log_topic: &DMatrix<f32>,
+    lats: &Latents,
+    batch_membership: &[usize],
+    ln_delta: &DMatrix<f32>,
+) -> DMatrix<f32> {
     let g = lats.beta_g.len();
-    let n = lats.theta_kn.ncols();
+    let n = log_topic.ncols();
     let bb = ln_delta.ncols();
 
-    let mut log_mu = ctx.log_topic.clone();
+    let mut log_mu = log_topic.clone();
     for j in 0..n {
-        let b = ctx.batch_membership[j];
+        let b = batch_membership[j];
         for gi in 0..g {
             let delta = if bb > 1 { ln_delta[(gi, b)] } else { 0.0 };
             log_mu[(gi, j)] += lats.beta_g[gi] + delta;

--- a/faba/Cargo.toml
+++ b/faba/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 
-version = "0.9.1"
+version = "0.9.2"
 
 [lib]
 # The library surface exists so `gem`'s integration tests (tests/) can reach

--- a/faba/Cargo.toml
+++ b/faba/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 
-version = "0.9.2"
+version = "0.9.3"
 
 [lib]
 # The library surface exists so `gem`'s integration tests (tests/) can reach

--- a/faba/Cargo.toml
+++ b/faba/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 
-version = "0.9.3"
+version = "0.9.4"
 
 [lib]
 # The library surface exists so `gem`'s integration tests (tests/) can reach

--- a/faba/src/gem/args.rs
+++ b/faba/src/gem/args.rs
@@ -161,6 +161,42 @@ pub struct TrainArgs {
 		if their global L2 norm exceeds this, bounding embedding inflation on loss spikes."
     )]
     pub max_grad_norm: f32,
+
+    #[arg(
+        long = "lineage-dag",
+        default_value_t = false,
+        help = "Lineage-aware pseudobulk DAG (experimental; default off).",
+        long_help = "Inject developmental structure at pseudobulk scale. When set, gem runs an\n\
+                     analytic pb-level velocity readout after phase 1 (identity θ_pb and\n\
+                     velocity δ_pb per pseudobulk per collapse level) that orients a directed\n\
+                     lineage structure over pseudobulks. Off by default — the per-cell embedding\n\
+                     is byte-identical to a plain run. Only meaningful with spliced+unspliced\n\
+                     input (β-sharing)."
+    )]
+    pub lineage_dag: bool,
+
+    #[arg(
+        long = "dag-learn",
+        default_value_t = false,
+        help = "Lineage-DAG: learn the pseudobulk DAG (M2) instead of a fixed graph.",
+        long_help = "Within `--lineage-dag`, learn the directed pb structure `W` jointly with\n\
+                     the embedding (velocity-drift SEM + DAGMA-style acyclicity + L1 +\n\
+                     velocity-orientation prior) instead of the default fixed velocity-oriented\n\
+                     KNN graph (M1). Ignored unless `--lineage-dag` is set. Experimental."
+    )]
+    pub dag_learn: bool,
+
+    #[arg(
+        long = "lineage-smooth",
+        default_value_t = false,
+        help = "Lineage-DAG: smooth the pb velocity readout δ_pb (opt-in).",
+        long_help = "Smooth the pb velocity readout δ_pb over θ-space KNN neighbours before it\n\
+                     orients the lineage graph, stabilizing sign(δ_pb). A wash on clean data\n\
+                     (no noise to remove, and it can blur branch-point velocity), so it is off\n\
+                     by default — the payoff is on noisy real spliced/unspliced ratios. Ignored\n\
+                     unless `--lineage-dag` is set."
+    )]
+    pub lineage_smooth: bool,
 }
 
 /// Runtime knobs: data preload, RNG seed, compute device, threads.

--- a/faba/src/gem/mod.rs
+++ b/faba/src/gem/mod.rs
@@ -1,5 +1,7 @@
-//! `faba gem` — joint embedding of gene counts (spliced + unspliced) into one
-//! cell/gene space, over the shared `graph_embedding_util` engine.
+//! `faba gem` — **Ge**odesic **E**mbedding + **M**otion: a joint cell-feature embedding
+//! over the shared `graph_embedding_util` engine. Motion is the local velocity δ (the
+//! tangent); the lineage is the geodesic path it traces. The engine is modality-agnostic;
+//! it is fed gene counts (spliced + unspliced) today, but embeds any per-feature count.
 //!
 //! Each feature row `{gene}/count/{spliced|unspliced}` maps to its gene, so a
 //! gene's spliced and unspliced tracks embed identically as `β_g` (β-sharing).

--- a/faba/src/main.rs
+++ b/faba/src/main.rs
@@ -299,21 +299,20 @@ Example:\n  \
     #[command(
         name = "gem",
         aliases = ["gem-embedding"],
-        about = "GEM: gene embedding (spliced + unspliced counts)",
-        long_about = "GEM — joint embedding of gene counts (spliced + unspliced)\n\
-            into one cell/gene space, over the shared graph_embedding_util engine.\n\n\
-            Each feature row `{gene}/count/{spliced|unspliced}` embeds as a base\n\
-            gene vector β_g — a gene's two tracks share one identity (β-sharing):\n\
-            spliced  count:  e_f = β_g\n\
-              unspliced count: e_f = β_g\n\
-            A single Poisson likelihood on counts. Cell identity comes from the\n\
-            SPLICED projection θ (mature mRNA = current state), written RAW as\n\
-            `{out}.latent.parquet` (magnitude kept); the same phase-2 pass fits an\n\
-            analytic velocity increment δ to the unspliced edges (identity held\n\
-            fixed) and writes it RAW as `{out}.velocity.parquet` (‖δ‖ = speed). The\n\
-            nascent state is just θ+δ = latent+velocity. No post-hoc unit-norm or\n\
-            co-embedding is written; per-gene velocity, if wanted, is the in-model\n\
-            δ_g (`--delta-l2` → `{out}.delta_dictionary.parquet`).",
+        about = "GEM: Geodesic Embedding + Motion — velocity (tangent) + lineage (path) in one cell space",
+        long_about = "GEM — Geodesic Embedding + Motion: a joint cell-feature embedding.\n\
+            Motion is the local velocity δ (the tangent); the lineage is the geodesic path it traces.\n\
+            Runs over the shared graph_embedding_util engine, which is modality-agnostic.\n\
+            Fed gene counts (spliced + unspliced) today; embeds any per-feature count.\n\n\
+            Per-gene β-sharing: each `{gene}/count/{spliced|unspliced}` row embeds as β_g.\n\
+            A gene's spliced and unspliced tracks thus share one identity.\n\
+            Cell identity is the spliced projection θ → `{out}.latent.parquet` (raw).\n\
+            A velocity increment δ is fit from the unspliced edges → `{out}.velocity.parquet`.\n\
+            The nascent state is just θ+δ; ‖δ‖ is speed.\n\
+            Per-gene velocity, if wanted, is the in-model δ_g (`--delta-l2`).\n\n\
+            With `--lineage-dag` it also shapes the embedding along a pseudobulk lineage.\n\
+            It then writes a per-cell pseudotime + fate backbone.\n\
+            That backbone is a prior for `faba lineage`, not a replacement.",
         after_long_help = "\
 	Example:\n\
   faba gem --genes out/rep1_wt_genes.zarr.zip -o out/gem\n\n\

--- a/faba/src/pipeline_util.rs
+++ b/faba/src/pipeline_util.rs
@@ -582,10 +582,19 @@ pub fn run_gene_count_qc(
                 sink.zip,
             );
             let merged: Vec<_> = spliced.into_iter().chain(unspliced).collect();
-            format_data_triplets_shared(merged, &feature_to_index, &cell_to_index, row_names, col_names)
-                .to_backend(&out.write_path)?;
+            format_data_triplets_shared(
+                merged,
+                &feature_to_index,
+                &cell_to_index,
+                row_names,
+                col_names,
+            )
+            .to_backend(&out.write_path)?;
             out.finalize()?;
-            info!("{}: wrote gene-count matrix to {}", batch_name, out.target_path);
+            info!(
+                "{}: wrote gene-count matrix to {}",
+                batch_name, out.target_path
+            );
             matrix_by_batch.insert(bam_file.clone(), out.target_path);
         }
 

--- a/faba/src/run_gem_embedding.rs
+++ b/faba/src/run_gem_embedding.rs
@@ -288,6 +288,9 @@ fn run_gem_genes_bge(
         phase1_cells_per_pb: args.collapse.phase1_cells_per_pb,
         feat_factor: Some(factor),
         delta_l2,
+        lineage_dag: args.train.lineage_dag,
+        dag_learnable: args.train.dag_learn,
+        lineage_smooth: args.train.lineage_smooth,
     };
     let out = ge::fit(&mut unified, cfg).context("ge::fit (genes bge)")?;
 
@@ -385,6 +388,135 @@ fn run_gem_genes_bge(
         info!(
             "wrote {}.velocity.parquet (raw cell velocity increment δ; ‖δ‖ = speed)",
             args.out
+        );
+    }
+
+    // Lineage-DAG (experimental): dump the per-level pseudobulk states — identity
+    // θ_pb, velocity δ_pb, and (M2) the learned DAG adjacency W — so the structure
+    // can be inspected / scored and consumed by the phase-2 cell lift. Only present
+    // when `--lineage-dag` ran on a β-sharing model.
+    if let Some(pbv) = &out.pb_velocity {
+        for (i, lvl) in pbv.iter().enumerate() {
+            let np = lvl.n_pb;
+            let pb_names: Vec<Box<str>> = (0..np)
+                .map(|p| format!("pb_{i}_{p}").into_boxed_str())
+                .collect();
+            let th = candle_util::candle_core::Tensor::from_vec(lvl.theta.clone(), (np, h), &cpu)?;
+            ge::save_embedding(
+                &format!("{}.pb_theta_l{i}.parquet", args.out),
+                &th,
+                &pb_names,
+                "pb",
+            )
+            .context("save pb theta")?;
+            let dl = candle_util::candle_core::Tensor::from_vec(lvl.delta.clone(), (np, h), &cpu)?;
+            ge::save_embedding(
+                &format!("{}.pb_velocity_l{i}.parquet", args.out),
+                &dl,
+                &pb_names,
+                "pb",
+            )
+            .context("save pb velocity")?;
+            if let Some(w) = out
+                .pb_dag_w
+                .as_ref()
+                .and_then(|d| d.get(i))
+                .filter(|w| !w.is_empty())
+            {
+                let wt = candle_util::candle_core::Tensor::from_vec(w.clone(), (np, np), &cpu)?;
+                ge::save_embedding(
+                    &format!("{}.pb_dag_l{i}.parquet", args.out),
+                    &wt,
+                    &pb_names,
+                    "pb",
+                )
+                .context("save pb dag W")?;
+            }
+        }
+        info!(
+            "wrote pb-level θ/δ{} for {} level(s)",
+            if out.pb_dag_w.is_some() {
+                " + learned DAG W"
+            } else {
+                ""
+            },
+            pbv.len()
+        );
+    }
+
+    // M3 phase-2 cell-lineage lift: per-cell pseudotime τ_c + landmark ambiguity
+    // (`{out}.pseudotime.parquet`) and per-cell fate over the terminal pb nodes
+    // (`{out}.fate.parquet`). Evaluation-only — lifted from the finest pb trajectory
+    // onto every cell. Present only when `--lineage-dag` produced a readout. These
+    // feed `faba lineage` as an informed backbone.
+    if let Some(lin) = &out.cell_lineage {
+        use matrix_util::traits::IoOps;
+        // pseudotime + ambiguity, two named columns, keyed on barcodes.
+        let mut pt = Vec::with_capacity(n * 2);
+        for c in 0..n {
+            pt.push(lin.tau[c]);
+            pt.push(lin.ambiguity[c]);
+        }
+        let pt_t = candle_util::candle_core::Tensor::from_vec(pt, (n, 2), &cpu)?;
+        let pt_cols = [
+            Box::<str>::from("pseudotime"),
+            Box::<str>::from("ambiguity"),
+        ];
+        pt_t.to_parquet_with_names(
+            &format!("{}.pseudotime.parquet", args.out),
+            (Some(&unified.barcodes), Some("cell")),
+            Some(&pt_cols),
+        )?;
+        info!(
+            "wrote {}.pseudotime.parquet (per-cell τ + landmark ambiguity; pb level {})",
+            args.out, lin.level
+        );
+
+        // fate: one column per terminal pb node (empty when no terminal exists,
+        // e.g. a single-fate or edge-free trajectory — skip the write then).
+        let k = lin.terminals.len();
+        if k > 0 {
+            let fate_t =
+                candle_util::candle_core::Tensor::from_vec(lin.fate.clone(), (n, k), &cpu)?;
+            let fate_cols: Vec<Box<str>> = lin
+                .terminals
+                .iter()
+                .map(|t| format!("fate_pb{t}").into_boxed_str())
+                .collect();
+            fate_t.to_parquet_with_names(
+                &format!("{}.fate.parquet", args.out),
+                (Some(&unified.barcodes), Some("cell")),
+                Some(&fate_cols),
+            )?;
+            info!(
+                "wrote {}.fate.parquet (per-cell fate over {} terminal pb node(s))",
+                args.out, k
+            );
+        }
+    }
+
+    // Unsupervised per-run QC diagnostics (`{out}.lineage_qc.json`) for an agent
+    // exploring random seeds: reject broken runs on `flag == "underfit"`, then inspect
+    // the structure. The remaining fields are DIAGNOSTICS, not a validated quality
+    // ranker (see LineageQc). Flat JSON, no ground truth needed.
+    if let Some(qc) = &out.lineage_qc {
+        let json = format!(
+            "{{\n  \"root_decisiveness\": {:.4},\n  \"velocity_coherence\": {:.4},\n  \
+             \"n_roots\": {},\n  \"n_terminals\": {},\n  \"mean_ambiguity\": {:.4},\n  \
+             \"likelihood\": {:.4},\n  \"flag\": \"{}\"\n}}\n",
+            qc.root_decisiveness,
+            qc.velocity_coherence,
+            qc.n_roots,
+            qc.n_terminals,
+            qc.mean_ambiguity,
+            qc.likelihood,
+            qc.flag,
+        );
+        std::fs::write(format!("{}.lineage_qc.json", args.out), json)
+            .with_context(|| format!("writing {}.lineage_qc.json", args.out))?;
+        info!(
+            "wrote {}.lineage_qc.json (flag={}, decisiveness={:.3}, {} fate(s))",
+            args.out, qc.flag, qc.root_decisiveness, qc.n_terminals
         );
     }
 

--- a/faba/src/run_lineage.rs
+++ b/faba/src/run_lineage.rs
@@ -20,9 +20,13 @@ use clap::{Args, ValueEnum};
 use log::{info, warn};
 use std::path::Path;
 
+use graph_embedding_util::type_annotation::{
+    annotate_with_communities, CommunityCalls, InputEmbeddings, TermOraConfig,
+};
 use matrix_util::common_io::mkdir_parent;
 use matrix_util::dmatrix_io::DMatrix;
 use matrix_util::layout::{phate_layout_2d, project_cells_nystrom, PhateArgs};
+use matrix_util::parquet::{write_named_table, Column};
 use matrix_util::principal_curve::{fit_principal_curves, PrincipalCurveArgs, PrincipalCurves};
 use matrix_util::principal_graph::{
     kmeans_centroids, mst_from_sqdist, pairwise_sqdist_rows_to_rows,
@@ -117,6 +121,42 @@ pub struct LineageArgs {
                 absent."
     )]
     pub root_from_gem: bool,
+
+    #[arg(
+        long,
+        help = "Marker TSV (gene<TAB>celltype) to name trajectory nodes by cell type",
+        long_help = "Annotate each trajectory node with a cell type by term over-representation \
+                     (the `faba annotate` core) run over the MST-node grouping, so the call \
+                     carries the same permutation-calibrated confidence.\n\
+                     Input: a `gene<TAB>celltype` TSV (tab/comma/space delimited).\n\
+                     Reads gene β from `{from}.beta_dictionary.parquet` and raw θ from \
+                     `{from}.latent.parquet`. Writes `{out}.lineage_annot.*` (per-cell calls \
+                     keyed by MST node) and `{out}.trajectory_annotation.parquet` \
+                     (node → role[root|terminal|internal] → cell_type → confidence)."
+    )]
+    pub markers: Option<Box<str>>,
+
+    #[arg(
+        long,
+        default_value_t = 500,
+        help = "With --markers: permutation draws calibrating each node's over-representation"
+    )]
+    pub marker_num_perm: usize,
+
+    #[arg(
+        long,
+        help = "Cell Ontology OBO file for the --markers ontology layer (needs --marker-label-cl)",
+        long_help = "Optional. Adds a TreeBH Cell-Ontology layer over the per-node marker calls, \
+                     as in `faba annotate`. Give the OBO graph here and the marker-type → CL id \
+                     map via --marker-label-cl (both required together)."
+    )]
+    pub marker_obo: Option<Box<str>>,
+
+    #[arg(
+        long,
+        help = "Curated `label<TAB>CL:id` TSV pairing marker types to CL ids (with --marker-obo)"
+    )]
+    pub marker_label_cl: Option<Box<str>>,
 
     #[arg(
         long,
@@ -251,6 +291,9 @@ pub fn run_lineage(args: &LineageArgs) -> Result<()> {
     let cell = DMatrix::<f32>::from_parquet(&latent_path)
         .with_context(|| format!("reading latent embedding {latent_path}"))?;
     let cell_names = cell.rows;
+    // Raw θ kept only for `--markers` node annotation, which scores in the same raw
+    // latent space `faba annotate` uses (the L2-normalized `theta` below drives the fit).
+    let raw_theta: Option<DMatrix<f32>> = args.markers.is_some().then(|| cell.mat.clone());
     let theta = if args.no_normalize_latent {
         cell.mat
     } else {
@@ -365,6 +408,24 @@ pub fn run_lineage(args: &LineageArgs) -> Result<()> {
     )?;
     write_curves(&curves, &format!("{out}.curves.parquet"))?;
 
+    // ---- optional marker annotation of the trajectory nodes ----
+    if let (Some(markers), Some(raw)) = (args.markers.as_deref(), raw_theta.as_ref()) {
+        annotate_trajectory(&AnnotateTrajArgs {
+            prefix,
+            out: &out,
+            markers,
+            raw_theta: raw,
+            cell_names: &cell_names,
+            labels: &labels,
+            k,
+            root,
+            directed: &directed,
+            num_perm: args.marker_num_perm,
+            obo: args.marker_obo.as_deref(),
+            label_cl: args.marker_label_cl.as_deref(),
+        })?;
+    }
+
     // ---- optional PHATE 2D layout (cells + nodes + curves projected) ----
     if args.layout == LayoutKind::Phate {
         let phate = PhateArgs {
@@ -382,6 +443,107 @@ pub fn run_lineage(args: &LineageArgs) -> Result<()> {
             &out,
         )?;
     }
+    Ok(())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Marker annotation of the trajectory
+////////////////////////////////////////////////////////////////////////
+
+/// Inputs for [`annotate_trajectory`] — bundled to keep the fan-in a struct.
+struct AnnotateTrajArgs<'a> {
+    prefix: &'a str,
+    out: &'a str,
+    markers: &'a str,
+    /// Raw θ `[N × H]` — the same latent space `faba annotate` scores in.
+    raw_theta: &'a DMatrix<f32>,
+    cell_names: &'a [Box<str>],
+    /// Per-cell MST-node id (the k-means `labels`) — the annotation clustering.
+    labels: &'a [usize],
+    /// Number of MST nodes.
+    k: usize,
+    root: usize,
+    /// Velocity-oriented directed edges `(from, to)`; a leaf (never a `from`) is terminal.
+    directed: &'a [(usize, usize)],
+    num_perm: usize,
+    obo: Option<&'a str>,
+    label_cl: Option<&'a str>,
+}
+
+/// Name each trajectory node by cell type: run the `faba annotate` term-ORA core over the
+/// MST-node grouping (raw θ vs the gem β dictionary), giving every node a permutation-
+/// calibrated call, then summarize the root / terminals / branches. Writes
+/// `{out}.lineage_annot.*` and `{out}.trajectory_annotation.parquet`.
+fn annotate_trajectory(a: &AnnotateTrajArgs) -> Result<()> {
+    let beta_path = format!("{}.beta_dictionary.parquet", a.prefix);
+    let beta = DMatrix::<f32>::from_parquet(&beta_path)
+        .with_context(|| format!("--markers needs the gem β dictionary {beta_path}"))?;
+    let cfg = TermOraConfig {
+        n_perm: a.num_perm,
+        obo: a.obo.map(str::to_owned),
+        label_cl: a.label_cl.map(str::to_owned),
+        ..TermOraConfig::default()
+    };
+    let input = InputEmbeddings {
+        feature_emb: &beta.mat,
+        gene_names: &beta.rows,
+        cell_emb: a.raw_theta,
+        cell_names: a.cell_names,
+    };
+    let calls = annotate_with_communities(
+        &input,
+        a.markers,
+        &format!("{}.lineage_annot", a.out),
+        true, // IDF-weight markers, as `faba annotate` does by default
+        a.labels,
+        a.k,
+        &cfg,
+    )?;
+    write_trajectory_annotation(a.out, &calls, a.root, a.directed, a.k)?;
+    Ok(())
+}
+
+/// Cross the per-node calls with the oriented MST → the labeled trajectory: one row per
+/// MST node — `role` (root | terminal | internal), `cell_type`, `confidence`.
+fn write_trajectory_annotation(
+    out: &str,
+    calls: &CommunityCalls,
+    root: usize,
+    directed: &[(usize, usize)],
+    k: usize,
+) -> Result<()> {
+    // A terminal is a directed leaf: it never appears as a `from`.
+    let mut has_out = vec![false; k];
+    for &(f, _) in directed {
+        if f < k {
+            has_out[f] = true;
+        }
+    }
+    let node_names = numbered("node_", k);
+    let roles: Vec<Box<str>> = (0..k)
+        .map(|node| {
+            if node == root {
+                Box::from("root")
+            } else if !has_out[node] {
+                Box::from("terminal")
+            } else {
+                Box::from("internal")
+            }
+        })
+        .collect();
+    let path = format!("{out}.trajectory_annotation.parquet");
+    write_named_table(
+        &path,
+        "node",
+        &node_names,
+        &[
+            (Box::from("role"), Column::Str(&roles)),
+            (Box::from("cell_type"), Column::Str(&calls.labels)),
+            (Box::from("confidence"), Column::F32(&calls.confidence)),
+        ],
+    )
+    .with_context(|| format!("writing {path}"))?;
+    info!("wrote {path} ({k} nodes; root={root})");
     Ok(())
 }
 

--- a/faba/src/run_lineage.rs
+++ b/faba/src/run_lineage.rs
@@ -109,6 +109,16 @@ pub struct LineageArgs {
     pub root_cell: Option<Box<str>>,
 
     #[arg(
+        long = "root-from-gem",
+        help = "Anchor the root at gem's inferred root (the min-pseudotime cell in \
+                {from}.pseudotime.parquet). Uses gem's velocity-DAG root inference — more \
+                robust than the per-edge flux pick — while lineage still fits the curves. \
+                Overridden by --root-node / --root-cell; falls back to flux if the file is \
+                absent."
+    )]
+    pub root_from_gem: bool,
+
+    #[arg(
         long,
         default_value_t = 100,
         help = "k-means iterations for centroid initialization"
@@ -159,14 +169,16 @@ fn choose_k(n: usize, requested: Option<usize>) -> usize {
     requested.unwrap_or_else(|| (n / 10).clamp(2, 200)).min(n)
 }
 
-/// Resolve the root MST node: `--root-node` (validated), else `--root-cell` (the
-/// node of the named cell's cluster), else the velocity-picked root, else node 0.
+/// Resolve the root MST node, in priority order: `--root-node` (validated), `--root-cell`
+/// (the node of the named cell's cluster), `gem_root` (the centroid of gem's inferred
+/// root cell, from `--root-from-gem`), the velocity-flux-picked root, else node 0.
 fn resolve_root(
     root_node: Option<usize>,
     root_cell: Option<&str>,
     cell_names: &[Box<str>],
     labels: &[usize],
     k: usize,
+    gem_root: Option<usize>,
     velocity_root: Option<usize>,
 ) -> Result<usize> {
     if let Some(r) = root_node {
@@ -178,8 +190,50 @@ fn resolve_root(
             .position(|c| c.as_ref() == name)
             .with_context(|| format!("--root-cell '{name}' not found in latent"))?;
         Ok(labels[idx])
+    } else if let Some(r) = gem_root {
+        Ok(r)
     } else {
         Ok(velocity_root.unwrap_or(0))
+    }
+}
+
+/// Map gem's inferred root to an MST centroid (for `--root-from-gem`): read
+/// `{prefix}.pseudotime.parquet`, take the barcode with minimum pseudotime (τ ≈ 0, the
+/// velocity-DAG source), find it in the latent, and return its cluster label. `None`
+/// (with a warning) when the file is absent or the barcode can't be matched — the caller
+/// then falls back to the velocity-flux root.
+fn gem_root_node(prefix: &str, cell_names: &[Box<str>], labels: &[usize]) -> Option<usize> {
+    let path = format!("{prefix}.pseudotime.parquet");
+    if !Path::new(&path).exists() {
+        warn!("--root-from-gem: {path} absent; falling back to the velocity-flux root");
+        return None;
+    }
+    let pt = match DMatrix::<f32>::from_parquet(&path) {
+        Ok(pt) => pt,
+        Err(e) => {
+            warn!("--root-from-gem: cannot read {path} ({e}); falling back to velocity root");
+            return None;
+        }
+    };
+    // Column 0 is `pseudotime` (column 1 is `ambiguity`); take the row-minimum barcode.
+    let rmin = (0..pt.mat.nrows()).min_by(|&a, &b| {
+        pt.mat[(a, 0)]
+            .partial_cmp(&pt.mat[(b, 0)])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })?;
+    let root_bc = pt.rows.get(rmin)?.as_ref();
+    match cell_names.iter().position(|c| c.as_ref() == root_bc) {
+        Some(idx) => {
+            info!(
+                "--root-from-gem: root cell '{root_bc}' (τ≈min) → MST node {}",
+                labels[idx]
+            );
+            Some(labels[idx])
+        }
+        None => {
+            warn!("--root-from-gem: root barcode '{root_bc}' not in latent; using flux root");
+            None
+        }
     }
 }
 
@@ -249,12 +303,19 @@ pub fn run_lineage(args: &LineageArgs) -> Result<()> {
 
     // ---- root selection ----
     let velocity_root = have_velocity.then(|| pick_velocity_root(&edges, &flux, k));
+    // Optional gem hand-off: anchor the root at gem's velocity-DAG-inferred root
+    // (min-pseudotime cell), more robust than the per-edge flux pick.
+    let gem_root = args
+        .root_from_gem
+        .then(|| gem_root_node(prefix, &cell_names, &labels))
+        .flatten();
     let root = resolve_root(
         args.root_node,
         args.root_cell.as_deref(),
         &cell_names,
         &labels,
         k,
+        gem_root,
         velocity_root,
     )?;
     info!("lineage root node = {root}");

--- a/graph-embedding-util/Cargo.toml
+++ b/graph-embedding-util/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.2.17"
+version = "0.2.18"
 
 [lib]
 name = "graph_embedding_util"

--- a/graph-embedding-util/Cargo.toml
+++ b/graph-embedding-util/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.2.18"
+version = "0.2.19"
 
 [lib]
 name = "graph_embedding_util"

--- a/graph-embedding-util/src/fit/config.rs
+++ b/graph-embedding-util/src/fit/config.rs
@@ -1,3 +1,5 @@
+use super::lift::{CellLineage, LineageQc};
+use super::projection::PbLevelVelocity;
 use crate::data::UnifiedData;
 use crate::model::JointEmbedModel;
 use crate::training::{CompositeMode, TrainingParams};
@@ -137,6 +139,24 @@ pub struct FitConfig {
     /// velocity increment `δ` (see [`FitOutput::cell_velocity`]).
     /// `None` = the standard free embedding (bge / Stage 0).
     pub feat_factor: Option<FeatFactorSpec>,
+    /// Lineage-DAG path (gem β-sharing only). When `true`, [`fit`] runs the
+    /// analytic **pseudobulk** velocity readout after phase 1 (identity `θ_pb` +
+    /// velocity `δ_pb` per pb node per level) and returns it in
+    /// [`FitOutput::pb_velocity`]; `δ_pb` orients the pb-DAG structure term. A
+    /// no-op (and a warning) when `feat_factor` is `None`. `false` = current
+    /// behaviour (bge and plain gem), byte-identical output.
+    pub lineage_dag: bool,
+    /// Within the lineage-DAG path, use the **learnable** pb-DAG (M2: a `W` adjacency
+    /// co-optimized with the embedding via a velocity-drift SEM + DAGMA-style
+    /// acyclicity + L1 + orientation prior) instead of the fixed velocity-oriented KNN
+    /// graph (M1). Ignored when `lineage_dag` is `false`.
+    pub dag_learnable: bool,
+    /// Smooth + confidence-gate the pb velocity readout `δ_pb` before it orients the
+    /// lineage graph / SEM drift / cell-lift (see
+    /// [`crate::fit::lineage::smooth_pb_velocity`]). Denoises `sign(δ_pb)` via θ-space
+    /// neighbour averaging — neutral on clean data, robustness on noisy real velocity.
+    /// Ignored when `lineage_dag` is `false`.
+    pub lineage_smooth: bool,
 }
 
 /// Caller-provided spec for the per-gene β-sharing feature factorization. Lengths
@@ -289,6 +309,25 @@ pub struct FitOutput {
     /// nascent state is `θ + δ` = `latent + velocity`. `0` for a cell missing either
     /// modality; `None` for a free (non-factored) model.
     pub cell_velocity: Option<Vec<f32>>,
+    /// Per-level pseudobulk velocity readout (identity `θ_pb` + velocity `δ_pb`),
+    /// present only when `lineage_dag` was set on a β-sharing model. One entry per
+    /// collapse level (coarsest→finest). Consumed by the lineage-DAG structure
+    /// term and the phase-2 cell lift. `None` otherwise.
+    pub pb_velocity: Option<Vec<PbLevelVelocity>>,
+    /// Learned pb-DAG adjacency per level (M2 learnable path only), each a dense
+    /// `[n_pb × n_pb]` row-major `W` aligned to `pb_velocity`. `None` for the fixed
+    /// (M1) path or when lineage-DAG is off. Consumed by the phase-2 cell lift to
+    /// integrate pseudotime and fate along the learned structure.
+    pub pb_dag_w: Option<Vec<Vec<f32>>>,
+    /// Phase-2 cell-lineage lift (M3): per-cell pseudotime `τ_c` + fate + ambiguity,
+    /// evaluated (no training) from the finest-level pb trajectory. `Some` only on the
+    /// lineage-DAG path with a non-empty pb velocity readout; `None` otherwise.
+    pub cell_lineage: Option<CellLineage>,
+    /// Unsupervised per-run QC diagnostics + `underfit` hygiene floor (decisiveness,
+    /// velocity coherence, fate count, ambiguity, likelihood, flag). For an agent to reject
+    /// broken runs and inspect structure — NOT a validated quality ranker. Written as
+    /// `{out}.lineage_qc.json`. `Some` alongside `cell_lineage`; `None` otherwise.
+    pub lineage_qc: Option<LineageQc>,
 }
 
 pub(crate) fn stage_params(config: &FitConfig) -> TrainingParams {

--- a/graph-embedding-util/src/fit/lift.rs
+++ b/graph-embedding-util/src/fit/lift.rs
@@ -1,0 +1,625 @@
+//! Phase-2 cell-lineage lift (M3): evaluation-only pseudotime + fate.
+//!
+//! Phase 1 shapes the shared dictionary through a directed pb-DAG (fixed M1 or
+//! learnable M2); phase 2 analytically projects every cell onto that dictionary
+//! (identity `θ_c` + velocity `δ_c`). This module lifts the pb-level structure to
+//! cells **by evaluation only** — no extra training:
+//!
+//! 1. **pb pseudotime `τ_pb`** — velocity-integration least squares on the directed
+//!    adjacency: every forward edge `i→j` asks `τ_j − τ_i ≈ step` (child one
+//!    velocity-step ahead), solved as a ridge-regularized graph-Laplacian system.
+//! 2. **pb fate `π_pb`** — absorption probabilities of an absorbing Markov chain on
+//!    the forward-oriented adjacency; the sinks (no outgoing edge) are the fates.
+//! 3. **cell lift** — landmark-assign each cell to the pb nodes by a softmax over
+//!    `‖θ_c − θ_p‖²`, then blend the pb pseudotime/fate, adding a local
+//!    along-velocity correction `⟨θ_c − θ_p, v̂_p⟩`.
+//! 4. **QC** — `ambiguity_c` = normalized entropy of the landmark weights (a cell
+//!    wedged between landmarks is flagged, never silently placed).
+//!
+//! Lives here (not in `faba`) so the pb integration + lift is unit-testable on
+//! synthetic chains; the `faba` wrapper only turns the result into parquet.
+
+use super::lineage::{dist2, row, unit_velocity};
+use super::projection::PbLevelVelocity;
+use nalgebra::{DMatrix, DVector};
+
+/// Edge weights below this are treated as absent when building the directed graph
+/// (the learnable `W` never reaches exactly zero; the fixed graph uses weight 1).
+const EDGE_EPS: f32 = 1e-6;
+/// Ridge added to the graph Laplacian's diagonal to fix its constant null space
+/// (the pseudotime is identifiable only up to an additive constant otherwise).
+const LAPLACIAN_RIDGE: f64 = 1e-3;
+/// A source is kept as a root only if it reaches ≥ this fraction of the best source's
+/// reach. A true root drains most of the graph; a single flipped branch manufactures a
+/// spurious source reaching only that branch — this ratio drops it while keeping
+/// genuine co-equal roots (distinct lineage origins each reaching a large subtree).
+const ROOT_REACH_FRAC: f64 = 0.5;
+/// Strong diagonal weight pinning each root to `τ = 0` in the Laplacian solve
+/// (a Dirichlet anchor that removes the global additive-constant freedom).
+const ROOT_ANCHOR: f64 = 1e3;
+
+/// Directed pb trajectory derived from the oriented pb-DAG of one collapse level.
+pub struct PbTrajectory {
+    pub n_pb: usize,
+    /// pb pseudotime `τ_pb`, min-max normalized to `[0, 1]`, length `n_pb`.
+    pub tau: Vec<f32>,
+    /// Root (source) pb node ids — where the velocity flow emanates (`τ ≈ 0`). A
+    /// velocity-directed DAG can have several sources, so multiple roots are allowed
+    /// (distinct lineage origins); spurious flip-sources are dropped by reach mass.
+    pub roots: Vec<usize>,
+    /// Top source's reachable fraction of the graph `[0, 1]` — the QC decisiveness score.
+    pub decisiveness: f32,
+    /// Terminal (sink) pb node ids — the fate basis (nodes with no forward edge out).
+    pub terminals: Vec<usize>,
+    /// Absorption distribution `[n_pb × n_terminals]` row-major: each pb node's fate
+    /// over the terminals (a terminal is one-hot on itself).
+    pub fate: Vec<f32>,
+    /// τ-per-embedding-distance scale (mean `|Δτ| / ‖Δθ‖` over forward edges), used
+    /// to put the per-cell along-velocity correction in the same units as `τ`.
+    pub tau_scale: f32,
+}
+
+/// Unsupervised per-run **diagnostics + hygiene floor** for lineage runs (no ground
+/// truth). An agent exploring random seeds reads this to reject broken runs
+/// (`flag == "underfit"`) and inspect a run's structure. NOTE: these are *diagnostics*,
+/// not a validated quality ranker — on the branching sim `root_decisiveness` correlated
+/// with quality on one seed batch but not another (coarse values + pipeline
+/// non-determinism), so it must not be trusted for fine seed selection. Reliable fine
+/// selection of the genuine tail needs a marker-prior root, not these scores.
+pub struct LineageQc {
+    /// Functional-backbone top-source reach `[0, 1]` — a structural summary (how much of
+    /// the backbone one source drains). A diagnostic, NOT a reliable ranker (see above).
+    pub root_decisiveness: f32,
+    /// Mean local velocity coherence (scVelo-style): how well each pb node's `v̂` agrees
+    /// with its θ-neighbours'. Meaningful for M1; ≈0 for M2 (which collapses the δ readout).
+    pub velocity_coherence: f32,
+    /// Number of inferred roots (sources). `1`–few expected; many ⇒ fragmented field.
+    pub n_roots: usize,
+    /// Number of terminal fates. Should roughly match the number of lineages.
+    pub n_terminals: usize,
+    /// Mean per-cell landmark ambiguity, `[0, 1]` (lower = more confident placement).
+    pub mean_ambiguity: f32,
+    /// Final-epoch refine loss (NCE ≈ neg-log-lik) — a fit-hygiene signal ONLY. It is
+    /// orientation-invariant, so it says nothing about trajectory quality.
+    pub likelihood: f32,
+    /// `"ok"` | `"underfit"` (no terminal structure / collapsed backbone — reject). This
+    /// binary FLOOR is the reliable part; the other fields are diagnostics, not a ranker.
+    pub flag: Box<str>,
+}
+
+/// Per-cell lineage lifted from a [`PbTrajectory`] (evaluation only).
+pub struct CellLineage {
+    /// Per-cell pseudotime `τ_c` in `[0, 1]`, length `n_cells`.
+    pub tau: Vec<f32>,
+    /// Per-cell landmark ambiguity = normalized entropy of the softmax weights in
+    /// `[0, 1]` (0 = pinned to one pb landmark, 1 = uniform over all). QC signal.
+    pub ambiguity: Vec<f32>,
+    /// Per-cell fate `[n_cells × n_terminals]` row-major (blend of pb fates).
+    pub fate: Vec<f32>,
+    /// pb node ids of the terminals (fate columns), mirrored from [`PbTrajectory`].
+    pub terminals: Vec<usize>,
+    /// Collapse level the lift ran on (finest, by default).
+    pub level: usize,
+}
+
+/// Directed edges `(i, j, w)` with `w > EDGE_EPS` from a dense `[n × n]` row-major
+/// adjacency (M2 learnable `W`, forward-masked; negatives are dropped). The lift
+/// only follows forward mass, so sub-`eps` and negative entries carry no edge.
+pub fn dense_to_edges(w: &[f32], n: usize) -> Vec<(usize, usize, f32)> {
+    let mut edges = Vec::new();
+    for (i, rowi) in w.chunks_exact(n).enumerate() {
+        for (j, &wij) in rowi.iter().enumerate() {
+            if wij > EDGE_EPS {
+                edges.push((i, j, wij));
+            }
+        }
+    }
+    edges
+}
+
+/// Boolean reachability: `reach[s*n + t]` is true when `t` is reachable from `s` over
+/// the directed edges (`s` reaches itself). `n_pb` is small, so an O(n·(n+e)) BFS from
+/// every node is fine.
+fn reachability(n: usize, edges: &[(usize, usize, f32)]) -> Vec<bool> {
+    let mut adj = vec![Vec::new(); n];
+    for &(i, j, _) in edges {
+        adj[i].push(j);
+    }
+    let mut reach = vec![false; n * n];
+    for s in 0..n {
+        reach[s * n + s] = true;
+        let mut stack = vec![s];
+        while let Some(u) = stack.pop() {
+            for &v in &adj[u] {
+                if !reach[s * n + v] {
+                    reach[s * n + v] = true;
+                    stack.push(v);
+                }
+            }
+        }
+    }
+    reach
+}
+
+/// Infer the lineage roots: the **sources** of the velocity-directed graph (nodes not
+/// reachable from outside their own strongly-connected component — where the flow
+/// emanates). Multiple sources are kept (a DAG/forest can have several lineage
+/// origins), but only those whose reachable mass is ≥ [`ROOT_REACH_FRAC`] of the best
+/// source's — dropping the spurious sources a single flipped branch would create. One
+/// representative per source SCC. Empty when there are no edges.
+fn find_roots(n: usize, edges: &[(usize, usize, f32)]) -> Vec<usize> {
+    if edges.is_empty() {
+        return Vec::new();
+    }
+    let reach = reachability(n, edges);
+    // `r` is a source iff every node that reaches `r` is also reachable from `r`
+    // (i.e. nothing outside `r`'s SCC drains into it).
+    let is_source = |r: usize| (0..n).all(|j| j == r || !reach[j * n + r] || reach[r * n + j]);
+    let mass = |r: usize| (0..n).filter(|&k| reach[r * n + k]).count();
+
+    // One representative per source SCC (skip SCC members already covered), ranked so
+    // the reach threshold is taken against the strongest source.
+    let mut sources: Vec<(usize, usize)> = Vec::new(); // (reach mass, rep node)
+    let mut covered = vec![false; n];
+    for r in 0..n {
+        if covered[r] || !is_source(r) {
+            continue;
+        }
+        for k in 0..n {
+            if reach[r * n + k] && reach[k * n + r] {
+                covered[k] = true; // same SCC
+            }
+        }
+        sources.push((mass(r), r));
+    }
+    let best = sources.iter().map(|&(m, _)| m).max().unwrap_or(0);
+    let thresh = (ROOT_REACH_FRAC * best as f64).ceil() as usize;
+    sources
+        .into_iter()
+        .filter(|&(m, _)| m >= thresh.max(1))
+        .map(|(_, r)| r)
+        .collect()
+}
+
+/// QC **decisiveness** diagnostic: reduce the graph to its *functional* backbone (each
+/// node keeps only its single strongest forward out-edge), then return the top source's
+/// reachable fraction `[0, 1]`. The reduction makes this comparable across M1's sparse
+/// velocity-KNN and M2's dense learned `W` (a dense graph trivially reaches everything,
+/// so raw reach ≡ 1 is useless). A structural summary only — its correlation with true
+/// quality is unstable across runs, so it is a diagnostic, not a reliable ranker.
+fn functional_decisiveness(n: usize, edges: &[(usize, usize, f32)]) -> f32 {
+    if edges.is_empty() {
+        return 0.0;
+    }
+    // Strongest forward out-edge per source node → a functional (≤1-out) graph.
+    let mut best_out: Vec<Option<(usize, f32)>> = vec![None; n];
+    for &(i, j, w) in edges {
+        if best_out[i].is_none_or(|(_, bw)| w > bw) {
+            best_out[i] = Some((j, w));
+        }
+    }
+    let backbone: Vec<(usize, usize, f32)> = best_out
+        .iter()
+        .enumerate()
+        .filter_map(|(i, e)| e.map(|(j, w)| (i, j, w)))
+        .collect();
+    let reach = reachability(n, &backbone);
+    let best = (0..n)
+        .map(|s| (0..n).filter(|&k| reach[s * n + k]).count())
+        .max()
+        .unwrap_or(0);
+    best as f32 / n.max(1) as f32
+}
+
+/// Mean local velocity coherence (scVelo-style "velocity confidence"): the average, over
+/// pb nodes, of the mean cosine between a node's unit velocity `v̂` and its θ-KNN
+/// neighbours' — an unsupervised measure of how smooth/coherent the velocity field is.
+fn velocity_coherence(vel: &PbLevelVelocity, h: usize, knn: usize) -> f32 {
+    let n = vel.n_pb;
+    if n < 2 {
+        return 0.0;
+    }
+    let (vhat, has_vel) = super::lineage::unit_velocity(vel, h);
+    let k = knn.min(n - 1);
+    let mut sum = 0f32;
+    let mut cnt = 0usize;
+    for i in 0..n {
+        if !has_vel[i] {
+            continue;
+        }
+        let ti = row(&vel.theta, i, h);
+        let mut nbrs: Vec<(f32, usize)> = (0..n)
+            .filter(|&j| j != i)
+            .map(|j| (dist2(ti, row(&vel.theta, j, h)), j))
+            .collect();
+        nbrs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        let vi = row(&vhat, i, h);
+        let (mut acc, mut m) = (0f32, 0usize);
+        for &(_, j) in nbrs.iter().take(k) {
+            if has_vel[j] {
+                let vj = row(&vhat, j, h);
+                acc += (0..h).map(|c| vi[c] * vj[c]).sum::<f32>();
+                m += 1;
+            }
+        }
+        if m > 0 {
+            sum += acc / m as f32;
+            cnt += 1;
+        }
+    }
+    if cnt > 0 {
+        sum / cnt as f32
+    } else {
+        0.0
+    }
+}
+
+/// Multi-source hop distance from the root set over the **undirected** edge set
+/// (`u32::MAX` for nodes disconnected from every root). Each node's distance is to its
+/// nearest root, so in a multi-root forest every subtree is measured from its own origin.
+fn root_distance(n: usize, edges: &[(usize, usize, f32)], roots: &[usize]) -> Vec<u32> {
+    let mut adj = vec![Vec::new(); n];
+    for &(i, j, _) in edges {
+        adj[i].push(j);
+        adj[j].push(i);
+    }
+    let mut dist = vec![u32::MAX; n];
+    let mut q = std::collections::VecDeque::new();
+    for &r in roots {
+        dist[r] = 0;
+        q.push_back(r);
+    }
+    while let Some(u) = q.pop_front() {
+        for &v in &adj[u] {
+            if dist[v] == u32::MAX {
+                dist[v] = dist[u] + 1;
+                q.push_back(v);
+            }
+        }
+    }
+    dist
+}
+
+/// Re-orient every edge to point *away* from the roots — from the endpoint nearer a
+/// root to the farther one. This overrides a locally-flipped velocity edge with the
+/// globally-consistent root geometry (the actual fix for whole-subtree inversions);
+/// equal-distance edges keep their original direction.
+fn reorient_by_root(edges: &[(usize, usize, f32)], dist: &[u32]) -> Vec<(usize, usize, f32)> {
+    edges
+        .iter()
+        .map(|&(i, j, w)| {
+            if dist[j] >= dist[i] {
+                (i, j, w)
+            } else {
+                (j, i, w)
+            }
+        })
+        .collect()
+}
+
+/// Velocity-integration least squares: every forward edge `i→j` contributes
+/// `w_ij (τ_j − τ_i − step)²`; minimizing gives the ridge-regularized graph-Laplacian
+/// system `(L + εI) τ = g`. `L` is the weighted Laplacian, `g` the net forward push.
+/// Each root is pinned to `τ ≈ 0` by a strong diagonal anchor ([`ROOT_ANCHOR`]),
+/// removing the additive-constant freedom. Returns raw `τ`; `[0.0; n]` with no edges.
+fn integrate_pseudotime(
+    n: usize,
+    edges: &[(usize, usize, f32)],
+    step: f32,
+    roots: &[usize],
+) -> Vec<f64> {
+    if edges.is_empty() {
+        return vec![0.0; n];
+    }
+    let mut m = DMatrix::<f64>::zeros(n, n);
+    let mut g = DVector::<f64>::zeros(n);
+    for &(i, j, w) in edges {
+        let w = f64::from(w);
+        let s = f64::from(step);
+        m[(i, i)] += w;
+        m[(j, j)] += w;
+        m[(i, j)] -= w;
+        m[(j, i)] -= w;
+        g[j] += w * s;
+        g[i] -= w * s;
+    }
+    for k in 0..n {
+        m[(k, k)] += LAPLACIAN_RIDGE;
+    }
+    for &r in roots {
+        m[(r, r)] += ROOT_ANCHOR; // Dirichlet anchor τ_r → 0 (g[r] stays 0)
+    }
+    m.lu()
+        .solve(&g)
+        .map(|v| v.iter().copied().collect())
+        .unwrap_or_else(|| vec![0.0; n])
+}
+
+/// Absorbing-Markov-chain fate. Sinks (no forward out-edge) are the absorbing
+/// terminals; every transient node's fate is its absorption distribution
+/// `B = (I − Q)^{-1} R`. Returns `(terminals, fate[n × k])` row-major, terminals
+/// one-hot on themselves. Empty terminals ⇒ `(vec![], vec![])`.
+fn absorbing_fate(n: usize, edges: &[(usize, usize, f32)]) -> (Vec<usize>, Vec<f32>) {
+    // Forward out-weight per node; a node with none is a sink (terminal).
+    let mut out_w = vec![0f64; n];
+    let mut adj = DMatrix::<f64>::zeros(n, n);
+    for &(i, j, w) in edges {
+        let w = f64::from(w);
+        adj[(i, j)] += w;
+        out_w[i] += w;
+    }
+    let terminals: Vec<usize> = (0..n).filter(|&i| out_w[i] < f64::from(EDGE_EPS)).collect();
+    let k = terminals.len();
+    if k == 0 || k == n {
+        // No structure to absorb into (or everything is a sink): no fate.
+        return (Vec::new(), Vec::new());
+    }
+    let term_col: std::collections::HashMap<usize, usize> =
+        terminals.iter().enumerate().map(|(c, &t)| (t, c)).collect();
+    let transient: Vec<usize> = (0..n).filter(|i| !term_col.contains_key(i)).collect();
+    let t_row: std::collections::HashMap<usize, usize> =
+        transient.iter().enumerate().map(|(r, &i)| (i, r)).collect();
+    let nt = transient.len();
+
+    // Row-normalized transition blocks among transient (Q) and into terminals (R).
+    let mut q = DMatrix::<f64>::zeros(nt, nt);
+    let mut r = DMatrix::<f64>::zeros(nt, k);
+    for (ri, &i) in transient.iter().enumerate() {
+        let denom = out_w[i];
+        if denom <= 0.0 {
+            continue;
+        }
+        for j in 0..n {
+            let p = adj[(i, j)] / denom;
+            if p == 0.0 {
+                continue;
+            }
+            if let Some(&col) = term_col.get(&j) {
+                r[(ri, col)] += p;
+            } else if let Some(&rj) = t_row.get(&j) {
+                q[(ri, rj)] += p;
+            }
+        }
+    }
+
+    // B = (I − Q)^{-1} R. A tiny ridge guards residual cycles (M2 acyclicity is
+    // soft, so Q may not be strictly substochastic on every row).
+    let mut im_q = DMatrix::<f64>::identity(nt, nt) - &q;
+    for d in 0..nt {
+        im_q[(d, d)] += LAPLACIAN_RIDGE;
+    }
+    let b = match im_q.lu().solve(&r) {
+        Some(b) => b,
+        None => return (terminals, Vec::new()),
+    };
+
+    let mut fate = vec![0f32; n * k];
+    for (&t, &col) in &term_col {
+        fate[t * k + col] = 1.0; // terminal → one-hot on itself
+    }
+    for (ri, &i) in transient.iter().enumerate() {
+        for col in 0..k {
+            fate[i * k + col] = b[(ri, col)] as f32;
+        }
+    }
+    (terminals, fate)
+}
+
+/// Build the [`PbTrajectory`] for one level from its velocity readout and directed
+/// edges (dense `W` → [`dense_to_edges`] for M2, fixed-lineage edges for M1).
+pub fn pb_trajectory(
+    vel: &PbLevelVelocity,
+    edges: &[(usize, usize, f32)],
+    h: usize,
+    step: f32,
+) -> PbTrajectory {
+    let n = vel.n_pb;
+
+    // Root-anchoring stage: infer the source(s) of the velocity-directed graph, then
+    // re-orient every edge to point away from the nearest root. This overrides
+    // locally-flipped δ with the globally-consistent root geometry, so a whole subtree
+    // can no longer integrate backward. All downstream steps use the re-oriented edges.
+    let roots = find_roots(n, edges);
+    let dist = root_distance(n, edges, &roots);
+    let oriented = reorient_by_root(edges, &dist);
+    let decisiveness = functional_decisiveness(n, &oriented);
+
+    let raw = integrate_pseudotime(n, &oriented, step, &roots);
+
+    // Min-max normalize τ to [0, 1] (roots sit at ≈ the minimum by construction).
+    let (lo, hi) = raw
+        .iter()
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(l, h), &x| {
+            (l.min(x), h.max(x))
+        });
+    let span = (hi - lo).max(1e-12);
+    let tau: Vec<f32> = raw.iter().map(|&x| ((x - lo) / span) as f32).collect();
+
+    // τ-per-distance scale: mean |Δτ| / ‖Δθ‖ over the re-oriented edges (1 when none).
+    let mut num = 0f64;
+    let mut den = 0f64;
+    for &(i, j, _) in &oriented {
+        let dt = (f64::from(tau[j]) - f64::from(tau[i])).abs();
+        let ti = row(&vel.theta, i, h);
+        let tj = row(&vel.theta, j, h);
+        let dl = ti
+            .iter()
+            .zip(tj)
+            .map(|(a, b)| (f64::from(*a) - f64::from(*b)).powi(2))
+            .sum::<f64>()
+            .sqrt();
+        if dl > 1e-8 {
+            num += dt;
+            den += dl;
+        }
+    }
+    let tau_scale = if den > 0.0 { (num / den) as f32 } else { 1.0 };
+
+    let (terminals, fate) = absorbing_fate(n, &oriented);
+    PbTrajectory {
+        n_pb: n,
+        tau,
+        roots,
+        decisiveness,
+        terminals,
+        fate,
+        tau_scale,
+    }
+}
+
+/// Assemble the unsupervised [`LineageQc`] diagnostics for one run from its trajectory,
+/// velocity readout, cell lift, and final refine loss. Bakes the binary `underfit` floor
+/// in; the remaining fields are diagnostics (not a validated ranker). `knn` = lineage KNN.
+pub fn compute_lineage_qc(
+    traj: &PbTrajectory,
+    vel: &PbLevelVelocity,
+    lin: &CellLineage,
+    likelihood: f32,
+    h: usize,
+    knn: usize,
+) -> LineageQc {
+    let coherence = velocity_coherence(vel, h, knn);
+    let mean_ambiguity = if lin.ambiguity.is_empty() {
+        0.0
+    } else {
+        lin.ambiguity.iter().sum::<f32>() / lin.ambiguity.len() as f32
+    };
+    // Binary FLOOR only — reject a run with no terminal structure or a collapsed
+    // backbone (decisiveness ≈ 0). NOT gated on coherence (M2 collapses δ while its
+    // `W`-trajectory is great). Everything else is `ok`. The other fields are diagnostics
+    // — decisiveness is NOT a reliable fine ranker (coarse + pipeline non-determinism).
+    let flag = if traj.terminals.is_empty() || traj.decisiveness < 0.12 {
+        "underfit"
+    } else {
+        "ok"
+    };
+    LineageQc {
+        root_decisiveness: traj.decisiveness,
+        velocity_coherence: coherence,
+        n_roots: traj.roots.len(),
+        n_terminals: traj.terminals.len(),
+        mean_ambiguity,
+        likelihood,
+        flag: flag.into(),
+    }
+}
+
+/// Lift the pb trajectory to cells: landmark-assign each cell `θ_c` to the pb nodes
+/// `θ_p` by a softmax over `‖θ_c − θ_p‖²`, then blend `τ_pb` (plus a local
+/// along-velocity correction) and `π_pb`. Evaluation only — no training. Cells are
+/// independent, so the per-cell work is rayon-parallel (like the phase-2 projection
+/// it follows).
+///
+/// `theta_c` is the phase-2 per-cell identity `[n_cells × h]` row-major (raw `θ`).
+// Loops index several parallel `[n_pb × h]` / `[n_pb × k]` / `[· × k]` buffers at
+// stride `h`/`k` (θ_pb, v̂_p, τ_pb, fate) by node/terminal id — a plain range loop
+// reads clearer than juggling zipped chunks in lockstep.
+#[allow(clippy::needless_range_loop)]
+pub fn lift_cells(
+    theta_c: &[f32],
+    n_cells: usize,
+    vel: &PbLevelVelocity,
+    traj: &PbTrajectory,
+    h: usize,
+    level: usize,
+) -> CellLineage {
+    use rayon::prelude::*;
+
+    let n_pb = vel.n_pb;
+    let k = traj.terminals.len();
+    let (vhat, _) = unit_velocity(vel, h); // per-node unit v̂ (zero rows where ‖δ‖≈0)
+
+    // Softmax bandwidth: mean nearest-landmark squared distance across cells (a
+    // scale that adapts to how tightly the pb landmarks tile the latent space).
+    let near_sum: f64 = (0..n_cells)
+        .into_par_iter()
+        .map(|c| {
+            let tc = row(theta_c, c, h);
+            let best = (0..n_pb)
+                .map(|p| dist2(tc, row(&vel.theta, p, h)))
+                .fold(f32::INFINITY, f32::min);
+            if best.is_finite() {
+                f64::from(best)
+            } else {
+                0.0
+            }
+        })
+        .sum();
+    let bandwidth = ((near_sum / n_cells.max(1) as f64) as f32).max(1e-6);
+    let ln_pb = (n_pb as f32).max(2.0).ln();
+
+    // One parallel pass per cell → (τ_c, ambiguity_c, fate_row). For each landmark the
+    // difference `θ_c − θ_p` is walked ONCE, yielding both the softmax distance `d²`
+    // and the along-velocity projection `⟨θ_c − θ_p, v̂_p⟩`.
+    let per_cell: Vec<(f32, f32, Vec<f32>)> = (0..n_cells)
+        .into_par_iter()
+        .map(|c| {
+            let tc = row(theta_c, c, h);
+            let mut d2 = vec![0f32; n_pb];
+            let mut proj = vec![0f32; n_pb];
+            for p in 0..n_pb {
+                let tp = row(&vel.theta, p, h);
+                let vp = row(&vhat, p, h);
+                let (mut dd, mut pj) = (0f32, 0f32);
+                for d in 0..h {
+                    let diff = tc[d] - tp[d];
+                    dd += diff * diff;
+                    pj += diff * vp[d];
+                }
+                d2[p] = dd;
+                proj[p] = pj;
+            }
+            // Softmax over −d²/bandwidth (shift by the min for numerical stability).
+            let dmin = d2.iter().copied().fold(f32::INFINITY, f32::min);
+            let mut w = vec![0f32; n_pb];
+            let mut wsum = 0f32;
+            for p in 0..n_pb {
+                let e = (-(d2[p] - dmin) / bandwidth).exp();
+                w[p] = e;
+                wsum += e;
+            }
+            let mut fate_row = vec![0f32; k];
+            if wsum <= 0.0 {
+                return (0.0, 0.0, fate_row);
+            }
+            let (mut tau_c, mut ent) = (0f32, 0f32);
+            for p in 0..n_pb {
+                let m = w[p] / wsum;
+                if m > 1e-12 {
+                    ent -= m * m.ln();
+                }
+                tau_c += m * (traj.tau[p] + proj[p] * traj.tau_scale);
+                for col in 0..k {
+                    fate_row[col] += m * traj.fate[p * k + col];
+                }
+            }
+            (
+                tau_c.clamp(0.0, 1.0),
+                (ent / ln_pb).clamp(0.0, 1.0),
+                fate_row,
+            )
+        })
+        .collect();
+
+    let mut tau = vec![0f32; n_cells];
+    let mut ambiguity = vec![0f32; n_cells];
+    let mut fate = vec![0f32; n_cells * k];
+    for (c, (t, a, fr)) in per_cell.into_iter().enumerate() {
+        tau[c] = t;
+        ambiguity[c] = a;
+        if k > 0 {
+            fate[c * k..c * k + k].copy_from_slice(&fr);
+        }
+    }
+
+    CellLineage {
+        tau,
+        ambiguity,
+        fate,
+        terminals: traj.terminals.clone(),
+        level,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/fit/lift/tests.rs
+++ b/graph-embedding-util/src/fit/lift/tests.rs
@@ -1,0 +1,147 @@
+//! Unit tests for the phase-2 cell-lineage lift (M3).
+
+use super::{dense_to_edges, lift_cells, pb_trajectory};
+use crate::fit::projection::PbLevelVelocity;
+
+/// A linear chain 0→1→2→3 in a 1-D latent (θ = 0,1,2,3), velocity all +1. The
+/// integrated pseudotime must be monotone increasing along the chain and the
+/// single sink (node 3) the only terminal.
+#[test]
+fn linear_chain_pseudotime_is_monotone() {
+    let h = 1;
+    let vel = PbLevelVelocity {
+        n_pb: 4,
+        theta: vec![0.0, 1.0, 2.0, 3.0],
+        delta: vec![1.0, 1.0, 1.0, 1.0],
+    };
+    let edges = vec![(0, 1, 1.0), (1, 2, 1.0), (2, 3, 1.0)];
+    let traj = pb_trajectory(&vel, &edges, h, 1.0);
+
+    assert!(
+        traj.tau[0] < traj.tau[1] && traj.tau[1] < traj.tau[2] && traj.tau[2] < traj.tau[3],
+        "pseudotime should increase along the chain: {:?}",
+        traj.tau
+    );
+    assert!(
+        (traj.tau[0] - 0.0).abs() < 1e-4,
+        "root τ≈0 ({})",
+        traj.tau[0]
+    );
+    assert!(
+        (traj.tau[3] - 1.0).abs() < 1e-4,
+        "leaf τ≈1 ({})",
+        traj.tau[3]
+    );
+    assert_eq!(traj.terminals, vec![3], "only node 3 is a sink");
+    assert_eq!(traj.roots, vec![0], "node 0 is the only source/root");
+}
+
+/// Two disjoint forward chains (0→1→2 and 3→4→5) are two separate lineages, so the
+/// root stage must return BOTH sources — a velocity DAG can have several origins.
+#[test]
+fn multiple_roots_for_disjoint_lineages() {
+    let h = 1;
+    let vel = PbLevelVelocity {
+        n_pb: 6,
+        theta: vec![0.0, 1.0, 2.0, 10.0, 11.0, 12.0],
+        delta: vec![1.0; 6],
+    };
+    let edges = vec![(0, 1, 1.0), (1, 2, 1.0), (3, 4, 1.0), (4, 5, 1.0)];
+    let traj = pb_trajectory(&vel, &edges, h, 1.0);
+    let mut roots = traj.roots.clone();
+    roots.sort_unstable();
+    assert_eq!(roots, vec![0, 3], "both chain heads are roots");
+}
+
+/// A redundant (k=2) forward chain with ONE edge flipped backward (2→3 given as 3→2).
+/// Node 3 still has a forward in-edge (1→3), so it is NOT a spurious source — the root
+/// stays node 0, and the root-distance re-orientation flips the bad edge back, so the
+/// integrated pseudotime is monotone again.
+#[test]
+fn reorientation_repairs_a_flipped_edge() {
+    let h = 1;
+    let vel = PbLevelVelocity {
+        n_pb: 5,
+        theta: vec![0.0, 1.0, 2.0, 3.0, 4.0],
+        delta: vec![1.0; 5],
+    };
+    // Forward chain + skip edges, but 2→3 is CORRUPTED to 3→2.
+    let edges = vec![
+        (0, 1, 1.0),
+        (1, 2, 1.0),
+        (3, 2, 1.0), // flipped (should be 2→3)
+        (3, 4, 1.0),
+        (0, 2, 1.0),
+        (1, 3, 1.0),
+        (2, 4, 1.0),
+    ];
+    let traj = pb_trajectory(&vel, &edges, h, 1.0);
+    assert_eq!(traj.roots, vec![0], "node 0 remains the sole root");
+    assert!(
+        (0..4).all(|i| traj.tau[i] < traj.tau[i + 1]),
+        "pseudotime should be monotone after flip repair: {:?}",
+        traj.tau
+    );
+}
+
+/// A bifurcation 0→1, 1→2, 1→3 with leaves 2,3. Both leaves are terminals; the
+/// root's fate splits between them; each leaf is one-hot on itself.
+#[test]
+fn bifurcation_has_two_fates() {
+    let h = 1;
+    let vel = PbLevelVelocity {
+        n_pb: 4,
+        theta: vec![0.0, 1.0, 2.0, 2.0],
+        delta: vec![1.0, 1.0, 1.0, 1.0],
+    };
+    let edges = vec![(0, 1, 1.0), (1, 2, 1.0), (1, 3, 1.0)];
+    let traj = pb_trajectory(&vel, &edges, h, 1.0);
+
+    assert_eq!(traj.terminals, vec![2, 3], "leaves 2 and 3 are terminals");
+    let k = 2;
+    // Leaf 2 one-hot on column 0, leaf 3 one-hot on column 1.
+    assert!((traj.fate[2 * k] - 1.0).abs() < 1e-4);
+    assert!((traj.fate[3 * k + 1] - 1.0).abs() < 1e-4);
+    // Root reaches both leaves (non-degenerate split).
+    assert!(
+        traj.fate[0] > 0.1 && traj.fate[1] > 0.1,
+        "root fate splits: {:?}",
+        &traj.fate[0..2]
+    );
+}
+
+/// Cells sitting exactly on the pb landmarks inherit their pseudotime; a cell at
+/// the root end is earlier than a cell at the leaf end.
+#[test]
+fn cell_lift_orders_cells_along_chain() {
+    let h = 1;
+    let vel = PbLevelVelocity {
+        n_pb: 4,
+        theta: vec![0.0, 1.0, 2.0, 3.0],
+        delta: vec![1.0, 1.0, 1.0, 1.0],
+    };
+    let edges = vec![(0, 1, 1.0), (1, 2, 1.0), (2, 3, 1.0)];
+    let traj = pb_trajectory(&vel, &edges, h, 1.0);
+
+    // Three cells: near root (θ=0.1), middle (θ=1.5), near leaf (θ=2.9).
+    let theta_c = vec![0.1f32, 1.5, 2.9];
+    let lin = lift_cells(&theta_c, 3, &vel, &traj, h, 0);
+    assert!(
+        lin.tau[0] < lin.tau[1] && lin.tau[1] < lin.tau[2],
+        "lifted cell pseudotime should track the chain: {:?}",
+        lin.tau
+    );
+    // Ambiguity is in [0,1]; a cell right on a landmark is less ambiguous than one
+    // wedged between two.
+    assert!(lin.ambiguity.iter().all(|&a| (0.0..=1.0).contains(&a)));
+}
+
+/// `dense_to_edges` keeps only strictly-positive entries (forward mass); zeros and
+/// negatives (a backward-masked learnable `W`) carry no edge.
+#[test]
+fn dense_to_edges_keeps_forward_mass_only() {
+    // 3×3: 0→1 = 0.5, 1→2 = 0.3, 2→0 = −0.2 (dropped), diagonal 0.
+    let w = vec![0.0, 0.5, 0.0, 0.0, 0.0, 0.3, -0.2, 0.0, 0.0];
+    let edges = dense_to_edges(&w, 3);
+    assert_eq!(edges, vec![(0, 1, 0.5), (1, 2, 0.3)]);
+}

--- a/graph-embedding-util/src/fit/lineage.rs
+++ b/graph-embedding-util/src/fit/lineage.rs
@@ -1,0 +1,196 @@
+//! Fixed pseudobulk lineage structure for the velocity-drift SEM residual (M1).
+//!
+//! Given the analytic pb-level velocity readout ([`PbLevelVelocity`]: identity
+//! `θ_pb` + velocity `δ_pb` per pb node per collapse level), build a **directed**
+//! neighbour graph over the pb nodes of each level, oriented by velocity: an edge
+//! `i → j` is kept when `j` is velocity-forward of `i` (`⟨θ_j − θ_i, δ_i⟩ > 0`).
+//! This fixed structure feeds the velocity-drift SEM residual
+//! `Σ_{i→j} w_ij ‖ê_j − ê_i − s·v̂_i‖²` added to phase-1 training (see
+//! `crate::training::PbSemTerm`). M2 replaces this fixed graph with a learnable
+//! DAGMA `W`; the residual form is unchanged.
+
+use super::projection::PbLevelVelocity;
+
+/// Nearest pb neighbours considered per node when building the directed graph.
+pub const DEFAULT_LINEAGE_KNN: usize = 10;
+/// Velocity-drift step `s` in the SEM residual `ê_j − ê_i − s·v̂_i`.
+pub const DEFAULT_SEM_STEP: f32 = 1.0;
+/// Weight `λ_sem` multiplying the SEM residual in the composite loss.
+pub const DEFAULT_SEM_WEIGHT: f32 = 0.1;
+/// θ-space neighbours averaged when smoothing the pb velocity field.
+pub const DEFAULT_SMOOTH_KNN: usize = 10;
+
+/// Fixed directed lineage structure over the pb nodes of one collapse level.
+/// Edges are `(parent i, child j, weight)` with `j` velocity-forward of `i`;
+/// `velocity` is the per-node **unit** drift `v̂` flattened `[n_pb × h]` (zero
+/// rows for nodes whose `‖δ‖ ≈ 0`, which emit no outgoing edges).
+pub struct PbLineageLevel {
+    pub n_pb: usize,
+    pub edges: Vec<(u32, u32, f32)>,
+    pub velocity: Vec<f32>,
+}
+
+impl PbLineageLevel {
+    /// Dense `[n_pb × n_pb]` row-major adjacency: `[i·n + j] = w` for edge `(i→j)`,
+    /// `0` elsewhere. Warm-starts the learnable pb-DAG `W` (M2) from this fixed
+    /// velocity-oriented structure so SGD refines from a correctly-oriented start
+    /// instead of zeros. The `(i, j)` layout matches `PbDagTerm`'s forward mask.
+    #[must_use]
+    pub fn to_dense(&self) -> Vec<f32> {
+        let n = self.n_pb;
+        let mut w = vec![0f32; n * n];
+        for &(i, j, wt) in &self.edges {
+            w[i as usize * n + j as usize] = wt;
+        }
+        w
+    }
+}
+
+/// Build one [`PbLineageLevel`] per collapse level (same order as `pb_vel`).
+pub fn build_pb_lineage(pb_vel: &[PbLevelVelocity], h: usize, knn: usize) -> Vec<PbLineageLevel> {
+    pb_vel
+        .iter()
+        .map(|lvl| build_one_level(lvl, h, knn))
+        .collect()
+}
+
+/// Smooth + confidence-gate the pb velocity field of every level (see
+/// [`smooth_pb_velocity`]). θ is unchanged; only δ is denoised. Applied to the pb
+/// readout before it orients the lineage graph / SEM drift / cell-lift, so all
+/// consumers see the same stabilized velocity.
+pub fn smooth_pb_velocity_levels(
+    pb_vel: &[PbLevelVelocity],
+    h: usize,
+    knn: usize,
+) -> Vec<PbLevelVelocity> {
+    pb_vel
+        .iter()
+        .map(|lvl| smooth_pb_velocity(lvl, h, knn))
+        .collect()
+}
+
+/// Velocity-graph smoothing of one level's pb velocity field: replace each node's raw δ
+/// with a Gaussian-kernel average of its θ-space KNN neighbours' δ,
+/// `v̄ᵢ = Σ_{j∈KNN(i)∪{i}} exp(−d²ᵢⱼ/σ²ᵢ)·δⱼ`. Summing **raw** δ (not unit v̂) lets
+/// higher-magnitude — more confident — neighbours dominate. θ is untouched.
+///
+/// Non-circular: uses only δ + θ geometry, never pseudotime — so it denoises the
+/// exogenous velocity anchor without dissolving the independence that breaks the
+/// structure-from-embedding circularity. Opt-in (`--lineage-smooth`); on the clean sim
+/// it is a wash (no noise to remove, and it can blur branch-point velocity), so the
+/// payoff is on noisy real spliced/unspliced data.
+pub fn smooth_pb_velocity(vel: &PbLevelVelocity, h: usize, knn: usize) -> PbLevelVelocity {
+    let n = vel.n_pb;
+    if n < 2 {
+        return PbLevelVelocity {
+            n_pb: n,
+            theta: vel.theta.clone(),
+            delta: vel.delta.clone(),
+        };
+    }
+    let theta = &vel.theta;
+    let k = knn.min(n - 1);
+
+    // Gaussian-kernel average over each node's k nearest θ-neighbours (self included).
+    let mut delta = vec![0f32; n * h];
+    for i in 0..n {
+        let mut nbrs = knn_sorted(theta, i, n, h);
+        nbrs.truncate(k);
+        // Adaptive bandwidth σ² = mean squared distance to the k neighbours (>0).
+        let sig2 = (nbrs.iter().map(|&(d, _)| d).sum::<f32>() / k.max(1) as f32).max(1e-8);
+        // Self contributes weight 1 (d = 0); neighbours a Gaussian of their θ distance.
+        let out = &mut delta[i * h..i * h + h];
+        out.copy_from_slice(row(&vel.delta, i, h));
+        for &(d, j) in &nbrs {
+            let w = (-d / sig2).exp();
+            let dj = row(&vel.delta, j, h);
+            for c in 0..h {
+                out[c] += w * dj[c];
+            }
+        }
+    }
+    PbLevelVelocity {
+        n_pb: n,
+        theta: theta.clone(),
+        delta,
+    }
+}
+
+/// Per-node unit velocity `v̂` (‖·‖-normalized `δ`; zero rows with `has_vel = false`
+/// where `‖δ‖ ≈ 0`, orientation undefined). Shared by the lineage graph, the pb-DAG
+/// term, and the cell lift so all orient off the identical velocity field.
+pub(crate) fn unit_velocity(lvl: &PbLevelVelocity, h: usize) -> (Vec<f32>, Vec<bool>) {
+    let n = lvl.n_pb;
+    let mut velocity = vec![0f32; n * h];
+    let mut has_vel = vec![false; n];
+    for i in 0..n {
+        let d = row(&lvl.delta, i, h);
+        let nrm = d.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if nrm > 1e-8 {
+            for k in 0..h {
+                velocity[i * h + k] = d[k] / nrm;
+            }
+            has_vel[i] = true;
+        }
+    }
+    (velocity, has_vel)
+}
+
+/// The other `n-1` nodes ranked by θ distance to node `i` (nearest first), as
+/// `(dist², j)`. Callers `take(k)`/`truncate(k)` the neighbour count they need.
+fn knn_sorted(theta: &[f32], i: usize, n: usize, h: usize) -> Vec<(f32, usize)> {
+    let ti = row(theta, i, h);
+    let mut nbrs: Vec<(f32, usize)> = (0..n)
+        .filter(|&j| j != i)
+        .map(|j| (dist2(ti, row(theta, j, h)), j))
+        .collect();
+    nbrs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    nbrs
+}
+
+/// Row `i` (length `h`) of a flattened `[n × h]` row-major buffer.
+pub(crate) fn row(m: &[f32], i: usize, h: usize) -> &[f32] {
+    &m[i * h..(i + 1) * h]
+}
+
+/// Squared Euclidean distance between two equal-length rows.
+pub(crate) fn dist2(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
+}
+
+// The node loops index several parallel `[n × h]` buffers at stride `h` (θ, δ,
+// v̂) by node id — a plain range loop is clearer than juggling zipped chunks.
+#[allow(clippy::needless_range_loop)]
+fn build_one_level(lvl: &PbLevelVelocity, h: usize, knn: usize) -> PbLineageLevel {
+    let n = lvl.n_pb;
+    let theta = &lvl.theta;
+    let (velocity, has_vel) = unit_velocity(lvl, h);
+
+    let k = knn.min(n.saturating_sub(1));
+    let mut edges = Vec::new();
+    for i in 0..n {
+        if !has_vel[i] {
+            continue; // no orientation → no outgoing edges
+        }
+        let ti = row(theta, i, h);
+        let nbrs = knn_sorted(theta, i, n, h); // nearest by identity distance
+        let vi = row(&velocity, i, h);
+        for &(_, j) in nbrs.iter().take(k) {
+            // Keep i → j only when j is velocity-forward of i.
+            let tj = row(theta, j, h);
+            let fwd: f32 = (0..h).map(|c| (tj[c] - ti[c]) * vi[c]).sum();
+            if fwd > 0.0 {
+                edges.push((i as u32, j as u32, 1.0f32));
+            }
+        }
+    }
+
+    PbLineageLevel {
+        n_pb: n,
+        edges,
+        velocity,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/fit/lineage/tests.rs
+++ b/graph-embedding-util/src/fit/lineage/tests.rs
@@ -1,0 +1,87 @@
+//! Unit tests for the fixed pb-lineage graph builder.
+
+use super::{build_pb_lineage, smooth_pb_velocity, PbLineageLevel};
+use crate::fit::projection::PbLevelVelocity;
+
+/// Velocity smoothing flips a sign-corrupted node back to agree with its neighbours,
+/// leaving θ untouched.
+#[test]
+fn smoothing_repairs_corrupted_sign() {
+    let h = 2;
+    // Four nodes on a line at x=0..3, velocity +x, but node 2 is CORRUPTED to −x. Its
+    // +x neighbours should outvote the corrupted self after smoothing.
+    let theta = vec![0.0, 0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0];
+    let delta = vec![
+        1.0, 0.0, // n0 +x
+        1.0, 0.0, // n1 +x
+        -1.0, 0.0, // n2 CORRUPTED −x
+        1.0, 0.0, // n3 +x
+    ];
+    let vel = PbLevelVelocity {
+        n_pb: 4,
+        theta,
+        delta,
+    };
+    let sm = smooth_pb_velocity(&vel, h, 3);
+
+    let d2x = sm.delta[2 * h];
+    assert!(d2x > 0.0, "node 2 sign not repaired (δx = {d2x})");
+    assert_eq!(sm.theta, vel.theta, "θ must be untouched");
+}
+
+/// Three pb nodes on a line at x = 0, 1, 2 (signal in dim 0), each with velocity
+/// pointing +x. Every retained edge must run from a lower x to a higher x
+/// (velocity-forward), and no backward edge may appear.
+#[test]
+fn edges_are_velocity_forward() {
+    let h = 2;
+    // θ_pb: positions along dim 0.
+    let theta = vec![
+        0.0, 0.0, /*n0*/ 1.0, 0.0, /*n1*/ 2.0, 0.0, /*n2*/
+    ];
+    // δ_pb: all point +dim0.
+    let delta = vec![1.0, 0.0, 1.0, 0.0, 1.0, 0.0];
+    let lvl = PbLevelVelocity {
+        n_pb: 3,
+        theta: theta.clone(),
+        delta,
+    };
+    let out = build_pb_lineage(&[lvl], h, 2);
+    let g: &PbLineageLevel = &out[0];
+    assert!(!g.edges.is_empty(), "expected forward edges");
+    for &(i, j, w) in &g.edges {
+        let xi = theta[i as usize * h];
+        let xj = theta[j as usize * h];
+        assert!(xj > xi, "edge {i}->{j} not forward (x {xi} -> {xj})");
+        assert!(w > 0.0);
+    }
+    // Unit velocity rows.
+    for i in 0..3 {
+        let v = &g.velocity[i * h..(i + 1) * h];
+        let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((n - 1.0).abs() < 1e-5, "velocity row {i} not unit ({n})");
+    }
+}
+
+/// A node with ~zero velocity has no defined orientation, so it emits no
+/// outgoing edges (and its unit-velocity row stays zero).
+#[test]
+fn zero_velocity_node_has_no_outgoing_edges() {
+    let h = 2;
+    let theta = vec![0.0, 0.0, 1.0, 0.0, 2.0, 0.0];
+    // Node 1 has zero velocity; 0 and 2 point +x.
+    let delta = vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let lvl = PbLevelVelocity {
+        n_pb: 3,
+        theta,
+        delta,
+    };
+    let out = build_pb_lineage(&[lvl], h, 2);
+    let g = &out[0];
+    assert!(
+        g.edges.iter().all(|&(i, _, _)| i != 1),
+        "zero-velocity node 1 should emit no outgoing edges"
+    );
+    let v1 = &g.velocity[h..2 * h];
+    assert_eq!(v1, &[0.0, 0.0]);
+}

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -3,13 +3,17 @@
 //! [`UnifiedData`] (so this crate stays free of file/path concerns).
 
 mod config;
-mod projection;
+pub mod lift;
+pub mod lineage;
+pub mod projection;
 mod samplers;
 
 pub use config::{
     load_feature_network, FeatFactorSpec, FeatureNetworkArgs, FeatureNetworkConfig, FitConfig,
     FitOutput,
 };
+pub use lift::{CellLineage, LineageQc};
+pub use projection::PbLevelVelocity;
 
 use crate::coarsen::{identity_axis, AxisCoarsenings};
 use crate::data::UnifiedData;
@@ -17,7 +21,8 @@ use crate::loss::{build_stratified_sampler, PerBatchStratifiedCellSampler, Strat
 use crate::model::{FactoredInit, JointEmbedModel, ModelArgs, ModelInit, ShareFeaturesArgs};
 use crate::stop::setup_stop_handler;
 use crate::training::{
-    train_composite, AxisSampler, CompositeAxis, CompositeMode, CompositeTrainContext,
+    train_composite, AxisSampler, CompositeAxis, CompositeMode, CompositeTrainContext, PbDagParams,
+    PbDagTerm, PbSemTerm,
 };
 use candle_util::candle_nn::{AdamW, Optimizer, ParamsAdamW, VarBuilder, VarMap};
 use data_beans_alg::collapse_data::{collapse_columns_multilevel_with_hierarchy, MultilevelParams};
@@ -30,7 +35,7 @@ use config::{
     load_or_compute_fisher_weights, stage_params, DEFAULT_AXIS_LAMBDA, DEFAULT_STRATIFY_ALPHA_CELL,
     DEFAULT_STRATIFY_ALPHA_PB,
 };
-use projection::{project_cells_phase2, CellBatchDivisor, PHASE2_RIDGE};
+use projection::{project_cells_phase2, project_pbs_phase2, CellBatchDivisor, PHASE2_RIDGE};
 use samplers::{build_active_samplers, build_smoother, subsample_cell_samplers_multilevel};
 
 /// Composite-objective gbe fit — trained in **two phases**.
@@ -465,6 +470,9 @@ pub fn fit(unified: &mut UnifiedData, mut config: FitConfig) -> anyhow::Result<F
                 dev: &config.device,
                 stop: &stop,
                 cell_to_pb_per_level: None,
+                lineage_sem: None,
+                lineage_dag: None,
+                lineage_dag_stride: 1,
             },
             &mut opt1,
             &p1,
@@ -478,6 +486,186 @@ pub fn fit(unified: &mut UnifiedData, mut config: FitConfig) -> anyhow::Result<F
     // output/co-embed reader) sees a fixed materialized dictionary. No-op for a
     // free model.
     cell_model.materialize_e_feat()?;
+
+    // Lineage-DAG refine (gem β-sharing only; M1 fixed structure). The warm-up
+    // phase 1 above yields a trained-enough dictionary: read pb-level velocity
+    // (identity θ_pb + velocity δ_pb, reusing the phase-2 dual solver on the
+    // already-batch-corrected pb aggregates), build a fixed velocity-oriented pb
+    // graph, and run a SECOND phase-1 pass with the velocity-drift SEM residual on
+    // so the shared E_feat picks up lineage geometry. The returned `pb_velocity` is
+    // the FINAL readout (post-refine), consumed by the phase-2 cell lift. Flag off
+    // or non-β-sharing ⇒ `None` and byte-identical training.
+    let mut pb_velocity: Option<Vec<PbLevelVelocity>> = None;
+    let mut pb_dag_w: Option<Vec<Vec<f32>>> = None;
+    let mut refine_loss = 0f32; // final refine loss → QC likelihood-hygiene signal
+    if config.lineage_dag && !stop.load(std::sync::atomic::Ordering::Relaxed) {
+        match config.feat_factor.as_ref() {
+            Some(spec) => {
+                // Warm-up pb velocity, optionally smoothed + confidence-gated (①+②) so
+                // `sign(δ_pb)` is stabilized before it orients the graph / SEM drift.
+                let warmup_vel = maybe_smooth(
+                    pb_velocity_readout(&cell_model, &pb_blobs, &spec.unspliced_rows)?,
+                    h,
+                    config.lineage_smooth,
+                );
+
+                // Rebuild the phase-1 axes for the refine pass (warm-up axes were
+                // consumed). Same axis set; only the lineage term differs.
+                let mut refine_axes: Vec<CompositeAxis> = Vec::with_capacity(1 + num_levels);
+                if use_cell_axis {
+                    refine_axes.push(CompositeAxis {
+                        model: &cell_model,
+                        unified,
+                        cell_axis: &cell_axis_coarsening,
+                        sampler: AxisSampler::PerBatchStratified(phase1_cell_samplers),
+                        lambda: DEFAULT_AXIS_LAMBDA,
+                        label: "cell",
+                    });
+                }
+                for (i, model) in level_models.iter().enumerate() {
+                    let (axis, stratified) = &level_axes_data[i];
+                    refine_axes.push(CompositeAxis {
+                        model,
+                        unified: &pb_blobs[i],
+                        cell_axis: axis,
+                        sampler: AxisSampler::Stratified(stratified),
+                        lambda: DEFAULT_AXIS_LAMBDA,
+                        label: "pb",
+                    });
+                }
+                let mut p2 = stage_params(&config);
+                p2.composite_mode = CompositeMode::Sum;
+
+                if config.dag_learnable {
+                    // Sample the DATA side densely (NCE every batch, ~16 batches/epoch)
+                    // and the STRUCTURE side sparsely (`W`/SEM every DAG_STRIDE steps) —
+                    // a warm-started `W` is a light prior, not a from-scratch structure to
+                    // hammer. `DAG_STRIDE = 8` ⇒ ~2 structure updates/epoch vs 16 NCE.
+                    const DAG_STRIDE: usize = 8;
+                    p2.batches_per_epoch = Some(p2.batches_per_epoch.unwrap_or(1).max(16));
+                    // Per-axis term slices lead with the optional cell axis, so pb level
+                    // `i`'s term sits at `offset + i`.
+                    let offset = usize::from(use_cell_axis);
+                    // Warm-start each `W` from M1's velocity-oriented KNN so SGD refines a
+                    // correctly-oriented structure instead of learning one from zeros
+                    // (zero-init `W` is the unstable, non-monotone start).
+                    let knn_init =
+                        lineage::build_pb_lineage(&warmup_vel, h, lineage::DEFAULT_LINEAGE_KNN);
+                    // M2: learnable pb-DAG. Build one `PbDagTerm` per pb level
+                    // (registers a `W` Var — must precede the optimizer) aligned to
+                    // the refine axes ([cell?] + pb levels).
+                    let mut dag_terms: Vec<Option<PbDagTerm>> = Vec::with_capacity(1 + num_levels);
+                    if use_cell_axis {
+                        dag_terms.push(None);
+                    }
+                    for (i, lvl) in warmup_vel.iter().enumerate() {
+                        let w0 = knn_init[i].to_dense();
+                        dag_terms.push(PbDagTerm::new(
+                            lvl,
+                            h,
+                            &PbDagParams::default(),
+                            &format!("dag_l{i}_w"),
+                            &varmap,
+                            &config.device,
+                            Some(&w0),
+                        )?);
+                    }
+                    let n_dag = dag_terms.iter().filter(|t| t.is_some()).count();
+                    info!(
+                        "Lineage-DAG refine (M2 learnable) — {} pb-level DAG(s), warm-started \
+                         from M1 KNN [SEM + DAGMA acyclicity + L1], structure every {} steps, {} epochs",
+                        n_dag, DAG_STRIDE, config.epochs
+                    );
+                    let mut opt2 = AdamW::new(varmap.all_vars(), adamw_params())?;
+                    refine_loss = train_composite(
+                        &CompositeTrainContext {
+                            axes: &refine_axes,
+                            feat_weights: &feat_weights,
+                            dev: &config.device,
+                            stop: &stop,
+                            cell_to_pb_per_level: None,
+                            lineage_sem: None,
+                            lineage_dag: Some(&dag_terms),
+                            lineage_dag_stride: DAG_STRIDE,
+                        },
+                        &mut opt2,
+                        &p2,
+                        smoother.as_mut(),
+                    )?;
+                    // Extract the learned `W` per pb level (aligned to `pb_blobs`).
+                    let mut ws = Vec::with_capacity(num_levels);
+                    for i in 0..num_levels {
+                        ws.push(match &dag_terms[offset + i] {
+                            Some(d) => d.w_dense()?,
+                            None => Vec::new(),
+                        });
+                    }
+                    pb_dag_w = Some(ws);
+                    drop(refine_axes);
+                } else {
+                    // M1: fixed velocity-oriented KNN graph + velocity-drift SEM residual.
+                    // The dense KNN graph (each node → its velocity-forward neighbours),
+                    // built once from the warm-up readout, shapes E_feat in a single refine
+                    // pass. `pb_dag_w` stays `None`; the M3 lift rebuilds the same graph from
+                    // the final `pb_velocity`.
+                    let levels =
+                        lineage::build_pb_lineage(&warmup_vel, h, lineage::DEFAULT_LINEAGE_KNN);
+                    let n_edges: usize = levels.iter().map(|l| l.edges.len()).sum();
+                    let mut terms: Vec<Option<PbSemTerm>> = Vec::with_capacity(1 + num_levels);
+                    if use_cell_axis {
+                        terms.push(None);
+                    }
+                    for lvl in &levels {
+                        terms.push(PbSemTerm::new(
+                            lvl,
+                            h,
+                            lineage::DEFAULT_SEM_STEP,
+                            lineage::DEFAULT_SEM_WEIGHT,
+                            &config.device,
+                        )?);
+                    }
+                    info!(
+                        "Lineage-DAG refine (M1 fixed) — {} oriented pb edge(s) across \
+                         {} level(s); velocity-drift SEM residual ON",
+                        n_edges,
+                        levels.len()
+                    );
+                    let mut opt2 = AdamW::new(varmap.all_vars(), adamw_params())?;
+                    refine_loss = train_composite(
+                        &CompositeTrainContext {
+                            axes: &refine_axes,
+                            feat_weights: &feat_weights,
+                            dev: &config.device,
+                            stop: &stop,
+                            cell_to_pb_per_level: None,
+                            lineage_sem: Some(&terms),
+                            lineage_dag: None,
+                            lineage_dag_stride: 1,
+                        },
+                        &mut opt2,
+                        &p2,
+                        smoother.as_mut(),
+                    )?;
+                    drop(refine_axes);
+                }
+
+                // Refresh the dictionary and read the FINAL pb velocity (post-refine),
+                // smoothed the same way so the M3 cell lift orients off a denoised field.
+                cell_model.materialize_e_feat()?;
+                pb_velocity = Some(maybe_smooth(
+                    pb_velocity_readout(&cell_model, &pb_blobs, &spec.unspliced_rows)?,
+                    h,
+                    config.lineage_smooth,
+                ));
+            }
+            None => {
+                log::warn!(
+                    "lineage_dag set but the model is not β-sharing (feat_factor = None); \
+                     skipping lineage refine"
+                );
+            }
+        }
+    }
 
     // ---- Phase 2: analytical per-cell projection onto the fixed feature
     // side. With E_feat/b_feat/z/δ held fixed, each cell's embedding is
@@ -531,12 +719,108 @@ pub fn fit(unified: &mut UnifiedData, mut config: FitConfig) -> anyhow::Result<F
         cell_velocity = splice;
     }
 
+    // ---- M3: phase-2 cell-lineage lift (evaluation only). Runs on the FINAL pb
+    // velocity readout + the now-projected per-cell identity θ_c. Integrate a pb
+    // pseudotime/fate along the oriented pb-DAG (learned `W` for M2, the fixed
+    // velocity-oriented graph for M1) at the finest level, then landmark-blend it to
+    // every cell. `None` when lineage-DAG is off or the readout is empty.
+    let mut lineage_qc: Option<LineageQc> = None;
+    let cell_lineage = match &pb_velocity {
+        Some(pbv) if !pbv.is_empty() && !stop.load(std::sync::atomic::Ordering::Relaxed) => {
+            let level = pbv.len() - 1; // finest level: densest landmark tiling
+            let vel = &pbv[level];
+            let edges = match &pb_dag_w {
+                // M2: dense learned W (forward-masked) → positive-mass edges.
+                Some(ws) => lift::dense_to_edges(&ws[level], vel.n_pb),
+                // M1: rebuild the fixed velocity-oriented graph from the readout.
+                None => lineage::build_pb_lineage(
+                    std::slice::from_ref(vel),
+                    h,
+                    lineage::DEFAULT_LINEAGE_KNN,
+                )
+                .pop()
+                .map(|l| {
+                    l.edges
+                        .into_iter()
+                        .map(|(i, j, w)| (i as usize, j as usize, w))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default(),
+            };
+            let traj = lift::pb_trajectory(vel, &edges, h, lineage::DEFAULT_SEM_STEP);
+            let theta_c = cell_model.e_cell.flatten_all()?.to_vec1()?;
+            let lin = lift::lift_cells(&theta_c, n_cells, vel, &traj, h, level);
+            // Unsupervised per-run QC diagnostics + `underfit` hygiene floor (decisiveness,
+            // coherence, fate count, ambiguity, likelihood) — for run inspection/rejection,
+            // not a validated quality ranker.
+            let qc = lift::compute_lineage_qc(
+                &traj,
+                vel,
+                &lin,
+                refine_loss,
+                h,
+                lineage::DEFAULT_LINEAGE_KNN,
+            );
+            info!(
+                "M3 cell lift — finest pb level {} ({} nodes, {} root(s), {} fate(s)); \
+                 QC decisiveness={:.3} coherence={:.3} flag={}",
+                level,
+                vel.n_pb,
+                traj.roots.len(),
+                traj.terminals.len(),
+                qc.root_decisiveness,
+                qc.velocity_coherence,
+                qc.flag,
+            );
+            lineage_qc = Some(qc);
+            Some(lin)
+        }
+        _ => None,
+    };
+
     Ok(FitOutput {
         model: cell_model,
         varmap,
         cell_nrms,
         cell_velocity,
+        pb_velocity,
+        pb_dag_w,
+        cell_lineage,
+        lineage_qc,
     })
+}
+
+/// Apply the velocity-graph smoothing + confidence gating (①+②) to a pb readout when
+/// `on`; an identity pass-through otherwise. Kept here so both readout sites share one
+/// call and the default constants stay in one place.
+fn maybe_smooth(vel: Vec<PbLevelVelocity>, h: usize, on: bool) -> Vec<PbLevelVelocity> {
+    if on {
+        lineage::smooth_pb_velocity_levels(&vel, h, lineage::DEFAULT_SMOOTH_KNN)
+    } else {
+        vel
+    }
+}
+
+/// Analytic pb-level velocity readout: identity `θ_pb` + velocity `δ_pb` per pb
+/// node per level, reusing the phase-2 dual solver on the (already
+/// batch-corrected) pb aggregates. Requires a materialized `e_feat` dictionary.
+/// Called twice on the lineage-DAG path — once on the warm-up dictionary (to
+/// orient the fixed pb graph) and once after the refine pass (the returned readout).
+fn pb_velocity_readout(
+    model: &JointEmbedModel,
+    pb_blobs: &[UnifiedData],
+    unspliced_rows: &[bool],
+) -> anyhow::Result<Vec<PbLevelVelocity>> {
+    let feat_flat = model.e_feat.flatten_all()?.to_vec1()?;
+    let b_feat_v = model.b_feat.to_vec1()?;
+    project_pbs_phase2(
+        &feat_flat,
+        &b_feat_v,
+        model.embedding_dim,
+        pb_blobs,
+        unspliced_rows,
+        f64::from(PHASE2_RIDGE),
+    )
 }
 
 /// Gather a backend-axis `[backend_rows × cols]` matrix onto the unified feature

--- a/graph-embedding-util/src/fit/projection.rs
+++ b/graph-embedding-util/src/fit/projection.rs
@@ -1,3 +1,5 @@
+use crate::cell_projection::{solve_cell_increment, solve_one_cell};
+use crate::data::UnifiedData;
 use crate::loss::PerBatchStratifiedCellSampler;
 use crate::model::JointEmbedModel;
 use candle_util::candle_core::Device;
@@ -143,7 +145,6 @@ pub(crate) fn project_cells_phase2(
     batch_divisor: Option<CellBatchDivisor>,
     unspliced_rows: Option<&[bool]>,
 ) -> anyhow::Result<(Vec<f32>, Option<Vec<f32>>)> {
-    use crate::cell_projection::{solve_cell_increment, solve_one_cell};
     use anyhow::Context;
     use candle_util::candle_core::Tensor;
     use rayon::prelude::*;
@@ -160,11 +161,6 @@ pub(crate) fn project_cells_phase2(
 
     let feat_flat: Vec<f32> = model.e_feat.flatten_all()?.to_vec1()?;
     let solve = |edges: &[(u32, f32)]| solve_one_cell(edges, &feat_flat, &b_feat, h, lambda);
-    // Velocity: analytic Poisson-MAP increment δ holding the identity `e_base`
-    // fixed (same likelihood/frame as the identity solve, so θ + δ is coherent).
-    let solve_incr = |e_base: &[f32], edges: &[(u32, f32)]| {
-        solve_cell_increment(edges, e_base, &feat_flat, &b_feat, h, lambda)
-    };
     let solved: Vec<SolvedCell> = cells
         .par_iter()
         .map(|&(cell, feats, counts)| {
@@ -189,25 +185,11 @@ pub(crate) fn project_cells_phase2(
                 // held fixed. Both index the shared β_g, so δ is a directed residual in
                 // θ's own frame. No post-hoc unit-norm on either — the nascent state is
                 // just θ + δ. δ = 0 when identity is empty or there are no unspliced edges.
+                // Empty δ (not `vec![0; h]`) when undefined — velocity_flat is already
+                // zero-initialized, so the storage loop just skips the copy.
                 Some(un) => {
-                    let mut spliced: Vec<(u32, f32)> = Vec::with_capacity(edges.len());
-                    let mut unspliced: Vec<(u32, f32)> = Vec::with_capacity(edges.len());
-                    for &(f, c) in &edges {
-                        if un[f as usize] {
-                            unspliced.push((f, c));
-                        } else {
-                            spliced.push((f, c));
-                        }
-                    }
-                    let (theta, b_s) = solve(&spliced);
-                    let theta_n = norm(&theta);
-                    // Empty δ (not `vec![0; h]`) when undefined — velocity_flat is
-                    // already zero-initialized, so the storage loop just skips the copy.
-                    let velocity = if theta_n > 1e-8 && !unspliced.is_empty() {
-                        solve_incr(&theta, &unspliced).0
-                    } else {
-                        Vec::new()
-                    };
+                    let (theta, theta_n, b_s, velocity) =
+                        solve_node_splice(&edges, un, &feat_flat, &b_feat, h, lambda);
                     SolvedCell {
                         cell: cell as usize,
                         latent: theta,
@@ -264,3 +246,105 @@ pub(crate) fn project_cells_phase2(
     // per-cell velocity increment `δ`, flat `[n_cells × h]`. `None` for bge.
     Ok((cell_nrms, velocity_flat))
 }
+
+/// Split one node's `(feature, count)` edges by the unspliced mask and run the
+/// dual analytic solve: identity `θ` from the spliced edges, then the velocity
+/// increment `δ` from the unspliced edges holding `θ` fixed (same likelihood
+/// frame, so `θ + δ` is coherent). Shared by the per-cell gem β-sharing path and
+/// the per-pseudobulk readout. `frozen_e` is row-major `[n_features × h]`.
+///
+/// Returns `(θ, ‖θ‖, b_c, δ)`; `δ` is **empty** — not zero-filled — when velocity
+/// is undefined (empty identity or no unspliced edges), so callers can skip the
+/// copy into a pre-zeroed buffer.
+fn solve_node_splice(
+    edges: &[(u32, f32)],
+    unspliced_rows: &[bool],
+    frozen_e: &[f32],
+    frozen_b: &[f32],
+    h: usize,
+    lambda: f64,
+) -> (Vec<f32>, f32, f32, Vec<f32>) {
+    let mut spliced: Vec<(u32, f32)> = Vec::with_capacity(edges.len());
+    let mut unspliced: Vec<(u32, f32)> = Vec::with_capacity(edges.len());
+    for &(f, c) in edges {
+        if unspliced_rows[f as usize] {
+            unspliced.push((f, c));
+        } else {
+            spliced.push((f, c));
+        }
+    }
+    let (theta, b_s) = solve_one_cell(&spliced, frozen_e, frozen_b, h, lambda);
+    let theta_n = theta.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let velocity = if theta_n > 1e-8 && !unspliced.is_empty() {
+        solve_cell_increment(&unspliced, &theta, frozen_e, frozen_b, h, lambda).0
+    } else {
+        Vec::new()
+    };
+    (theta, theta_n, b_s, velocity)
+}
+
+/// Per-level pseudobulk phase-2 velocity readout: the analytic identity `θ_pb`
+/// and velocity increment `δ_pb` for every pb node of one collapse level, each
+/// flattened `[n_pb × h]` row-major. Produced by [`project_pbs_phase2`] for the
+/// lineage-DAG path — `δ_pb` orients the pb-DAG structure term, `θ_pb` are the
+/// latent landmarks the phase-2 cell lift attaches to.
+pub struct PbLevelVelocity {
+    pub n_pb: usize,
+    /// Identity `θ_pb`, `[n_pb × h]` row-major (raw spliced Poisson-MAP).
+    pub theta: Vec<f32>,
+    /// Velocity `δ_pb`, `[n_pb × h]` row-major; zero rows where undefined.
+    pub delta: Vec<f32>,
+}
+
+/// Phase-2 **pseudobulk** velocity readout (gem β-sharing / lineage-DAG path).
+/// Analytically re-projects every pb node of every level onto the frozen feature
+/// dictionary — identity `θ_pb` from its spliced aggregate, velocity `δ_pb` from
+/// its unspliced aggregate with `θ_pb` fixed — exactly as [`project_cells_phase2`]
+/// does per cell, but at pseudobulk resolution. Reuses the pb aggregates already
+/// built for phase 1 (`pb_blobs[level].triplets`), which are already
+/// batch-corrected, so no batch divisor is applied. `frozen_e` is row-major
+/// `[n_features × h]`.
+///
+/// Returns one [`PbLevelVelocity`] per level, in `pb_blobs` order (coarsest→finest).
+pub(crate) fn project_pbs_phase2(
+    frozen_e: &[f32],
+    frozen_b: &[f32],
+    h: usize,
+    pb_blobs: &[UnifiedData],
+    unspliced_rows: &[bool],
+    lambda: f64,
+) -> anyhow::Result<Vec<PbLevelVelocity>> {
+    use rayon::prelude::*;
+
+    let mut out = Vec::with_capacity(pb_blobs.len());
+    for pb in pb_blobs {
+        let n_pb = pb.n_cells();
+        // Group the pb's (feature, count) edges by pb-node id.
+        let mut per_pb: Vec<Vec<(u32, f32)>> = vec![Vec::new(); n_pb];
+        for t in &pb.triplets {
+            per_pb[t.cell as usize].push((t.feature, t.count));
+        }
+        let solved: Vec<(Vec<f32>, Vec<f32>)> = per_pb
+            .par_iter()
+            .map(|edges| {
+                let (theta, _n, _b, delta) =
+                    solve_node_splice(edges, unspliced_rows, frozen_e, frozen_b, h, lambda);
+                (theta, delta)
+            })
+            .collect();
+        let mut theta = vec![0f32; n_pb * h];
+        let mut delta = vec![0f32; n_pb * h];
+        for (p, (th, dl)) in solved.into_iter().enumerate() {
+            let s = p * h;
+            theta[s..s + h].copy_from_slice(&th);
+            if !dl.is_empty() {
+                delta[s..s + h].copy_from_slice(&dl);
+            }
+        }
+        out.push(PbLevelVelocity { n_pb, theta, delta });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/fit/projection/tests.rs
+++ b/graph-embedding-util/src/fit/projection/tests.rs
@@ -1,0 +1,110 @@
+//! Unit tests for the pseudobulk phase-2 velocity readout.
+
+use super::project_pbs_phase2;
+use crate::data::UnifiedData;
+
+/// Cosine alignment of two equal-length vectors.
+fn cos(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (na * nb)
+}
+
+// Two pb nodes with planted identity θ* and velocity δ*. Spliced rows carry
+// counts at the noiseless rate exp(⟨e_f, θ*⟩ + b_f + b_c); unspliced rows at
+// exp(⟨e_f, θ*+δ*⟩ + b_f + b_c). The dual pb projection must recover θ* from the
+// spliced aggregate and δ* from the unspliced aggregate (θ* held fixed).
+#[test]
+fn pb_projection_recovers_theta_and_delta() {
+    let h = 4;
+    let n_spliced = 8;
+    let n_feat = n_spliced * 2; // rows 0..8 spliced, 8..16 unspliced
+    let unspliced_rows: Vec<bool> = (0..n_feat).map(|f| f >= n_spliced).collect();
+
+    // Deterministic frozen dictionary e_f / b_f.
+    let mut e = vec![0f32; n_feat * h];
+    let mut b = vec![0f32; n_feat];
+    for f in 0..n_feat {
+        for k in 0..h {
+            e[f * h + k] = (((f * 7 + k * 13) % 11) as f32 / 11.0) - 0.5;
+        }
+        b[f] = (((f * 5) % 7) as f32 / 7.0) - 0.3;
+    }
+
+    // Per-pb planted identity + velocity.
+    let theta_star = [[0.6f32, -0.4, 0.3, 0.2], [-0.3, 0.5, -0.2, 0.4]];
+    let delta_star = [[0.25f32, -0.3, 0.15, 0.2], [-0.2, 0.1, 0.3, -0.25]];
+    let b_c = [0.2f32, -0.1];
+    let n_pb = theta_star.len();
+
+    let rate = |f: usize, latent: &[f32; 4], bc: f32| -> f32 {
+        let ef = &e[f * h..(f + 1) * h];
+        let s: f32 = ef.iter().zip(latent).map(|(a, c)| a * c).sum::<f32>() + b[f] + bc;
+        s.exp()
+    };
+    let counts = nalgebra::DMatrix::<f32>::from_fn(n_feat, n_pb, |f, p| {
+        if unspliced_rows[f] {
+            // nascent state = θ* + δ*
+            let nascent = [
+                theta_star[p][0] + delta_star[p][0],
+                theta_star[p][1] + delta_star[p][1],
+                theta_star[p][2] + delta_star[p][2],
+                theta_star[p][3] + delta_star[p][3],
+            ];
+            rate(f, &nascent, b_c[p])
+        } else {
+            rate(f, &theta_star[p], b_c[p])
+        }
+    });
+
+    let names: Vec<Box<str>> = (0..n_feat)
+        .map(|f| format!("g{f}").into_boxed_str())
+        .collect();
+    let pb = UnifiedData::from_pseudobulks(&counts, names, (0..n_feat).collect()).unwrap();
+
+    let levels = project_pbs_phase2(&e, &b, h, &[pb], &unspliced_rows, 1e-3).unwrap();
+    assert_eq!(levels.len(), 1);
+    let lv = &levels[0];
+    assert_eq!(lv.n_pb, n_pb);
+    assert_eq!(lv.theta.len(), n_pb * h);
+    assert_eq!(lv.delta.len(), n_pb * h);
+
+    for p in 0..n_pb {
+        let th = &lv.theta[p * h..(p + 1) * h];
+        let dl = &lv.delta[p * h..(p + 1) * h];
+        let ct = cos(th, &theta_star[p]);
+        let cd = cos(dl, &delta_star[p]);
+        assert!(ct > 0.97, "pb {p} identity misaligned (cos={ct:.3})");
+        assert!(cd > 0.97, "pb {p} velocity misaligned (cos={cd:.3})");
+    }
+}
+
+// A pb node with no unspliced edges (spliced-only) yields a defined θ but a
+// zero δ row (velocity undefined), and the buffer stays the right shape.
+#[test]
+fn pb_projection_zero_delta_without_unspliced() {
+    let h = 3;
+    let n_feat = 6;
+    // Every row spliced ⇒ no unspliced aggregate for any pb.
+    let unspliced_rows = vec![false; n_feat];
+    let mut e = vec![0f32; n_feat * h];
+    let mut b = vec![0f32; n_feat];
+    for f in 0..n_feat {
+        for k in 0..h {
+            e[f * h + k] = (((f * 5 + k * 3) % 7) as f32 / 7.0) - 0.5;
+        }
+        b[f] = 0.0;
+    }
+    let counts = nalgebra::DMatrix::<f32>::from_fn(n_feat, 1, |f, _| f as f32 + 1.0);
+    let names: Vec<Box<str>> = (0..n_feat)
+        .map(|f| format!("g{f}").into_boxed_str())
+        .collect();
+    let pb = UnifiedData::from_pseudobulks(&counts, names, (0..n_feat).collect()).unwrap();
+
+    let levels = project_pbs_phase2(&e, &b, h, &[pb], &unspliced_rows, 1e-2).unwrap();
+    let lv = &levels[0];
+    assert_eq!(lv.delta, vec![0.0; h]);
+    // Identity is non-trivial (there were spliced edges).
+    assert!(lv.theta.iter().any(|x| x.abs() > 1e-6));
+}

--- a/graph-embedding-util/src/lib.rs
+++ b/graph-embedding-util/src/lib.rs
@@ -48,7 +48,8 @@ pub use eval::{
 };
 pub use feature_qc::{hvg_feature_qc, FeatureQcConfig, FeatureQcResult};
 pub use fit::{
-    fit, load_feature_network, FeatFactorSpec, FeatureNetworkArgs, FitConfig, FitOutput,
+    fit, load_feature_network, CellLineage, FeatFactorSpec, FeatureNetworkArgs, FitConfig,
+    FitOutput, LineageQc, PbLevelVelocity,
 };
 pub use model::JointEmbedModel;
 pub use postprocess::{cell_clusters, feature_coembedding};

--- a/graph-embedding-util/src/training.rs
+++ b/graph-embedding-util/src/training.rs
@@ -17,6 +17,8 @@
 use crate::coarsen::AxisCoarsenings;
 use crate::data::UnifiedData;
 use crate::feature_network::FeatureNetworkSmoother;
+use crate::fit::lineage::PbLineageLevel;
+use crate::fit::projection::PbLevelVelocity;
 use crate::loss::{
     nce_loss, nce_loss_chain, nce_loss_identity, sample_chain_batch, sample_edge_batch,
     sample_per_batch_stratified_edge_batch, sample_stratified_edge_batch, ChainAxis,
@@ -26,8 +28,10 @@ use crate::loss::{
 };
 use crate::model::JointEmbedModel;
 use crate::progress::new_progress_bar;
+use candle_util::candle_core::{DType, Var};
 use candle_util::candle_core::{Device, Tensor};
 use candle_util::candle_nn::AdamW;
+use candle_util::candle_nn::VarMap;
 use log::info;
 use rand::{rngs::StdRng, RngExt, SeedableRng};
 use rand_distr::weighted::WeightedIndex;
@@ -151,14 +155,294 @@ pub struct CompositeTrainContext<'a> {
     /// ignored otherwise. Comes from
     /// `MultilevelCollapseOut::cell_to_pb_per_level`.
     pub cell_to_pb_per_level: Option<&'a [Vec<usize>]>,
+    /// Optional per-axis velocity-drift SEM term (lineage-DAG refine pass, M1 fixed
+    /// structure). Aligned 1:1 with `axes`: `None` for axes with no lineage structure
+    /// (the cell axis, and any pb level with no oriented edges), `Some` otherwise.
+    /// When set, each `Some` term's penalty is added to the per-step loss so its
+    /// pb embedding is pulled toward the velocity-consistent geometry.
+    pub lineage_sem: Option<&'a [Option<PbSemTerm>]>,
+    /// Optional per-axis learnable pb-DAG term (lineage-DAG refine pass, M2). Aligned
+    /// 1:1 with `axes` like `lineage_sem`, but its `W` is a learned adjacency
+    /// co-optimized with the embedding. Mutually exclusive with `lineage_sem`.
+    pub lineage_dag: Option<&'a [Option<PbDagTerm>]>,
+    /// Apply the `lineage_dag` structure loss only every `lineage_dag_stride` steps
+    /// (NCE still runs every step). The structure is a light prior on a warm-started
+    /// `W`; hammering it every step over-shapes the embedding, so we sample the DATA
+    /// side densely and the STRUCTURE side sparsely. `1` = every step; ignored unless
+    /// `lineage_dag` is set.
+    pub lineage_dag_stride: usize,
 }
 
+/// Device-side velocity-drift SEM term for one pb axis (lineage-DAG, M1 fixed
+/// structure). Precomputes the per-edge source/target index tensors, weights, and
+/// the constant drift `s·v̂_i`, so each training step is two `index_select`s plus
+/// elementwise ops. Penalizes `Σ_{i→j} w_ij ‖e_j − e_i − s·v̂_i‖² · λ / Σw`, i.e.
+/// a pb node should sit one velocity-step ahead of its parent along the flow.
+pub struct PbSemTerm {
+    /// `[E]` parent (source) node id per edge.
+    src: Tensor,
+    /// `[E]` child (target) node id per edge.
+    dst: Tensor,
+    /// `[E]` edge weight.
+    w: Tensor,
+    /// `[E, H]` constant drift `s·v̂_i` (unit velocity of the parent, scaled).
+    drift: Tensor,
+    /// `λ_sem / Σw` — the weight, folded with the `Σw` normalizer.
+    scale: f64,
+}
+
+impl PbSemTerm {
+    /// Build the device term for one level, or `None` when the level has no
+    /// oriented edges (nothing to penalize). `step` is `s`, `weight` is `λ_sem`.
+    pub fn new(
+        level: &PbLineageLevel,
+        h: usize,
+        step: f32,
+        weight: f32,
+        dev: &Device,
+    ) -> anyhow::Result<Option<Self>> {
+        if level.edges.is_empty() {
+            return Ok(None);
+        }
+        let e = level.edges.len();
+        let mut src = Vec::with_capacity(e);
+        let mut dst = Vec::with_capacity(e);
+        let mut w = Vec::with_capacity(e);
+        let mut drift = Vec::with_capacity(e * h);
+        let mut wsum = 0f32;
+        for &(i, j, wij) in &level.edges {
+            src.push(i);
+            dst.push(j);
+            w.push(wij);
+            wsum += wij;
+            let vi = &level.velocity[i as usize * h..(i as usize + 1) * h];
+            for &vk in vi {
+                drift.push(step * vk);
+            }
+        }
+        Ok(Some(Self {
+            src: Tensor::from_vec(src, e, dev)?,
+            dst: Tensor::from_vec(dst, e, dev)?,
+            w: Tensor::from_vec(w, e, dev)?,
+            drift: Tensor::from_vec(drift, (e, h), dev)?,
+            scale: f64::from(weight) / f64::from(wsum.max(1e-8)),
+        }))
+    }
+}
+
+/// `tr(A) = Σ_i A_ii`, via the elementwise product with the identity `eye`.
+fn trace(a: &Tensor, eye: &Tensor) -> anyhow::Result<Tensor> {
+    Ok(a.mul(eye)?.sum_all()?)
+}
+
+/// DAGMA/NOTEARS-style acyclicity surrogate `Σ_{k=1}^K tr((W∘W)^k)/k! / P` — candle
+/// has no differentiable log-det, so this truncated trace-of-powers of `W∘W` stands
+/// in for `tr(e^{W∘W}) − P`: it is `≈ 0` iff `W` is acyclic (a nilpotent adjacency
+/// has zero-trace powers) and strictly positive when `W` carries a cycle.
+fn acyclicity_series(
+    w_eff: &Tensor,
+    eye: &Tensor,
+    order: usize,
+    p: usize,
+) -> anyhow::Result<Tensor> {
+    let a = w_eff.sqr()?; // W ∘ W, [P, P]
+    let mut ak = a.clone();
+    let mut h = trace(&ak, eye)?; // k = 1
+    let mut fact = 1.0f64;
+    for k in 2..=order {
+        ak = ak.matmul(&a)?;
+        fact *= k as f64;
+        h = (h + trace(&ak, eye)?.affine(1.0 / fact, 0.0)?)?;
+    }
+    Ok(h.affine(1.0 / p as f64, 0.0)?)
+}
+
+/// Velocity-drift SEM penalty on one axis's pb embedding `e_cell`, differentiable
+/// in `e_cell`: `λ · (Σ_ij w_ij ‖e_j − e_i − s·v̂_i‖²) / Σw`.
+fn sem_penalty(e_cell: &Tensor, term: &PbSemTerm) -> anyhow::Result<Tensor> {
+    let e_src = e_cell.index_select(&term.src, 0)?;
+    let e_dst = e_cell.index_select(&term.dst, 0)?;
+    let resid = e_dst.sub(&e_src)?.sub(&term.drift)?; // [E, H]
+    let sq = resid.sqr()?.sum(1)?; // [E]
+    let weighted = sq.mul(&term.w)?.sum_all()?; // scalar
+    Ok(weighted.affine(term.scale, 0.0)?)
+}
+
+/// Hyperparameters for the learnable pb-DAG term (lineage-DAG, M2).
+#[derive(Clone, Copy)]
+pub struct PbDagParams {
+    /// Velocity-drift step `s` in the SEM residual `e_j − Σ_i W_ij(e_i + s·v̂_i)`.
+    pub step: f32,
+    /// Weight on the SEM reconstruction residual.
+    pub sem_weight: f32,
+    /// Weight on the L1 sparsity penalty `‖W‖_1`.
+    pub l1_weight: f32,
+    /// Weight on the DAGMA-style acyclicity penalty.
+    pub acyc_weight: f32,
+    /// Truncation order `K` of the trace-of-powers acyclicity surrogate
+    /// `Σ_{k=1}^K tr((W∘W)^k)/k!` (≈ `tr(e^{W∘W}) − P`, zero iff acyclic).
+    pub acyc_order: usize,
+}
+
+impl Default for PbDagParams {
+    fn default() -> Self {
+        Self {
+            step: 2.0,
+            sem_weight: 1.0,
+            l1_weight: 0.01,
+            acyc_weight: 0.3,
+            acyc_order: 4,
+        }
+    }
+}
+
+/// Learnable directed pb-DAG term for one level (lineage-DAG, M2). Holds a learnable
+/// adjacency `W [P×P]` (registered in the varmap, so AdamW co-optimizes it with the
+/// embedding) plus the constant drift `s·v̂`, an identity, and a fixed **forward
+/// candidate mask** derived from the exogenous velocity. `W` is restricted to
+/// velocity-forward edges by construction (`W_eff = W ∘ fwd_mask`), so the learned
+/// DAG cannot run against the velocity field and is (near-)acyclic for free — this is
+/// the "velocity anchors orientation" idea as a hard constraint rather than a soft
+/// penalty. [`Self::dag_loss`] is `sem·‖E − W_eff(E + s·v̂)‖² + l1·‖W_eff‖₁ +
+/// acyc·h(W_eff)`, differentiable in both `E` and `W`.
+pub struct PbDagTerm {
+    /// Learnable adjacency `[P, P]` (Var tensor).
+    w: Tensor,
+    /// Constant drift `s·v̂` `[P, H]` (parent's own velocity step).
+    drift: Tensor,
+    /// Identity `[P, P]` — used for the trace via `(A∘I).sum`.
+    eye: Tensor,
+    /// Forward candidate mask `[P, P]`: `1` where edge `i→j` is velocity-forward
+    /// (`⟨θ_j − θ_i, v̂_i⟩ > 0`, `i` has velocity, `j ≠ i`), `0` otherwise. Multiplied
+    /// into `W` so only forward edges can carry weight.
+    fwd_mask: Tensor,
+    params: PbDagParams,
+    p: usize,
+}
+
+impl PbDagTerm {
+    /// Build the learnable term for one level, registering the `W` Var under
+    /// `var_name`. Returns `None` when the level has fewer than two nodes. The
+    /// forward-orientation mask and drift are fixed from the warm-up velocity/identity
+    /// (`vel.theta` / `vel.delta`). `w_init` warm-starts `W` from a fixed structure
+    /// (M1's velocity-oriented KNN, `[p×p]` row-major) so SGD refines from a correctly-
+    /// oriented start; `None` zero-initializes (the DAGMA-clean but unstable start).
+    pub fn new(
+        vel: &PbLevelVelocity,
+        h: usize,
+        params: &PbDagParams,
+        var_name: &str,
+        varmap: &VarMap,
+        dev: &Device,
+        w_init: Option<&[f32]>,
+    ) -> anyhow::Result<Option<Self>> {
+        let p = vel.n_pb;
+        if p < 2 {
+            return Ok(None);
+        }
+        // Unit velocity v̂ per node (zero when ‖δ‖ ≈ 0), shared with the lineage graph.
+        let (vhat, has_vel) = crate::fit::lineage::unit_velocity(vel, h);
+        // Constant drift s·v̂.
+        let drift: Vec<f32> = vhat.iter().map(|x| params.step * x).collect();
+        // Forward candidate mask: keep W_ij only where j is velocity-forward of i
+        // (⟨θ_j − θ_i, v̂_i⟩ > 0). Undefined-velocity rows and the diagonal stay 0, so
+        // the learned DAG is forward-oriented by construction. θ is the warm-up identity.
+        let theta = &vel.theta;
+        let mut fwd = vec![0f32; p * p];
+        for i in 0..p {
+            if !has_vel[i] {
+                continue;
+            }
+            let ti = &theta[i * h..(i + 1) * h];
+            let vi = &vhat[i * h..(i + 1) * h];
+            for j in 0..p {
+                if j == i {
+                    continue;
+                }
+                let tj = &theta[j * h..(j + 1) * h];
+                let f: f32 = (0..h).map(|c| (tj[c] - ti[c]) * vi[c]).sum();
+                if f > 0.0 {
+                    fwd[i * p + j] = 1.0;
+                }
+            }
+        }
+        let eye: Vec<f32> = (0..p * p)
+            .map(|idx| f32::from(idx / p == idx % p))
+            .collect();
+
+        let w0 = match w_init {
+            Some(init) => {
+                anyhow::ensure!(
+                    init.len() == p * p,
+                    "w_init length {} != p·p {}",
+                    init.len(),
+                    p * p
+                );
+                Tensor::from_vec(init.to_vec(), (p, p), dev)?
+            }
+            None => Tensor::zeros((p, p), DType::F32, dev)?,
+        };
+        let w_var = Var::from_tensor(&w0)?;
+        varmap
+            .data()
+            .lock()
+            .unwrap()
+            .insert(var_name.to_string(), w_var.clone());
+
+        Ok(Some(Self {
+            w: w_var.as_tensor().clone(),
+            drift: Tensor::from_vec(drift, (p, h), dev)?,
+            eye: Tensor::from_vec(eye, (p, p), dev)?,
+            fwd_mask: Tensor::from_vec(fwd, (p, p), dev)?,
+            params: *params,
+            p,
+        }))
+    }
+
+    /// Full learnable-DAG loss for this level, differentiable in `e_cell` and `W`.
+    pub fn dag_loss(&self, e_cell: &Tensor) -> anyhow::Result<Tensor> {
+        let w_eff = self.w.mul(&self.fwd_mask)?; // forward-only (also zeros self-loops)
+                                                 // SEM reconstruction: E − W_effᵀ · (E + s·v̂). `fwd_mask[i,j]=1` marks j as
+                                                 // velocity-forward of i, so W_eff[i,j] is the edge i→j (i earlier, j later). We
+                                                 // must reconstruct the CHILD j from its PARENT i (`e_j ≈ e_i + s·v̂_i`), i.e.
+                                                 // `recon[j] = Σ_i W_eff[i,j]·(e_i + drift_i)` — that is `W_effᵀ·(E+drift)`, NOT
+                                                 // `W_eff·(...)`. Without the transpose each node is reconstructed from its
+                                                 // successors and the whole velocity-drift convention runs backward (M1's SEM,
+                                                 // `e_j − e_i − s·v̂_i`, is the correct forward form we match here). Normalize PER
+                                                 // NODE (sum over H, mean over P) — `mean_all` would divide the W-gradient by P·H.
+        let parent = e_cell.add(&self.drift)?; // [P, H]
+        let recon = w_eff.t()?.matmul(&parent)?; // [P, H] — Wᵀ: child from parent
+        let sem = e_cell.sub(&recon)?.sqr()?.sum(1)?.mean(0)?;
+        // L1 sparsity (per-node budget).
+        let l1 = w_eff.abs()?.sum(1)?.mean(0)?;
+        // Acyclicity surrogate.
+        let acyc = self.acyclicity(&w_eff)?;
+        let loss = sem.affine(f64::from(self.params.sem_weight), 0.0)?;
+        let loss = (loss + l1.affine(f64::from(self.params.l1_weight), 0.0)?)?;
+        let loss = (loss + acyc.affine(f64::from(self.params.acyc_weight), 0.0)?)?;
+        Ok(loss)
+    }
+
+    /// DAGMA/NOTEARS-style acyclicity surrogate (see [`acyclicity_series`]).
+    fn acyclicity(&self, w_eff: &Tensor) -> anyhow::Result<Tensor> {
+        acyclicity_series(w_eff, &self.eye, self.params.acyc_order, self.p)
+    }
+
+    /// The current effective forward adjacency `W_eff = W ∘ fwd_mask` as a host
+    /// `[P, P]` row-major buffer — consumed by the phase-2 cell lift (M3).
+    pub fn w_dense(&self) -> anyhow::Result<Vec<f32>> {
+        Ok(self.w.mul(&self.fwd_mask)?.flatten_all()?.to_vec1()?)
+    }
+}
+
+/// Returns the final epoch's mean composite loss (an NCE ≈ neg-log-likelihood proxy),
+/// used as a fit-hygiene signal by the lineage QC.
 pub fn train_composite(
     ctx: &CompositeTrainContext,
     opt: &mut AdamW,
     params: &TrainingParams,
     smoother: Option<&mut FeatureNetworkSmoother>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<f32> {
     assert!(!ctx.axes.is_empty(), "composite training needs >= 1 axis");
 
     // Shared style — consistent with every other faba/senna progress bar
@@ -168,6 +452,10 @@ pub fn train_composite(
     let mut rng = StdRng::seed_from_u64(params.seed);
     let refresh_every = smoother.as_ref().map_or(0, |s| s.refresh_epochs);
     let mut smoother = smoother;
+    // Global step index (across epochs) — gates the sparse structure-side update.
+    let mut global_step = 0usize;
+    let dag_stride = ctx.lineage_dag_stride.max(1);
+    let mut last_avg = 0f32; // final-epoch mean loss, returned as the fit-hygiene signal
 
     // Smoother refreshes against the *shared* E_feat — pull it from the
     // first axis (every axis points at the same tensor).
@@ -258,6 +546,30 @@ pub fn train_composite(
                     loss = (loss + pen)?;
                 }
             }
+            // Velocity-drift SEM residual (lineage-DAG refine pass). One penalty per
+            // pb axis with oriented edges, pulling its pb embedding toward the
+            // velocity-consistent geometry; gradients reach `E_feat` through the NCE
+            // coupling. `None` (default) is a no-op → byte-identical training.
+            if let Some(terms) = ctx.lineage_sem {
+                for (axis, term) in ctx.axes.iter().zip(terms) {
+                    if let Some(t) = term {
+                        loss = (loss + sem_penalty(&axis.model.e_cell, t)?)?;
+                    }
+                }
+            }
+            // Learnable pb-DAG (M2): the SEM/acyclicity/sparsity/orientation loss on
+            // the learned `W`. Applied only every `dag_stride` steps — the DATA side
+            // (NCE) trains every step, the STRUCTURE side (`W`) only occasionally, so a
+            // warm-started `W` is nudged rather than hammered (over-shaping collapse).
+            if let Some(terms) = ctx.lineage_dag {
+                if global_step.is_multiple_of(dag_stride) {
+                    for (axis, term) in ctx.axes.iter().zip(terms) {
+                        if let Some(t) = term {
+                            loss = (loss + t.dag_loss(&axis.model.e_cell)?)?;
+                        }
+                    }
+                }
+            }
             // Backward + optional global-norm gradient clip + step.
             candle_util::grad_clip::clipped_backward_step(
                 opt,
@@ -270,6 +582,7 @@ pub fn train_composite(
                 Some(a) => (a + ld)?,
             });
             n_steps += 1;
+            global_step += 1;
 
             if ctx.stop.load(Ordering::Relaxed) {
                 break;
@@ -281,6 +594,7 @@ pub fn train_composite(
             Some(t) => t.to_scalar::<f32>()? / n_steps.max(1) as f32,
             None => 0f32,
         };
+        last_avg = avg;
         prog_bar.set_message(format!("loss={avg:.3}"));
         prog_bar.inc(1);
         // Every-epoch info; senna/pinto's `--verbose` flag raises the
@@ -300,12 +614,12 @@ pub fn train_composite(
                 epoch + 1,
                 params.epochs
             );
-            return Ok(());
+            return Ok(last_avg);
         }
     }
     prog_bar.finish_and_clear();
 
-    Ok(())
+    Ok(last_avg)
 }
 
 /// One step of `CompositeMode::Sum` — sample a minibatch from every
@@ -602,3 +916,6 @@ fn single_axis_step(
     };
     Ok(Some(bip_loss))
 }
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/training/tests.rs
+++ b/graph-embedding-util/src/training/tests.rs
@@ -1,0 +1,175 @@
+//! Unit tests for the velocity-drift SEM residual and the learnable pb-DAG term.
+
+use super::{acyclicity_series, sem_penalty, PbDagParams, PbDagTerm, PbSemTerm};
+use crate::fit::lineage::PbLineageLevel;
+use crate::fit::projection::PbLevelVelocity;
+use candle_util::candle_core::{Device, Tensor, Var};
+use candle_util::candle_nn::VarMap;
+
+fn eye(p: usize, dev: &Device) -> Tensor {
+    let v: Vec<f32> = (0..p * p).map(|i| f32::from(i / p == i % p)).collect();
+    Tensor::from_vec(v, (p, p), dev).unwrap()
+}
+
+/// One edge 0→1, parent velocity v̂₀ = (1,0), step s = 1. The residual is
+/// `e₁ − e₀ − v̂₀`, so the penalty vanishes exactly when `e₁ = e₀ + (1,0)` and is
+/// positive otherwise.
+fn one_edge_level() -> PbLineageLevel {
+    PbLineageLevel {
+        n_pb: 2,
+        edges: vec![(0, 1, 1.0)],
+        velocity: vec![1.0, 0.0, /*n0*/ 0.0, 0.0 /*n1*/],
+    }
+}
+
+#[test]
+fn sem_penalty_zero_at_consistency() {
+    let dev = Device::Cpu;
+    let h = 2;
+    let term = PbSemTerm::new(&one_edge_level(), h, 1.0, 1.0, &dev)
+        .unwrap()
+        .unwrap();
+
+    // e₁ = e₀ + s·v̂₀ = (0.5,0.3) + (1,0) = (1.5,0.3) → residual 0.
+    let consistent = Tensor::from_vec(vec![0.5f32, 0.3, 1.5, 0.3], (2, h), &dev).unwrap();
+    let pen0 = sem_penalty(&consistent, &term)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!(pen0 < 1e-6, "penalty should vanish at consistency ({pen0})");
+
+    // Off-consistency (e₁ not a velocity-step ahead) → strictly positive.
+    let bad = Tensor::from_vec(vec![0.5f32, 0.3, 0.5, 0.3], (2, h), &dev).unwrap();
+    let pen1 = sem_penalty(&bad, &term)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!(
+        pen1 > 1e-3,
+        "penalty should be positive off-consistency ({pen1})"
+    );
+}
+
+#[test]
+fn sem_penalty_gradient_step_reduces() {
+    let dev = Device::Cpu;
+    let h = 2;
+    let term = PbSemTerm::new(&one_edge_level(), h, 1.0, 1.0, &dev)
+        .unwrap()
+        .unwrap();
+
+    // Start off-consistency; one gradient-descent step on e_cell must lower it.
+    let var =
+        Var::from_tensor(&Tensor::from_vec(vec![0.5f32, 0.3, 0.5, 0.3], (2, h), &dev).unwrap())
+            .unwrap();
+    let before = sem_penalty(var.as_tensor(), &term)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+
+    let loss = sem_penalty(var.as_tensor(), &term).unwrap();
+    let grads = loss.backward().unwrap();
+    let g = grads.get(var.as_tensor()).unwrap();
+    let stepped = (var.as_tensor() - (g * 0.1).unwrap()).unwrap();
+    let after = sem_penalty(&stepped, &term)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+
+    assert!(
+        after < before,
+        "gradient step should reduce the SEM penalty ({before} -> {after})"
+    );
+}
+
+/// A level with no oriented edges produces no term (nothing to penalize).
+#[test]
+fn empty_level_yields_no_term() {
+    let dev = Device::Cpu;
+    let level = PbLineageLevel {
+        n_pb: 3,
+        edges: vec![],
+        velocity: vec![0.0; 6],
+    };
+    assert!(PbSemTerm::new(&level, 2, 1.0, 1.0, &dev).unwrap().is_none());
+}
+
+// ---- M2: learnable pb-DAG ----
+
+/// A strictly-upper-triangular (acyclic) `W` has ~zero acyclicity; a 2-cycle is
+/// strictly positive.
+#[test]
+fn acyclicity_zero_for_dag_positive_for_cycle() {
+    let dev = Device::Cpu;
+    // DAG: 0→1, 0→2, 1→2.
+    let dag = Tensor::from_vec(
+        vec![0.0f32, 0.5, 0.3, 0.0, 0.0, 0.7, 0.0, 0.0, 0.0],
+        (3, 3),
+        &dev,
+    )
+    .unwrap();
+    let h_dag = acyclicity_series(&dag, &eye(3, &dev), 6, 3)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!(h_dag.abs() < 1e-6, "DAG acyclicity should be ~0 ({h_dag})");
+
+    // 2-cycle: 0↔1.
+    let cyc = Tensor::from_vec(vec![0.0f32, 0.6, 0.7, 0.0], (2, 2), &dev).unwrap();
+    let h_cyc = acyclicity_series(&cyc, &eye(2, &dev), 6, 2)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!(
+        h_cyc > 1e-3,
+        "cycle acyclicity should be positive ({h_cyc})"
+    );
+}
+
+/// The learnable term builds (registering a zero-initialized `W`), and its loss is
+/// finite, non-negative, and differentiable in both `e_cell` and `W`.
+#[test]
+fn dag_term_builds_and_loss_is_differentiable() {
+    let dev = Device::Cpu;
+    let h = 3;
+    let vel = PbLevelVelocity {
+        n_pb: 3,
+        theta: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 0.0],
+        delta: vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+    };
+    let vm = VarMap::new();
+    let term = PbDagTerm::new(
+        &vel,
+        h,
+        &PbDagParams::default(),
+        "dag_test_w",
+        &vm,
+        &dev,
+        None,
+    )
+    .unwrap()
+    .unwrap();
+    // W starts at zero (clean DAGMA start).
+    assert!(term.w_dense().unwrap().iter().all(|&x| x == 0.0));
+
+    let e = Var::from_tensor(
+        &Tensor::from_vec(
+            vec![0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+            (3, h),
+            &dev,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let loss = term.dag_loss(e.as_tensor()).unwrap();
+    let val = loss.to_scalar::<f32>().unwrap();
+    assert!(
+        val.is_finite() && val >= 0.0,
+        "dag loss finite non-neg ({val})"
+    );
+    // Gradients flow to both the embedding and the W var.
+    let grads = loss.backward().unwrap();
+    assert!(grads.get(e.as_tensor()).is_some(), "no grad to e_cell");
+    let w_var = vm.data().lock().unwrap().get("dag_test_w").unwrap().clone();
+    assert!(grads.get(w_var.as_tensor()).is_some(), "no grad to W");
+}

--- a/graph-embedding-util/src/type_annotation.rs
+++ b/graph-embedding-util/src/type_annotation.rs
@@ -79,7 +79,10 @@ pub use output::write_label_tsvs;
 /// (Euclidean nearest-centroid → QC → cluster → hypergeometric + permutation
 /// calibration → optional TreeBH ontology). The statistically-firm successor to
 /// [`annotate_embeddings`]; `faba gem-annotate` drives it.
-pub use term_ora::{annotate_embeddings_ora, TermOraConfig, TERM_ORA_OUTPUT_SUFFIXES};
+pub use term_ora::{
+    annotate_embeddings_ora, annotate_with_communities, CommunityCalls, TermOraConfig,
+    TERM_ORA_OUTPUT_SUFFIXES,
+};
 
 /// Bind the generic `enrichment` TreeBH ontology core to the concrete OBO
 /// loader (load OBO + `label→CL`, inject access closures, run). Shared by the

--- a/graph-embedding-util/src/type_annotation/term_ora.rs
+++ b/graph-embedding-util/src/type_annotation/term_ora.rs
@@ -109,6 +109,17 @@ impl Default for TermOraConfig {
 
 const UNASSIGNED: usize = usize::MAX;
 
+/// Per-community (cluster / MST-node) firm call returned by
+/// [`annotate_with_communities`], so a caller (e.g. `faba lineage --markers`) can name
+/// each trajectory node without re-reading the parquet.
+pub struct CommunityCalls {
+    /// Called cell type per community (or `"unassigned"`), length `n_comm`.
+    pub labels: Vec<Box<str>>,
+    /// Confidence of each community's call (the FDR-sparse softmax `Q`; `0` when
+    /// unassigned), length `n_comm`.
+    pub confidence: Vec<f32>,
+}
+
 /// Name of a term index, mapping the [`UNASSIGNED`] sentinel to `"unassigned"`.
 fn label_of(t: usize, type_names: &[Box<str>]) -> Box<str> {
     if t == UNASSIGNED {
@@ -118,8 +129,9 @@ fn label_of(t: usize, type_names: &[Box<str>]) -> Box<str> {
     }
 }
 
-/// End-to-end firm annotation from in-memory embeddings. See the module docs for
-/// the pipeline. Writes the `{out_prefix}.*` artifacts and returns nothing.
+/// End-to-end firm annotation from in-memory embeddings, clustering cells with **Leiden**
+/// over their own cosine kNN graph, then delegating to [`annotate_with_communities`].
+/// See the module docs for the pipeline. Writes the `{out_prefix}.*` artifacts.
 pub fn annotate_embeddings_ora(
     input: &InputEmbeddings<'_>,
     markers_path: &str,
@@ -127,6 +139,46 @@ pub fn annotate_embeddings_ora(
     use_idf: bool,
     cfg: &TermOraConfig,
 ) -> Result<()> {
+    let n = input.cell_emb.nrows();
+    let h = input.cell_emb.ncols();
+    anyhow::ensure!(n >= 2, "term-ORA needs ≥ 2 cells, found {n}");
+    // Communities are Leiden over the cell kNN graph — the embedding's own geometry,
+    // independent of the term labels (module docs step 4).
+    let cell_flat = row_major(input.cell_emb);
+    let community = cluster_cells(&cell_flat, n, h, cfg)?;
+    let n_comm = community.iter().copied().max().map_or(0, |m| m + 1).max(1);
+    info!(
+        "clustered cells into {n_comm} communities (knn={}, res={})",
+        cfg.knn, cfg.resolution
+    );
+    annotate_with_communities(
+        input,
+        markers_path,
+        out_prefix,
+        use_idf,
+        &community,
+        n_comm,
+        cfg,
+    )?;
+    Ok(())
+}
+
+/// Firm annotation given an **externally-supplied** cell clustering (`community[i]` =
+/// cell `i`'s group id, `n_comm` groups) rather than Leiden. Runs the shared pipeline —
+/// term centroids, nearest-centroid `fine_label`, per-term QC, then cluster × term
+/// over-representation + permutation calibration over the *given* grouping — and writes
+/// every `{out_prefix}.*` artifact. [`annotate_embeddings_ora`] wraps this with Leiden;
+/// `faba lineage --markers` passes the MST-node clustering, so each trajectory node gets
+/// the same permutation-calibrated call.
+pub fn annotate_with_communities(
+    input: &InputEmbeddings<'_>,
+    markers_path: &str,
+    out_prefix: &str,
+    use_idf: bool,
+    community: &[usize],
+    n_comm: usize,
+    cfg: &TermOraConfig,
+) -> Result<CommunityCalls> {
     anyhow::ensure!(
         cfg.obo.is_some() == cfg.label_cl.is_some(),
         "--obo and --label-cl must be given together to run the ontology layer (got only one)"
@@ -148,7 +200,13 @@ pub fn annotate_embeddings_ora(
     anyhow::ensure!(gene_names.len() == g, "gene_names len != feature rows");
     anyhow::ensure!(cell_names.len() == n, "cell_names len != cell rows");
     anyhow::ensure!(n >= 2, "term-ORA needs ≥ 2 cells, found {n}");
-    info!("term-ORA: β [{g} × {h}], cells [{n} × {h}]");
+    anyhow::ensure!(
+        community.len() == n,
+        "community len {} != cell rows {n}",
+        community.len()
+    );
+    anyhow::ensure!(n_comm >= 1, "need ≥ 1 community, got {n_comm}");
+    info!("term-ORA: β [{g} × {h}], cells [{n} × {h}], {n_comm} group(s)");
 
     let (type_names, type_markers) = parse_and_match_markers(markers_path, gene_names, use_idf)?;
     let c = type_names.len();
@@ -189,16 +247,8 @@ pub fn annotate_embeddings_ora(
         "after QC only {n_assigned} cells remain assigned — loosen --assign-mad or check markers"
     );
 
-    // ----- 4. cluster cells (cosine kNN + Leiden) -----
-    let community = cluster_cells(&cell_flat, n, h, cfg)?;
-    let n_comm = community.iter().copied().max().map_or(0, |m| m + 1).max(1);
-    info!(
-        "clustered cells into {n_comm} communities (knn={}, res={})",
-        cfg.knn, cfg.resolution
-    );
-
     // ----- 5. cluster × term over-representation + permutation calibration -----
-    let ora = cluster_term_ora(&assign, &community, n_comm, c, cfg);
+    let ora = cluster_term_ora(&assign, community, n_comm, c, cfg);
 
     // ----- 6. cluster calls → per-cell firm labels -----
     // Each cluster's call is its top over-represented term, kept only if
@@ -234,7 +284,7 @@ pub fn annotate_embeddings_ora(
     write_annot_parquet(
         out_prefix,
         cell_names,
-        &community,
+        community,
         &coarse_label,
         &assign,
         &dist,
@@ -247,7 +297,7 @@ pub fn annotate_embeddings_ora(
     write_label_tsvs(out_prefix, cell_names, &coarse_label, &coarse_conf)?;
     write_cluster_term_matrices(out_prefix, &comm_names, &type_names, &ora)?;
     write_calibration(out_prefix, &ora, n_assigned, n_outliers)?;
-    log_cluster_calls(&cluster_label, &type_names, &community, n_comm);
+    log_cluster_calls(&cluster_label, &type_names, community, n_comm);
 
     // ----- 7. optional ontology (TreeBH over the cluster × term matrix) -----
     if let (Some(obo), Some(label_cl)) = (cfg.obo.as_deref(), cfg.label_cl.as_deref()) {
@@ -262,7 +312,19 @@ pub fn annotate_embeddings_ora(
         )?;
     }
 
-    Ok(())
+    // Per-community calls, so a trajectory caller can name each node directly.
+    let comm_calls = CommunityCalls {
+        labels: (0..n_comm)
+            .map(|k| label_of(cluster_label[k], &type_names))
+            .collect(),
+        confidence: (0..n_comm)
+            .map(|k| match cluster_label[k] {
+                UNASSIGNED => 0.0,
+                t => ora.q_soft[k * c + t],
+            })
+            .collect(),
+    };
+    Ok(comm_calls)
 }
 
 //////////////////////////////

--- a/senna/Cargo.toml
+++ b/senna/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.6.13"
+version = "0.6.14"
 
 [lib]
 name = "senna"

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -642,6 +642,10 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
             feat_factor: None,
             // δ_g splice offset is gem-only (needs feat_factor); off for bge.
             delta_l2: 0.0,
+            // Lineage-DAG is a gem-only (β-sharing) path; off for bge.
+            lineage_dag: false,
+            dag_learnable: false,
+            lineage_smooth: false,
         })
     };
 


### PR DESCRIPTION
## Lineage-aware `faba gem` → `lineage` → `annotate`

Adds developmental-trajectory support end to end: gem shapes a velocity-oriented
pseudobulk DAG and lifts per-cell pseudotime/fate; lineage consumes gem's robust root;
and the trajectory is named by cell type using the existing annotation projection.
All gated by flags — default runs are unchanged / byte-identical.

### `faba gem --lineage-dag` (M0–M3)
- **M0**: analytic pb velocity readout (θ_pb + δ_pb), reusing the phase-2 dual solver.
- **M1** (default): fixed velocity-oriented KNN graph + velocity-drift SEM residual.
- **M2** (`--dag-learn`): learnable DAGMA `W`, **warm-started from M1** with sparse
  structure updates. Fixes a transposed SEM reconstruction that optimized velocity
  backward; with the warm-start + sparse cadence M2 becomes the strong path (mode
  ρ≈0.95, correct fate count) at 40 epochs.
- **M3**: phase-2 cell lift → per-cell pseudotime + fate, with a **root-anchoring** stage
  (source detection → BFS re-orientation → Dirichlet anchor; multi-root).
- Opt-in δ_pb smoothing (`--lineage-smooth`); per-run QC diagnostics + `underfit` floor
  (`{out}.lineage_qc.json`, honest: a floor + diagnostics, not a validated ranker).

### `faba lineage`
- `--root-from-gem`: anchor the MST root at gem's velocity-DAG root (min-pseudotime cell),
  more robust than the per-edge flux pick. On the sim: flux root ρ=−0.48 (inverted) →
  gem root ρ=+0.96.
- `--markers <gene\tcelltype TSV>`: name each trajectory node by cell type using the
  **same** term-ORA projection `faba annotate` uses, run over the MST-node grouping →
  per-node permutation-calibrated calls + `{out}.trajectory_annotation.parquet`
  (node → role → cell_type → q). Optional Cell-Ontology layer (`--marker-obo` /
  `--marker-label-cl`).

### Shared crate refactor
- `graph-embedding-util`: `annotate_with_communities` (pub) extracted from
  `annotate_embeddings_ora` — takes an external clustering; the Leiden path delegates, so
  `faba annotate` output is **byte-identical**.

### Rename
- GEM backronym → **Geodesic Embedding + Motion** (token/CLI unchanged).

### data-beans-sim
- `--trajectory`: branching-velocity ground truth used to validate all of the above.

## Validation
- Sim pseudotime recovery: M1 ρ≈0.85±0.05; M2 (fixed) mode ρ≈0.95, correct fate count.
- `--root-from-gem` fixes lineage orientation (−0.48 → +0.96) and Slingshot beats the
  coarse backbone.
- `lineage --markers` per-cell fine labels **byte-identical** to plain `faba annotate`;
  root resolves to the progenitor type.
- All crate tests pass; clippy clean; `faba annotate` regression byte-identical.

## Not in scope (deferred)
- Marker-prior root for the genuine seed tail on real data.
- Config/output `Option<Lineage…>` grouping + refine-block extraction (a `/simplify`
  altitude follow-on).
- Terminal-topic separation isn't demonstrable on the *interpolated* trajectory sim
  (annotate can't either) — a data property; distinct real cell types will separate.
