### PR TITLE
feat(senna): projection-based hierarchical-Bayes bulk deconvolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-util"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anndists",
  "anyhow",
@@ -5079,7 +5079,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "senna"
-version = "0.6.14"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -5105,6 +5105,7 @@ dependencies = [
  "log",
  "matrix-param",
  "matrix-util",
+ "mcmc-util",
  "nalgebra 0.34.2",
  "nalgebra-sparse",
  "ndarray",

--- a/matrix-util/Cargo.toml
+++ b/matrix-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-util"
-version = "0.3.7"
+version = "0.3.8"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/matrix-util/src/archetypal.rs
+++ b/matrix-util/src/archetypal.rs
@@ -422,7 +422,12 @@ fn assign_theta(z: &DMatrix<f32>, alpha: &DMatrix<f32>, fw_iters: usize) -> DMat
 }
 
 /// Solve `min_{a ∈ Δ^{K-1}} ‖x − αᵀ a‖²` by Frank–Wolfe.
-fn simplex_lsq(alpha: &DMatrix<f32>, x: &DVector<f32>, fw_iters: usize) -> DVector<f32> {
+///
+/// `alpha` is `[K, H]` (each row an archetype); the fit reconstructs `x` `[H]`
+/// as a convex combination `αᵀ a` of the rows. Returns the simplex weights `a`
+/// `[K]`. Reused by `senna deconvolve` to initialize cell-type fractions from a
+/// projected bulk sample against the anchor rows.
+pub fn simplex_lsq(alpha: &DMatrix<f32>, x: &DVector<f32>, fw_iters: usize) -> DVector<f32> {
     let k = alpha.nrows();
     let mut a = DVector::<f32>::from_element(k, 1.0 / k as f32);
     for _ in 0..fw_iters {

--- a/matrix-util/src/lib.rs
+++ b/matrix-util/src/lib.rs
@@ -20,6 +20,7 @@ pub mod parquet;
 pub mod principal_curve;
 pub mod principal_graph;
 pub mod progress;
+pub mod running_quantile;
 pub mod sparse_stat;
 pub mod tensor_io;
 pub mod tensor_util;

--- a/matrix-util/src/running_quantile.rs
+++ b/matrix-util/src/running_quantile.rs
@@ -1,0 +1,216 @@
+//! Online quantile estimation via the **P² algorithm** (Jain & Chlamtac, 1985):
+//! an arbitrary target quantile from a stream using five markers, O(1) memory,
+//! no stored samples. Companion to the running mean/variance in
+//! [`crate::traits::RunningStatOps`] for cases (e.g. MCMC credible intervals)
+//! where storing every draw to sort for a quantile is too expensive.
+
+/// Single-quantile P² estimator for a stream of scalars.
+///
+/// ```
+/// use matrix_util::running_quantile::P2Quantile;
+/// let mut med = P2Quantile::new(0.5);
+/// for i in 0..1000 { med.add(f64::from(i)); }
+/// assert!((med.quantile() - 500.0).abs() < 25.0);
+/// ```
+#[derive(Clone, Debug)]
+pub struct P2Quantile {
+    p: f64,
+    /// First ≤5 observations, buffered until the markers are initialized.
+    init: Vec<f64>,
+    q: [f64; 5],  // marker heights
+    n: [f64; 5],  // marker positions (integer-valued)
+    np: [f64; 5], // desired marker positions
+    dn: [f64; 5], // desired-position increments
+    count: usize,
+}
+
+impl P2Quantile {
+    #[must_use]
+    pub fn new(p: f64) -> Self {
+        let p = p.clamp(0.0, 1.0);
+        Self {
+            p,
+            init: Vec::with_capacity(5),
+            q: [0.0; 5],
+            n: [1.0, 2.0, 3.0, 4.0, 5.0],
+            np: [1.0, 1.0 + 2.0 * p, 1.0 + 4.0 * p, 3.0 + 2.0 * p, 5.0],
+            dn: [0.0, p / 2.0, p, (1.0 + p) / 2.0, 1.0],
+            count: 0,
+        }
+    }
+
+    pub fn add(&mut self, x: f64) {
+        self.count += 1;
+        if self.count <= 5 {
+            self.init.push(x);
+            if self.count == 5 {
+                self.init.sort_by(f64::total_cmp);
+                self.q.copy_from_slice(&self.init);
+            }
+            return;
+        }
+        // 1. Locate the cell k containing x, adjusting the extreme markers.
+        let k = if x < self.q[0] {
+            self.q[0] = x;
+            0
+        } else if x >= self.q[4] {
+            self.q[4] = x;
+            3
+        } else {
+            (0..4)
+                .find(|&i| self.q[i] <= x && x < self.q[i + 1])
+                .unwrap_or(3)
+        };
+        // 2. Increment positions of the markers above the cell.
+        for i in (k + 1)..5 {
+            self.n[i] += 1.0;
+        }
+        // 3. Advance the desired positions.
+        for i in 0..5 {
+            self.np[i] += self.dn[i];
+        }
+        // 4. Adjust the three interior markers (parabolic, or linear if it
+        //    would break monotonicity).
+        for i in 1..4 {
+            let d = self.np[i] - self.n[i];
+            let go_up = d >= 1.0 && (self.n[i + 1] - self.n[i]) > 1.0;
+            let go_dn = d <= -1.0 && (self.n[i - 1] - self.n[i]) < -1.0;
+            if go_up || go_dn {
+                let ds = if d >= 0.0 { 1.0 } else { -1.0 };
+                let qp = self.parabolic(i, ds);
+                self.q[i] = if self.q[i - 1] < qp && qp < self.q[i + 1] {
+                    qp
+                } else {
+                    self.linear(i, ds)
+                };
+                self.n[i] += ds;
+            }
+        }
+    }
+
+    fn parabolic(&self, i: usize, d: f64) -> f64 {
+        let (q, n) = (&self.q, &self.n);
+        q[i] + d / (n[i + 1] - n[i - 1])
+            * ((n[i] - n[i - 1] + d) * (q[i + 1] - q[i]) / (n[i + 1] - n[i])
+                + (n[i + 1] - n[i] - d) * (q[i] - q[i - 1]) / (n[i] - n[i - 1]))
+    }
+
+    fn linear(&self, i: usize, d: f64) -> f64 {
+        let j = if d > 0.0 { i + 1 } else { i - 1 };
+        self.q[i] + d * (self.q[j] - self.q[i]) / (self.n[j] - self.n[i])
+    }
+
+    /// Current estimate of the target quantile.
+    #[must_use]
+    pub fn quantile(&self) -> f64 {
+        if self.count == 0 {
+            return f64::NAN;
+        }
+        if self.count < 5 {
+            let mut v = self.init.clone();
+            v.sort_by(f64::total_cmp);
+            let idx = (((v.len() - 1) as f64) * self.p).round() as usize;
+            return v[idx.min(v.len() - 1)];
+        }
+        self.q[2]
+    }
+
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+/// Per-row P² trackers for a set of target quantiles, fed one dense column
+/// (observation vector) at a time — mirrors the column-add convention of
+/// [`crate::sparse_stat::SparseRunningStatistics`]. Row `r`'s estimate of the
+/// `qi`-th quantile is `quantile(qi)[r]`.
+pub struct RunningQuantiles {
+    nrows: usize,
+    quantiles: Vec<f64>,
+    est: Vec<P2Quantile>, // row-major: [row * n_quantiles + qi]
+}
+
+impl RunningQuantiles {
+    #[must_use]
+    pub fn new(nrows: usize, quantiles: &[f64]) -> Self {
+        let est = (0..nrows)
+            .flat_map(|_| quantiles.iter().map(|&p| P2Quantile::new(p)))
+            .collect();
+        Self {
+            nrows,
+            quantiles: quantiles.to_vec(),
+            est,
+        }
+    }
+
+    /// Feed one observation vector (length `nrows`).
+    pub fn add_dense_column(&mut self, values: &[f32]) {
+        assert_eq!(values.len(), self.nrows, "column length != nrows");
+        let nq = self.quantiles.len();
+        for (row, &v) in values.iter().enumerate() {
+            for qi in 0..nq {
+                self.est[row * nq + qi].add(f64::from(v));
+            }
+        }
+    }
+
+    /// Per-row estimate of the `qi`-th target quantile.
+    #[must_use]
+    pub fn quantile(&self, qi: usize) -> Vec<f32> {
+        let nq = self.quantiles.len();
+        (0..self.nrows)
+            .map(|row| self.est[row * nq + qi].quantile() as f32)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Deterministic near-uniform permutation of 0..m so the empirical CDF is
+    // known: the p-quantile is ≈ p·m.
+    fn perm(m: u64) -> impl Iterator<Item = f64> {
+        (0..m).map(move |i| ((i.wrapping_mul(7919)) % m) as f64)
+    }
+
+    #[test]
+    fn recovers_quantiles_within_tolerance() {
+        let m = 10_007u64;
+        for &p in &[0.05, 0.25, 0.5, 0.75, 0.95] {
+            let mut est = P2Quantile::new(p);
+            for x in perm(m) {
+                est.add(x);
+            }
+            let want = p * m as f64;
+            let got = est.quantile();
+            assert!(
+                (got - want).abs() < 0.02 * m as f64,
+                "p={p}: got {got:.1}, want ≈ {want:.1}"
+            );
+        }
+    }
+
+    #[test]
+    fn running_quantiles_per_row() {
+        // Two rows: row 0 ~ U(0,m), row 1 = row0 + m (shifted). Check both.
+        let m = 5_003u64;
+        let mut rq = RunningQuantiles::new(2, &[0.5]);
+        for x in perm(m) {
+            rq.add_dense_column(&[x as f32, x as f32 + m as f32]);
+        }
+        let med = rq.quantile(0);
+        assert!((med[0] - 0.5 * m as f32).abs() < 0.02 * m as f32);
+        assert!((med[1] - 1.5 * m as f32).abs() < 0.02 * m as f32);
+    }
+
+    #[test]
+    fn handles_fewer_than_five() {
+        let mut est = P2Quantile::new(0.5);
+        est.add(3.0);
+        est.add(1.0);
+        est.add(2.0);
+        assert!((est.quantile() - 2.0).abs() < 1e-9);
+    }
+}

--- a/senna/Cargo.toml
+++ b/senna/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.6.14"
+version = "0.7.0"
 
 [lib]
 name = "senna"
@@ -26,6 +26,7 @@ cuda = [
     "graph-embedding-util/cuda",
     "matrix-util/cuda",
     "matrix-param/cuda",
+    "mcmc-util/cuda",
 ]
 metal = [
     "candle-util/metal",
@@ -35,6 +36,7 @@ metal = [
     "graph-embedding-util/metal",
     "matrix-util/metal",
     "matrix-param/metal",
+    "mcmc-util/metal",
 ]
 hdf5 = ["data-beans/hdf5"]
 
@@ -48,6 +50,7 @@ genomic-data = { workspace = true }
 graph-embedding-util = { workspace = true }
 matrix-util = { workspace = true }
 matrix-param = { workspace = true }
+mcmc-util = { workspace = true }
 leiden = { workspace = true }
 hsblock = { workspace = true }
 petgraph = { workspace = true }

--- a/senna/examples/bench_tool.rs
+++ b/senna/examples/bench_tool.rs
@@ -1,0 +1,140 @@
+//! Throwaway benchmark helper for `senna deconvolve`:
+//!   markers <dict.parquet> <out.tsv> <topN>   — top-N genes per topic → marker TSV
+//!   score   <true_fractions.parquet> <fractions_ci.tsv>  — corr / RMSE / CI coverage
+
+use matrix_util::dmatrix_io::DMatrix;
+use matrix_util::traits::IoOps;
+use std::collections::HashMap;
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(String::as_str) {
+        Some("markers") => markers(&args[2], &args[3], args[4].parse()?),
+        Some("score") => score(&args[2], &args[3]),
+        _ => {
+            eprintln!("usage: bench_tool markers <dict.parquet> <out.tsv> <topN> | score <true.parquet> <ci.tsv>");
+            Ok(())
+        }
+    }
+}
+
+fn markers(dict: &str, out: &str, top_n: usize) -> anyhow::Result<()> {
+    let m = DMatrix::<f32>::from_parquet(dict)?; // G×K
+    let (g, k) = (m.mat.nrows(), m.mat.ncols());
+    let mut lines = Vec::new();
+    for kk in 0..k {
+        let mut idx: Vec<usize> = (0..g).collect();
+        idx.sort_by(|&a, &b| m.mat[(b, kk)].total_cmp(&m.mat[(a, kk)]));
+        for &gi in idx.iter().take(top_n) {
+            lines.push(format!("{}\t{}", m.rows[gi], m.cols[kk]));
+        }
+    }
+    std::fs::write(out, lines.join("\n"))?;
+    eprintln!(
+        "wrote {} marker rows ({top_n}/topic × {k} topics) → {out}",
+        lines.len()
+    );
+    Ok(())
+}
+
+fn score(truth: &str, ci_tsv: &str) -> anyhow::Result<()> {
+    let t = DMatrix::<f32>::from_parquet(truth)?; // rows=sample, cols=celltype
+                                                  // (sample,celltype) -> (mean, lo, hi)
+    let mut est: HashMap<(String, String), (f32, f32, f32)> = HashMap::new();
+    for (i, line) in std::fs::read_to_string(ci_tsv)?.lines().enumerate() {
+        if i == 0 {
+            continue;
+        }
+        let f: Vec<&str> = line.split('\t').collect();
+        if f.len() < 6 {
+            continue;
+        }
+        est.insert(
+            (f[0].to_string(), f[1].to_string()),
+            (f[2].parse()?, f[4].parse()?, f[5].parse()?),
+        );
+    }
+
+    let mut xs = Vec::new(); // true
+    let mut ys = Vec::new(); // est mean
+    let mut covered = 0usize;
+    let mut n = 0usize;
+    let mut abs_sum = 0f64;
+    let mut sq_sum = 0f64;
+    let mut per_ct: HashMap<String, (Vec<f32>, Vec<f32>)> = HashMap::new();
+    let mut missing = 0usize;
+    for (si, sname) in t.rows.iter().enumerate() {
+        for (ci, cname) in t.cols.iter().enumerate() {
+            let truth_v = t.mat[(si, ci)];
+            let Some(&(mean, lo, hi)) = est.get(&(sname.to_string(), cname.to_string())) else {
+                missing += 1;
+                continue;
+            };
+            xs.push(truth_v);
+            ys.push(mean);
+            let e = per_ct.entry(cname.to_string()).or_default();
+            e.0.push(truth_v);
+            e.1.push(mean);
+            if truth_v >= lo && truth_v <= hi {
+                covered += 1;
+            }
+            abs_sum += f64::from((mean - truth_v).abs());
+            sq_sum += f64::from((mean - truth_v).powi(2));
+            n += 1;
+        }
+    }
+    if missing > 0 {
+        eprintln!("WARNING: {missing} (sample,celltype) pairs had no estimate (name mismatch?)");
+        eprintln!("  truth samples e.g.: {:?}", &t.rows[..t.rows.len().min(2)]);
+        eprintln!("  truth celltypes: {:?}", t.cols);
+        let ks: Vec<_> = est.keys().take(2).cloned().collect();
+        eprintln!("  est keys e.g.: {ks:?}");
+    }
+
+    println!(
+        "n pairs        = {n}   ({} samples × {} celltypes)",
+        t.rows.len(),
+        t.cols.len()
+    );
+    println!("overall Pearson= {:.4}", pearson(&xs, &ys));
+    println!("RMSE           = {:.4}", (sq_sum / n as f64).sqrt());
+    println!("MAE            = {:.4}", abs_sum / n as f64);
+    println!(
+        "95% CI coverage= {:.1}%  ({covered}/{n})",
+        100.0 * covered as f64 / n as f64
+    );
+    let mut cts: Vec<_> = per_ct.keys().cloned().collect();
+    cts.sort();
+    for ct in cts {
+        let (x, y) = &per_ct[&ct];
+        println!(
+            "  {ct:<10} per-type Pearson = {:.4}  (mean true {:.3}, mean est {:.3})",
+            pearson(x, y),
+            x.iter().sum::<f32>() / x.len() as f32,
+            y.iter().sum::<f32>() / y.len() as f32
+        );
+    }
+    Ok(())
+}
+
+fn pearson(x: &[f32], y: &[f32]) -> f64 {
+    let n = x.len() as f64;
+    if n < 2.0 {
+        return f64::NAN;
+    }
+    let (sx, sy): (f64, f64) = (
+        x.iter().map(|&v| v as f64).sum(),
+        y.iter().map(|&v| v as f64).sum(),
+    );
+    let sxx: f64 = x.iter().map(|&v| (v as f64).powi(2)).sum();
+    let syy: f64 = y.iter().map(|&v| (v as f64).powi(2)).sum();
+    let sxy: f64 = x.iter().zip(y).map(|(&a, &b)| a as f64 * b as f64).sum();
+    let cov = sxy - sx * sy / n;
+    let vx = sxx - sx * sx / n;
+    let vy = syy - sy * sy / n;
+    if vx > 0.0 && vy > 0.0 {
+        cov / (vx.sqrt() * vy.sqrt())
+    } else {
+        f64::NAN
+    }
+}

--- a/senna/src/deconvolve/anchors.rs
+++ b/senna/src/deconvolve/anchors.rs
@@ -1,0 +1,190 @@
+//! Per-cell-type anchor prior `N(t̂_c, Σ_c)` in the embedding space — the
+//! channel through which annotate-by-projection uncertainty enters the
+//! deconvolution.
+//!
+//! `t̂_c` is the IDF-weighted centroid of type `c`'s marker genes in the anchor
+//! embedding (the same construction `annotate-by-projection` uses). `Σ_c` is
+//! the within-type scatter of those marker coordinates: **isotropic** `σ_c²·I`
+//! by default (confident, tight types → small `σ_c` → pinned fractions), or a
+//! **shrunk full** `H×H` covariance. A type with too few markers falls back to
+//! the global median spread.
+
+use super::args::{AnchorConfig, AnchorCov};
+use crate::embed_common::Mat;
+use crate::marker_support::build_annotation_matrix;
+use anyhow::Result;
+use log::info;
+use matrix_util::utils::median;
+
+/// Minimum markers for a type to trust its own scatter estimate.
+const MIN_MARKERS_FOR_SCATTER: usize = 2;
+/// Shrinkage weight toward the isotropic target in `AnchorCov::Full`.
+const SHRINK_ALPHA: f32 = 0.1;
+/// Diagonal jitter keeping the shrunk covariance positive-definite.
+const COV_JITTER: f32 = 1e-4;
+
+pub struct AnchorPrior {
+    /// `C×H` prior means `t̂_c` (rows).
+    pub mean: Mat,
+    /// `C` cell-type names.
+    pub names: Vec<Box<str>>,
+    /// `C` isotropic prior std per type (used directly in isotropic mode, and
+    /// as the Cholesky fallback in full mode).
+    pub sigma: Vec<f32>,
+    /// `C` lower-triangular Cholesky factors `L_c` (`H×H`) for full-covariance
+    /// mode; `None` for isotropic mode.
+    pub chol: Option<Vec<Mat>>,
+}
+
+pub fn build_anchor_prior(
+    anchor_emb: &Mat,
+    gene_names: &[Box<str>],
+    markers_path: &str,
+    cfg: &AnchorConfig,
+) -> Result<AnchorPrior> {
+    let info = build_annotation_matrix(markers_path, gene_names)?;
+    let membership = info.membership_ga; // G×C, IDF-weighted
+    let names = info.annot_names;
+    let (c, h, d) = (names.len(), anchor_emb.ncols(), anchor_emb.nrows());
+    anyhow::ensure!(
+        membership.nrows() == d,
+        "anchor: marker membership genes ({}) != embedding genes ({d})",
+        membership.nrows()
+    );
+    anyhow::ensure!(c >= 2, "anchor: need at least 2 cell types, got {c}");
+
+    // Per-type IDF-weighted centroid + marker bookkeeping.
+    let mut mean = Mat::zeros(c, h);
+    let mut wsum = vec![0f32; c];
+    let mut count = vec![0usize; c];
+    for g in 0..d {
+        for ct in 0..c {
+            let w = membership[(g, ct)];
+            if w > 0.0 {
+                wsum[ct] += w;
+                count[ct] += 1;
+                for j in 0..h {
+                    mean[(ct, j)] += w * anchor_emb[(g, j)];
+                }
+            }
+        }
+    }
+    for ct in 0..c {
+        if wsum[ct] > 0.0 {
+            for j in 0..h {
+                mean[(ct, j)] /= wsum[ct];
+            }
+        }
+    }
+
+    // Per-type average per-dimension scatter → isotropic σ_c².
+    let mut var = vec![0f32; c];
+    for g in 0..d {
+        for ct in 0..c {
+            let w = membership[(g, ct)];
+            if w > 0.0 {
+                let mut sq = 0f32;
+                for j in 0..h {
+                    let dlt = anchor_emb[(g, j)] - mean[(ct, j)];
+                    sq += dlt * dlt;
+                }
+                var[ct] += w * sq;
+            }
+        }
+    }
+    let mut sigma = vec![0f32; c];
+    let mut valid = Vec::new();
+    for ct in 0..c {
+        if wsum[ct] > 0.0 && count[ct] >= MIN_MARKERS_FOR_SCATTER {
+            let s = (var[ct] / (h as f32 * wsum[ct])).max(0.0).sqrt();
+            sigma[ct] = s;
+            if s > 0.0 {
+                valid.push(s);
+            }
+        }
+    }
+    // Global fallback spread for under-determined types.
+    let global = if valid.is_empty() {
+        embedding_std(anchor_emb).max(1e-3)
+    } else {
+        median(&valid)
+    };
+    let floor = 1e-3 * global;
+    for s in &mut sigma {
+        if *s <= 0.0 {
+            *s = global;
+        }
+        *s = s.max(floor) * cfg.scale;
+    }
+    info!(
+        "anchor prior: {c} types, σ range [{:.3e}, {:.3e}] (median {:.3e}, scale {:.2})",
+        sigma.iter().cloned().fold(f32::INFINITY, f32::min),
+        sigma.iter().cloned().fold(0.0, f32::max),
+        global * cfg.scale,
+        cfg.scale
+    );
+
+    let chol = match cfg.cov {
+        AnchorCov::Isotropic => None,
+        AnchorCov::Full => Some(full_cholesky(anchor_emb, &membership, &mean, &sigma, h)),
+    };
+
+    Ok(AnchorPrior {
+        mean,
+        names,
+        sigma,
+        chol,
+    })
+}
+
+/// Global per-dimension std of the embedding (fallback spread).
+fn embedding_std(emb: &Mat) -> f32 {
+    let n = (emb.nrows() * emb.ncols()) as f32;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = emb.sum() / n;
+    let var = emb.iter().map(|&x| (x - mean) * (x - mean)).sum::<f32>() / n;
+    var.max(0.0).sqrt()
+}
+
+/// Shrunk full-covariance Cholesky factors, one per type. Shrinks the weighted
+/// empirical covariance toward `σ_c²·I` and adds jitter; falls back to the
+/// isotropic `σ_c·I` factor if the Cholesky is not positive-definite.
+fn full_cholesky(emb: &Mat, membership: &Mat, mean: &Mat, sigma: &[f32], h: usize) -> Vec<Mat> {
+    let c = mean.nrows();
+    let d = emb.nrows();
+    (0..c)
+        .map(|ct| {
+            let mut cov = Mat::zeros(h, h);
+            let mut wsum = 0f32;
+            for g in 0..d {
+                let w = membership[(g, ct)];
+                if w > 0.0 {
+                    wsum += w;
+                    let mut dv = vec![0f32; h];
+                    for j in 0..h {
+                        dv[j] = emb[(g, j)] - mean[(ct, j)];
+                    }
+                    for a in 0..h {
+                        for b in 0..h {
+                            cov[(a, b)] += w * dv[a] * dv[b];
+                        }
+                    }
+                }
+            }
+            let target = sigma[ct] * sigma[ct]; // isotropic target variance
+            if wsum > 0.0 {
+                cov /= wsum;
+            }
+            for a in 0..h {
+                for b in 0..h {
+                    cov[(a, b)] *= 1.0 - SHRINK_ALPHA;
+                }
+                cov[(a, a)] += SHRINK_ALPHA * target + COV_JITTER;
+            }
+            cov.cholesky()
+                .map_or_else(|| Mat::identity(h, h) * sigma[ct], |c| c.l())
+        })
+        .collect()
+}

--- a/senna/src/deconvolve/args.rs
+++ b/senna/src/deconvolve/args.rs
@@ -1,0 +1,200 @@
+//! CLI arguments for `senna deconvolve`.
+
+use clap::{Args, ValueEnum};
+
+/// Prior covariance shape for the per-cell-type anchor `t_c`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum AnchorCov {
+    /// `Σ_c = σ_c²·I` — one scale per type from the marker-coordinate scatter.
+    Isotropic,
+    /// Shrunk empirical `H×H` covariance of the type's marker coordinates.
+    Full,
+}
+
+#[derive(Args, Debug)]
+pub struct DeconvolveArgs {
+    #[arg(
+        short = 'f',
+        long = "from",
+        required = true,
+        help = "Run manifest with a feature embedding: `senna bge --skip-etm` or `masked-topic`",
+        long_help = "Run manifest exposing a per-gene embedding ρ.\n\
+                     `senna bge --skip-etm` is exact: the raw Poisson ρ is persisted as\n\
+                     dictionary.parquet (default ETM bge overwrites it with β — re-run with\n\
+                     --skip-etm). `masked-topic` is supported as a transfer approximation\n\
+                     (its ρ was trained under a softmax-ETM head)."
+    )]
+    pub from: Box<str>,
+
+    #[arg(
+        short = 'm',
+        long = "markers",
+        required = true,
+        help = "Marker-gene TSV: `gene<TAB>celltype` per line (tab/comma/space delimited)"
+    )]
+    pub markers: Box<str>,
+
+    #[arg(
+        long = "bulk",
+        required = true,
+        num_args = 1..,
+        help = "One or more bulk count matrices (parquet/tsv; genes × samples)"
+    )]
+    pub bulk: Vec<Box<str>>,
+
+    #[arg(
+        short = 'o',
+        long = "out",
+        help = "Output prefix (default: `--from` with `.senna.json`/`.json` stripped, `.deconv`)"
+    )]
+    pub out: Option<Box<str>>,
+
+    //////////////////////////////////////////////////////////////////////
+    // Sampler                                                            //
+    //////////////////////////////////////////////////////////////////////
+    #[arg(
+        long = "warmup",
+        default_value_t = 500,
+        help = "Gibbs warmup (burn-in) sweeps, discarded before collection"
+    )]
+    pub warmup: usize,
+
+    #[arg(
+        long = "draws",
+        default_value_t = 500,
+        help = "Posterior draws collected after warmup (thinned)"
+    )]
+    pub draws: usize,
+
+    #[arg(
+        long = "thin",
+        default_value_t = 1,
+        help = "Keep one draw per `thin` sweeps"
+    )]
+    pub thin: usize,
+
+    #[arg(
+        long = "seed",
+        default_value_t = 42,
+        help = "RNG seed (per-sample + anchor chains)"
+    )]
+    pub seed: u64,
+
+    #[arg(
+        long = "frac-prior-shape",
+        default_value_t = 1.0,
+        help = "Gamma prior shape a0 on cell-type abundances w (weak: 1.0)"
+    )]
+    pub frac_prior_shape: f32,
+
+    #[arg(
+        long = "frac-prior-rate",
+        default_value_t = 1.0,
+        help = "Gamma prior rate b0 on cell-type abundances w (weak: 1.0)"
+    )]
+    pub frac_prior_rate: f32,
+
+    #[arg(
+        long = "project-ridge",
+        default_value_t = 1.0,
+        help = "Ridge λ for the Poisson projection of bulk into the embedding"
+    )]
+    pub project_ridge: f64,
+
+    #[arg(
+        long = "init-iters",
+        default_value_t = 50,
+        help = "Frank-Wolfe iterations for the simplex fraction initialization"
+    )]
+    pub init_iters: usize,
+
+    #[arg(
+        long = "nb-dispersion",
+        default_value_t = 10000.0,
+        help = "Negative-binomial dispersion r (size); smaller = more overdispersion (default ≈ Poisson)",
+        long_help = "Per-(gene,sample) overdispersion via a Gamma(r,r) multiplicative factor ε\n\
+                     on the Poisson rate: y ~ Poisson(ε·Σ_c w_c μ_{g,c}), Var(y)=λ+λ²/r. Small r\n\
+                     absorbs reference/gene misfit into ε; r → ∞ recovers Poisson. Held fixed:\n\
+                     freely sampling r is non-identifiable against the fractions (ε competes with\n\
+                     w through the per-type exposure), so it is a knob, not a hyperparameter."
+    )]
+    pub nb_dispersion: f32,
+
+    #[arg(
+        long = "count-scale",
+        default_value_t = 1.0,
+        help = "Effective-count multiplier τ ∈ (0,1] tempering the likelihood (smaller → wider CIs)",
+        long_help = "Power-posterior temperature: all count sufficient statistics are scaled by τ\n\
+                     (likelihood^τ), so the posterior reflects τ·(observed counts) of independent\n\
+                     evidence. τ=1 uses raw counts (tight, often overconfident at high depth);\n\
+                     τ<1 widens credible intervals (variance ∝ 1/τ). Calibrate against held-out\n\
+                     coverage."
+    )]
+    pub count_scale: f32,
+
+    //////////////////////////////////////////////////////////////////////
+    // Anchors (annotate-by-projection uncertainty)                       //
+    //////////////////////////////////////////////////////////////////////
+    #[arg(
+        long = "anchor-cov",
+        value_enum,
+        default_value_t = AnchorCov::Isotropic,
+        help = "Anchor prior covariance: isotropic scale, or shrunk full H×H"
+    )]
+    pub anchor_cov: AnchorCov,
+
+    #[arg(
+        long = "anchor-prior-scale",
+        default_value_t = 1.0,
+        help = "Multiplier on the anchor prior spread (larger → looser, wider fraction CIs)"
+    )]
+    pub anchor_prior_scale: f32,
+}
+
+/// Plain (non-clap) sampler settings threaded into the Gibbs core.
+pub struct SamplerConfig {
+    pub warmup: usize,
+    pub draws: usize,
+    pub thin: usize,
+    pub seed: u64,
+    pub a0: f32,
+    pub b0: f32,
+    pub project_ridge: f64,
+    pub init_iters: usize,
+    /// NB dispersion r (`--nb-dispersion`), held fixed.
+    pub nb_r: f32,
+    /// Likelihood tempering τ (`--count-scale`).
+    pub tau: f32,
+}
+
+/// Plain (non-clap) anchor-prior settings.
+pub struct AnchorConfig {
+    pub cov: AnchorCov,
+    pub scale: f32,
+}
+
+impl DeconvolveArgs {
+    #[must_use]
+    pub fn sampler_config(&self) -> SamplerConfig {
+        SamplerConfig {
+            warmup: self.warmup,
+            draws: self.draws,
+            thin: self.thin,
+            seed: self.seed,
+            a0: self.frac_prior_shape,
+            b0: self.frac_prior_rate,
+            project_ridge: self.project_ridge,
+            init_iters: self.init_iters,
+            nb_r: self.nb_dispersion,
+            tau: self.count_scale,
+        }
+    }
+
+    #[must_use]
+    pub fn anchor_config(&self) -> AnchorConfig {
+        AnchorConfig {
+            cov: self.anchor_cov,
+            scale: self.anchor_prior_scale,
+        }
+    }
+}

--- a/senna/src/deconvolve/gibbs.rs
+++ b/senna/src/deconvolve/gibbs.rs
@@ -1,0 +1,470 @@
+//! Hierarchical Gibbs sampler for projection-based deconvolution.
+//!
+//! Model, per bulk sample `s` (rayon-parallel; independent seeded chains):
+//! ```text
+//!   μ_{g,c} = exp(ρ_g·t_c + a_g)
+//!   ε_{s,g} ~ Gamma(r, r)                            (NB overdispersion, mean 1)
+//!   y_{s,g} ~ Poisson(ε_{s,g}·Σ_c w_{s,c} μ_{g,c})
+//!   Z_{s,·,g} ~ Multinomial(y_{s,g}, p), p_c ∝ w_{s,c} μ_{g,c}   (ε cancels in the split)
+//!   ε_{s,g}   ~ Gamma(r + τy_{s,g}, r + τλ_{s,g})                (conjugate)
+//!   w_{s,c}   ~ Gamma(a0 + τΣ_g Z_{s,c,g}, b0 + τΣ_g ε_{s,g}μ_{g,c})
+//! ```
+//! `r` (`--nb-dispersion`) is the negative-binomial dispersion, held fixed
+//! (freely sampling it is non-identifiable against the fractions — ε competes
+//! with w through the per-type exposure). `r → ∞` recovers Poisson. `τ`
+//! (`--count-scale`) tempers the likelihood (power posterior):
+//! every count sufficient statistic is scaled by τ, so the posterior reflects
+//! τ·(observed counts) of evidence and its variance scales as 1/τ — the CI
+//! calibration knob at high read depth.
+//! Global cell-type anchors `t_c` are resampled by one elliptical-slice step
+//! per sweep under the annotate-by-projection prior `N(t̂_c, Σ_c)`, with the
+//! pooled Poisson likelihood
+//! `ℓ(t_c) = τ·Σ_g[A_{c,g}(ρ_g·t_c+a_g) − W_{c,g}·exp(ρ_g·t_c+a_g)]`,
+//! `A_{c,g}=Σ_s Z_{s,c,g}`, `W_{c,g}=Σ_s w_{s,c}·ε_{s,g}` (ε-weighted exposure).
+//! This is the coupling that lets annotation uncertainty widen (or confident
+//! types pin) the fraction posterior.
+
+use super::anchors::AnchorPrior;
+use super::args::SamplerConfig;
+use super::source::EmbeddingSource;
+use crate::embed_common::{DVec, Mat};
+use log::info;
+use matrix_util::running_quantile::RunningQuantiles;
+use mcmc_util::engine::elliptical_slice_step;
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+use rand_distr::{Binomial, Distribution, Gamma, StandardNormal};
+use rayon::prelude::*;
+
+/// Clamp on the Poisson log-rate before `exp`.
+const SCORE_CLAMP: f32 = 30.0;
+/// Offset for the anchor-chain RNG seed (separate stream from the per-sample chains).
+const ANCHOR_SEED_OFFSET: u64 = 0x9E37_79B9_7F4A_7C15;
+
+pub struct ResidualStat {
+    pub total: f64,
+    pub deviance: f64,
+    pub pearson: f64,
+}
+
+pub struct DeconvResult {
+    pub fractions_mean: Mat,
+    pub fractions_sd: Mat,
+    pub fractions_lo: Mat,
+    pub fractions_hi: Mat,
+    pub abundance_mean: Mat,
+    pub expression: Vec<Mat>,
+    pub anchors_post: Mat,
+    pub residual: Vec<ResidualStat>,
+    pub celltype_names: Vec<Box<str>>,
+}
+
+struct SampleOut {
+    w_new: Vec<f32>,
+    contrib: Vec<f32>, // sampled counts, laid out [c*D + g]
+    eps: Vec<f32>,     // NB overdispersion factor per gene
+}
+
+/// Sweep-invariant inputs shared across all samples. `mu_gm` is gene-major
+/// (`mu_gm[g*C + ct] = μ_{g,c}`) so the inner per-type loop reads a contiguous,
+/// SIMD-friendly slice instead of a strided column.
+struct SweepCtx<'a> {
+    mu_gm: &'a [f32],
+    d: usize,
+    c: usize,
+    a0: f32,
+    b0: f32,
+    /// NB dispersion `r` and likelihood temperature `τ`.
+    nb_r: f32,
+    tau: f32,
+}
+
+/// Sample one bulk column: per-gene NB factor `ε`, gene allocation `Z`, then a
+/// tempered Gamma draw of the abundances `w`.
+fn sample_one(ctx: &SweepCtx, y_col: &[f32], w_s: &[f32], rng: &mut SmallRng) -> SampleOut {
+    let (d, c) = (ctx.d, ctx.c);
+    let (r, tau) = (ctx.nb_r, ctx.tau);
+    let mut nvec = vec![0f32; c];
+    let mut contrib = vec![0f32; c * d];
+    let mut eps = vec![0f32; d];
+    let mut m_exp = vec![0f32; c]; // ε-weighted exposure Σ_g ε_g μ_{g,c}
+    let mut rr = vec![0f32; c];
+    for g in 0..d {
+        let mu_row = &ctx.mu_gm[g * c..g * c + c]; // contiguous over cell types
+        let mut lam = 0f32;
+        for ct in 0..c {
+            let rc = w_s[ct] * mu_row[ct];
+            rr[ct] = rc;
+            lam += rc;
+        }
+        let y = y_col[g].round();
+        // ε_g ~ Gamma(r + τy, r + τλ): soaks per-gene misfit; ε→1 as r→∞.
+        let eg = Gamma::new(f64::from(r + tau * y), 1.0 / f64::from(r + tau * lam))
+            .map_or(1.0, |gm| gm.sample(rng) as f32);
+        eps[g] = eg;
+        for ct in 0..c {
+            m_exp[ct] += eg * mu_row[ct];
+        }
+        if y <= 0.0 || lam <= 0.0 {
+            continue;
+        }
+        // Multinomial(y, rr/λ) via conditional binomials — ε cancels here.
+        let mut remaining = y as u64;
+        let mut remain_p = lam;
+        for ct in 0..c - 1 {
+            if remaining == 0 {
+                break;
+            }
+            let p = if remain_p > 0.0 {
+                f64::from((rr[ct] / remain_p).clamp(0.0, 1.0))
+            } else {
+                0.0
+            };
+            let zc = if p >= 1.0 {
+                remaining
+            } else if p <= 0.0 {
+                0
+            } else {
+                Binomial::new(remaining, p).map_or(0, |b| b.sample(rng))
+            };
+            nvec[ct] += zc as f32;
+            contrib[ct * d + g] = zc as f32;
+            remaining -= zc;
+            remain_p -= rr[ct];
+        }
+        nvec[c - 1] += remaining as f32;
+        contrib[(c - 1) * d + g] = remaining as f32;
+    }
+
+    // w_c ~ Gamma(a0 + τ·n_c, b0 + τ·M_c): tempered, ε-weighted exposure.
+    let mut w_new = vec![0f32; c];
+    for ct in 0..c {
+        let shape = f64::from(ctx.a0 + tau * nvec[ct]);
+        let scale = 1.0 / f64::from(ctx.b0 + tau * m_exp[ct]);
+        let draw = Gamma::new(shape, scale).map_or(1e-12, |g| g.sample(rng) as f32);
+        w_new[ct] = if draw.is_finite() && draw > 1e-12 {
+            draw
+        } else {
+            1e-12
+        };
+    }
+    SampleOut {
+        w_new,
+        contrib,
+        eps,
+    }
+}
+
+pub fn run_gibbs(
+    src: &EmbeddingSource,
+    bulk: &Mat,
+    prior: &AnchorPrior,
+    init_w: &Mat,
+    cfg: &SamplerConfig,
+) -> anyhow::Result<DeconvResult> {
+    let d = src.rho.nrows();
+    let h = src.h;
+    let s = bulk.ncols();
+    let c = prior.mean.nrows();
+    anyhow::ensure!(
+        bulk.nrows() == d,
+        "gibbs: bulk genes ({}) != ρ genes ({d})",
+        bulk.nrows()
+    );
+
+    let mem_floats = (c as u128) * (d as u128) * (s as u128);
+    if mem_floats > 200_000_000 {
+        info!(
+            "deconvolve: expression tensor is large (C·D·S ≈ {} floats); consider a reduced \
+             gene reference if memory is tight",
+            mem_floats
+        );
+    }
+
+    let a = &src.gene_offset;
+    // ρ·t̂_cᵀ is constant across sweeps (anchor means are fixed); precompute the
+    // base log-rate so each anchor lnpdf only adds ρ·δ.
+    let base = &src.rho * prior.mean.transpose(); // D×C
+                                                  // ρᵀ reused every sweep to form the C×D log-rate in one gemm.
+    let rho_t = src.rho.transpose(); // H×D
+
+    // Per-sample abundances + independent RNG streams.
+    let mut w: Vec<Vec<f32>> = (0..s)
+        .map(|si| (0..c).map(|ct| init_w[(si, ct)]).collect())
+        .collect();
+    let mut rngs: Vec<SmallRng> = (0..s)
+        .map(|si| SmallRng::seed_from_u64(cfg.seed.wrapping_add(si as u64)))
+        .collect();
+    let mut anchor_rng = SmallRng::seed_from_u64(cfg.seed.wrapping_add(ANCHOR_SEED_OFFSET));
+
+    // Anchor state: t_c = t̂_c + δ_c (δ starts at zero).
+    let mut delta: Vec<DVec> = (0..c).map(|_| DVec::zeros(h)).collect();
+    let mut tmat = prior.mean.clone(); // C×H current anchors
+
+    // Post-warmup accumulators. Fraction mean/sd come from running moments and
+    // the credible interval from streaming P² quantiles — no stored per-draw arrays.
+    let mut frac_sum = vec![0f64; s * c];
+    let mut frac_sumsq = vec![0f64; s * c];
+    let mut frac_quant = RunningQuantiles::new(s * c, &[0.025, 0.975]);
+    let mut frac_flat = vec![0f32; s * c]; // this sweep's fractions, fed to the quantiles
+    let mut abundance_sum = vec![0f64; s * c];
+    // Per type a column-major D×S block: [ct*D*S + si*D + g].
+    let mut zexp = vec![0f64; c * d * s];
+    let mut delta_sum: Vec<DVec> = (0..c).map(|_| DVec::zeros(h)).collect();
+    let mut n_collect = 0usize;
+
+    // Per-sweep scratch, allocated once and refilled each sweep.
+    let mut mu_gm = vec![0f32; c * d];
+    let mut a_pool = vec![0f32; c * d];
+    let mut w_exp = vec![0f32; c * d];
+
+    let total = cfg.warmup + cfg.draws * cfg.thin.max(1);
+    for it in 0..total {
+        // 1. Reference rates from the current anchors, gene-major. tmat·ρᵀ is
+        // C×D column-major, whose buffer index g*C+ct already equals ρ_g·t_c —
+        // exactly the gene-major μ layout the sampler reads contiguously.
+        let scd = &tmat * &rho_t; // C×D
+        let scd_buf = scd.as_slice();
+        for i in 0..c * d {
+            mu_gm[i] = (scd_buf[i] + a[i / c])
+                .clamp(-SCORE_CLAMP, SCORE_CLAMP)
+                .exp();
+        }
+
+        // 2. Per-sample NB factor + gene allocation + abundance draw (parallel).
+        // Bulk is column-major, so each sample's gene column is a zero-copy slice.
+        let ctx = SweepCtx {
+            mu_gm: &mu_gm,
+            d,
+            c,
+            a0: cfg.a0,
+            b0: cfg.b0,
+            nb_r: cfg.nb_r,
+            tau: cfg.tau,
+        };
+        let bulk_buf = bulk.as_slice();
+        let outs: Vec<SampleOut> = rngs
+            .par_iter_mut()
+            .enumerate()
+            .map(|(si, rng)| sample_one(&ctx, &bulk_buf[si * d..(si + 1) * d], &w[si], rng))
+            .collect();
+
+        // 3. Aggregate: update w, pooled A and W, and (post-warmup) collect.
+        let collecting = it >= cfg.warmup && (it - cfg.warmup).is_multiple_of(cfg.thin.max(1));
+        // A_{c,g} = Σ_s Z_{s,c,g}; W_{c,g} = Σ_s w_{s,c}·ε_{s,g} (ε-weighted exposure).
+        a_pool.fill(0.0);
+        w_exp.fill(0.0);
+        for (si, out) in outs.iter().enumerate() {
+            w[si].copy_from_slice(&out.w_new);
+            let wsum: f32 = out.w_new.iter().sum();
+            for (ap, &cn) in a_pool.iter_mut().zip(&out.contrib) {
+                *ap += cn;
+            }
+            for ct in 0..c {
+                let wc = out.w_new[ct];
+                for (we, &e) in w_exp[ct * d..(ct + 1) * d].iter_mut().zip(&out.eps) {
+                    *we += wc * e;
+                }
+            }
+            if collecting {
+                for ct in 0..c {
+                    let idx = si * c + ct;
+                    let frac = if wsum > 0.0 {
+                        out.w_new[ct] / wsum
+                    } else {
+                        0.0
+                    };
+                    frac_flat[idx] = frac;
+                    frac_sum[idx] += f64::from(frac);
+                    frac_sumsq[idx] += f64::from(frac) * f64::from(frac);
+                    abundance_sum[idx] += f64::from(out.w_new[ct]);
+                    // zexp per type is a contiguous column-major D×S block.
+                    let off = ct * d * s + si * d;
+                    let dst = &mut zexp[off..off + d];
+                    for (z, &v) in dst.iter_mut().zip(&out.contrib[ct * d..ct * d + d]) {
+                        *z += f64::from(v);
+                    }
+                }
+            }
+        }
+
+        // 4. Anchor ESS update (one step per type; A,W changed this sweep).
+        // Likelihood tempered by τ (same power posterior as the count updates).
+        let tau = cfg.tau;
+        for ct in 0..c {
+            let a_c = &a_pool[ct * d..(ct + 1) * d];
+            let w_cg = &w_exp[ct * d..(ct + 1) * d];
+            let base_c = base.column(ct);
+            let lnpdf = |dl: &DVec| -> f32 {
+                let rd = &src.rho * dl; // D
+                let mut ll = 0f32;
+                for g in 0..d {
+                    let sg = base_c[g] + rd[g] + a[g];
+                    ll += a_c[g] * sg - w_cg[g] * sg.clamp(-SCORE_CLAMP, SCORE_CLAMP).exp();
+                }
+                tau * ll
+            };
+            let prior_sample = draw_prior(prior, ct, h, &mut anchor_rng);
+            let cur_ll = lnpdf(&delta[ct]);
+            let (new_delta, _) =
+                elliptical_slice_step(&delta[ct], &prior_sample, &lnpdf, cur_ll, &mut anchor_rng);
+            delta[ct] = new_delta;
+            // t_c = t̂_c + δ_c → refresh the anchor row.
+            for j in 0..h {
+                tmat[(ct, j)] = prior.mean[(ct, j)] + delta[ct][j];
+            }
+            if collecting {
+                delta_sum[ct] += &delta[ct];
+            }
+        }
+
+        if collecting {
+            frac_quant.add_dense_column(&frac_flat);
+            n_collect += 1;
+        }
+        if it % 100 == 0 {
+            info!("deconvolve gibbs: sweep {it}/{total} (collected {n_collect})");
+        }
+    }
+
+    anyhow::ensure!(n_collect > 0, "gibbs: no posterior draws collected");
+    let frac_lo = frac_quant.quantile(0);
+    let frac_hi = frac_quant.quantile(1);
+    let acc = Accum {
+        frac_sum: &frac_sum,
+        frac_sumsq: &frac_sumsq,
+        frac_lo: &frac_lo,
+        frac_hi: &frac_hi,
+        abundance_sum: &abundance_sum,
+        zexp: &zexp,
+        delta_sum: &delta_sum,
+        n_collect,
+    };
+    Ok(finalize(src, bulk, prior, &acc))
+}
+
+/// Post-warmup accumulators handed to [`finalize`].
+struct Accum<'a> {
+    frac_sum: &'a [f64],
+    frac_sumsq: &'a [f64],
+    frac_lo: &'a [f32],
+    frac_hi: &'a [f32],
+    abundance_sum: &'a [f64],
+    zexp: &'a [f64],
+    delta_sum: &'a [DVec],
+    n_collect: usize,
+}
+
+/// Draw `ν ~ N(0, Σ_c)`: `σ_c·z` (isotropic) or `L_c·z` (full).
+fn draw_prior(prior: &AnchorPrior, ct: usize, h: usize, rng: &mut SmallRng) -> DVec {
+    let z = DVec::from_fn(h, |_, _| {
+        let v: f64 = StandardNormal.sample(rng);
+        v as f32
+    });
+    match &prior.chol {
+        Some(chols) => &chols[ct] * z,
+        None => z * prior.sigma[ct],
+    }
+}
+
+fn finalize(src: &EmbeddingSource, bulk: &Mat, prior: &AnchorPrior, acc: &Accum) -> DeconvResult {
+    let d = src.rho.nrows();
+    let h = src.h;
+    let s = bulk.ncols();
+    let c = prior.mean.nrows();
+    let nc = acc.n_collect as f64;
+    let (zexp, delta_sum) = (acc.zexp, acc.delta_sum);
+
+    let mut fractions_mean = Mat::zeros(s, c);
+    let mut fractions_sd = Mat::zeros(s, c);
+    let mut fractions_lo = Mat::zeros(s, c);
+    let mut fractions_hi = Mat::zeros(s, c);
+    let mut abundance_mean = Mat::zeros(s, c);
+    for si in 0..s {
+        for ct in 0..c {
+            let idx = si * c + ct;
+            let mean = (acc.frac_sum[idx] / nc) as f32;
+            let var = (acc.frac_sumsq[idx] / nc - f64::from(mean) * f64::from(mean)).max(0.0);
+            fractions_mean[(si, ct)] = mean;
+            fractions_sd[(si, ct)] = var.sqrt() as f32;
+            fractions_lo[(si, ct)] = acc.frac_lo[idx];
+            fractions_hi[(si, ct)] = acc.frac_hi[idx];
+            abundance_mean[(si, ct)] = (acc.abundance_sum[idx] / nc) as f32;
+        }
+    }
+
+    let expression: Vec<Mat> = (0..c)
+        .map(|ct| Mat::from_fn(d, s, |g, si| (zexp[ct * d * s + si * d + g] / nc) as f32))
+        .collect();
+
+    let mut anchors_post = prior.mean.clone();
+    for ct in 0..c {
+        for j in 0..h {
+            anchors_post[(ct, j)] += delta_sum[ct][j] / acc.n_collect as f32;
+        }
+    }
+
+    // Posterior-predictive residuals at the posterior-mean anchors + abundances.
+    let sc = &src.rho * anchors_post.transpose();
+    let mu = Mat::from_fn(d, c, |g, ct| {
+        (sc[(g, ct)] + src.gene_offset[g])
+            .clamp(-SCORE_CLAMP, SCORE_CLAMP)
+            .exp()
+    });
+    let residual = (0..s)
+        .map(|si| residual_stat(bulk, &mu, &abundance_mean, si))
+        .collect();
+
+    DeconvResult {
+        fractions_mean,
+        fractions_sd,
+        fractions_lo,
+        fractions_hi,
+        abundance_mean,
+        expression,
+        anchors_post,
+        residual,
+        celltype_names: prior.names.clone(),
+    }
+}
+
+fn residual_stat(bulk: &Mat, mu: &Mat, abundance: &Mat, si: usize) -> ResidualStat {
+    let d = bulk.nrows();
+    let c = mu.ncols();
+    let mut total = 0f64;
+    let mut deviance = 0f64;
+    let (mut sy, mut sl, mut syy, mut sll, mut syl) = (0f64, 0f64, 0f64, 0f64, 0f64);
+    for g in 0..d {
+        let y = f64::from(bulk[(g, si)]).max(0.0);
+        let mut lam = 0f64;
+        for ct in 0..c {
+            lam += f64::from(abundance[(si, ct)]) * f64::from(mu[(g, ct)]);
+        }
+        lam = lam.max(1e-12);
+        total += y;
+        deviance += if y > 0.0 {
+            2.0 * (y * (y / lam).ln() - (y - lam))
+        } else {
+            2.0 * lam
+        };
+        sy += y;
+        sl += lam;
+        syy += y * y;
+        sll += lam * lam;
+        syl += y * lam;
+    }
+    let n = d as f64;
+    let cov = syl - sy * sl / n;
+    let vy = (syy - sy * sy / n).max(0.0);
+    let vl = (sll - sl * sl / n).max(0.0);
+    let pearson = if vy > 0.0 && vl > 0.0 {
+        cov / (vy.sqrt() * vl.sqrt())
+    } else {
+        0.0
+    };
+    ResidualStat {
+        total,
+        deviance,
+        pearson,
+    }
+}

--- a/senna/src/deconvolve/io.rs
+++ b/senna/src/deconvolve/io.rs
@@ -1,0 +1,187 @@
+//! Output writers for `senna deconvolve`.
+
+use super::gibbs::DeconvResult;
+use crate::embed_common::{axis_id_names, Mat};
+use anyhow::{Context, Result};
+use log::info;
+use matrix_util::traits::IoOps;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+/// Metadata recorded in the run summary JSON.
+pub struct RunMeta<'a> {
+    pub from: &'a str,
+    pub markers: &'a str,
+    pub kind: String,
+    pub exact: bool,
+    pub warmup: usize,
+    pub draws: usize,
+    pub bulk_files: &'a [Box<str>],
+}
+
+pub fn write_outputs(
+    out: &str,
+    sample_names: &[Box<str>],
+    gene_names: &[Box<str>],
+    sample_z: &Mat,
+    result: &DeconvResult,
+    meta: &RunMeta,
+) -> Result<()> {
+    let ct = &result.celltype_names;
+    let h_names = axis_id_names("h", sample_z.ncols());
+
+    // Fractions (posterior mean, wide) + credible-interval long form.
+    write_wide_tsv(
+        &format!("{out}.fractions.tsv"),
+        "sample",
+        sample_names,
+        ct,
+        &result.fractions_mean,
+    )?;
+    write_fraction_ci(&format!("{out}.fractions_ci.tsv"), sample_names, ct, result)?;
+    write_wide_tsv(
+        &format!("{out}.abundance.tsv"),
+        "sample",
+        sample_names,
+        ct,
+        &result.abundance_mean,
+    )?;
+
+    // Projected bulk + posterior anchors (embedding space).
+    sample_z.to_parquet_with_names(
+        &format!("{out}.sample_embedding.parquet"),
+        (Some(sample_names), Some("sample")),
+        Some(&h_names),
+    )?;
+    result.anchors_post.to_parquet_with_names(
+        &format!("{out}.anchors.parquet"),
+        (Some(ct), Some("celltype")),
+        Some(&h_names),
+    )?;
+
+    // Per-cell-type expression stacks (samples × genes), DE-ready.
+    let expr_dir = format!("{out}.expression");
+    std::fs::create_dir_all(&expr_dir)
+        .with_context(|| format!("creating expression dir {expr_dir}"))?;
+    for (c, mat) in result.expression.iter().enumerate() {
+        let sg = mat.transpose(); // D×S → S×D
+        let fname = format!("{expr_dir}/{}.parquet", sanitize(&ct[c]));
+        sg.to_parquet_with_names(
+            &fname,
+            (Some(sample_names), Some("sample")),
+            Some(gene_names),
+        )?;
+    }
+
+    // Per-sample QC.
+    write_residual(&format!("{out}.residual.tsv"), sample_names, result)?;
+    write_manifest(out, meta)?;
+
+    info!(
+        "senna deconvolve: wrote {out}.{{fractions,fractions_ci,abundance,residual}}.tsv, \
+         {out}.{{sample_embedding,anchors}}.parquet, {out}.expression/*.parquet"
+    );
+    Ok(())
+}
+
+/// Wide `sample × celltype` TSV of a matrix.
+fn write_wide_tsv(
+    path: &str,
+    corner: &str,
+    rows: &[Box<str>],
+    cols: &[Box<str>],
+    mat: &Mat,
+) -> Result<()> {
+    let mut w = BufWriter::new(File::create(path).with_context(|| format!("create {path}"))?);
+    write!(w, "{corner}")?;
+    for c in cols {
+        write!(w, "\t{c}")?;
+    }
+    writeln!(w)?;
+    for (i, name) in rows.iter().enumerate() {
+        write!(w, "{name}")?;
+        for j in 0..cols.len() {
+            write!(w, "\t{:.6}", mat[(i, j)])?;
+        }
+        writeln!(w)?;
+    }
+    Ok(())
+}
+
+/// Long-form fraction credible intervals.
+fn write_fraction_ci(
+    path: &str,
+    samples: &[Box<str>],
+    cols: &[Box<str>],
+    result: &DeconvResult,
+) -> Result<()> {
+    let mut w = BufWriter::new(File::create(path).with_context(|| format!("create {path}"))?);
+    writeln!(w, "sample\tcelltype\tmean\tsd\tq2.5\tq97.5")?;
+    for (i, s) in samples.iter().enumerate() {
+        for (j, ctn) in cols.iter().enumerate() {
+            writeln!(
+                w,
+                "{s}\t{ctn}\t{:.6}\t{:.6}\t{:.6}\t{:.6}",
+                result.fractions_mean[(i, j)],
+                result.fractions_sd[(i, j)],
+                result.fractions_lo[(i, j)],
+                result.fractions_hi[(i, j)],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn write_residual(path: &str, samples: &[Box<str>], result: &DeconvResult) -> Result<()> {
+    let mut w = BufWriter::new(File::create(path).with_context(|| format!("create {path}"))?);
+    writeln!(w, "sample\ttotal_counts\tdeviance\tpearson")?;
+    for (i, s) in samples.iter().enumerate() {
+        let r = &result.residual[i];
+        writeln!(
+            w,
+            "{s}\t{:.1}\t{:.4}\t{:.4}",
+            r.total, r.deviance, r.pearson
+        )?;
+    }
+    Ok(())
+}
+
+fn write_manifest(out: &str, meta: &RunMeta) -> Result<()> {
+    let path = format!("{out}.deconvolve.json");
+    let json = serde_json::json!({
+        "version": 1,
+        "kind": "deconvolve",
+        "from": meta.from,
+        "markers": meta.markers,
+        "source_kind": meta.kind,
+        "projection_exact": meta.exact,
+        "warmup": meta.warmup,
+        "draws": meta.draws,
+        "bulk": meta.bulk_files.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+        "outputs": {
+            "fractions": format!("{out}.fractions.tsv"),
+            "fractions_ci": format!("{out}.fractions_ci.tsv"),
+            "abundance": format!("{out}.abundance.tsv"),
+            "sample_embedding": format!("{out}.sample_embedding.parquet"),
+            "anchors": format!("{out}.anchors.parquet"),
+            "expression_dir": format!("{out}.expression"),
+            "residual": format!("{out}.residual.tsv"),
+        },
+    });
+    std::fs::write(&path, serde_json::to_string_pretty(&json)?)
+        .with_context(|| format!("writing {path}"))?;
+    Ok(())
+}
+
+/// Filesystem-safe cell-type label for per-type filenames.
+fn sanitize(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/senna/src/deconvolve/mod.rs
+++ b/senna/src/deconvolve/mod.rs
@@ -1,0 +1,76 @@
+//! `senna deconvolve` — projection-based hierarchical-Bayes bulk deconvolution.
+//!
+//! Builds a cell-type reference from a feature embedding (`bge --skip-etm` or
+//! `masked-topic`): each type's gene profile is reconstructed as
+//! `μ_{g,c} = exp(ρ_g·t_c + a_g)`, with anchors `t_c` drawn from the
+//! annotate-by-projection marker centroids and their scatter. Bulk samples are
+//! projected into the same latent, then a full Gibbs sampler (Gamma-Poisson
+//! conjugate fractions + multinomial gene allocation + elliptical-slice anchor
+//! updates) yields BayesPrism-style deliverables — per-sample cell-type
+//! fractions with credible intervals and a per-cell-type expression tensor.
+
+mod anchors;
+mod args;
+mod gibbs;
+mod io;
+mod project;
+mod source;
+#[cfg(test)]
+mod tests;
+
+pub use args::DeconvolveArgs;
+
+use crate::embed_common::read_bulk_data_aligned;
+use crate::run_manifest;
+use anyhow::Result;
+use log::info;
+use matrix_util::common_io::mkdir_parent;
+use source::EmbeddingSource;
+
+pub fn run(args: &DeconvolveArgs) -> Result<()> {
+    let out: String = match args.out.as_deref() {
+        Some(o) => o.to_string(),
+        None => format!("{}.deconv", run_manifest::derive_out_prefix(&args.from)),
+    };
+    mkdir_parent(&out)?;
+
+    // 1. Reference: embedding ρ + gene offset, and marker-anchored prior.
+    let src = EmbeddingSource::load(&args.from)?;
+    let prior = anchors::build_anchor_prior(
+        &src.anchor_emb,
+        &src.feature_names,
+        &args.markers,
+        &args.anchor_config(),
+    )?;
+
+    // 2. Bulk: load and align to the reference gene order.
+    let bulk = read_bulk_data_aligned(&args.bulk, &src.feature_names)?;
+    info!(
+        "deconvolve: {} bulk samples × {} genes, {} cell types",
+        bulk.samples.len(),
+        bulk.genes.len(),
+        prior.names.len()
+    );
+
+    // 3. Project bulk into the shared latent + warm-start fractions.
+    let cfg = args.sampler_config();
+    let sample_z = project::project_bulk(&src.rho, &src.gene_offset, &bulk.data, cfg.project_ridge);
+    let init_w = project::init_fractions(&prior.mean, &sample_z, cfg.init_iters);
+
+    // 4. Hierarchical Gibbs.
+    let result = gibbs::run_gibbs(&src, &bulk.data, &prior, &init_w, &cfg)?;
+
+    // 5. Write deliverables.
+    let meta = io::RunMeta {
+        from: &args.from,
+        markers: &args.markers,
+        kind: src.kind.to_string(),
+        exact: src.exact,
+        warmup: cfg.warmup,
+        draws: cfg.draws,
+        bulk_files: &args.bulk,
+    };
+    io::write_outputs(&out, &bulk.samples, &bulk.genes, &sample_z, &result, &meta)?;
+    info!("senna deconvolve complete → {out}.*");
+    Ok(())
+}

--- a/senna/src/deconvolve/project.rs
+++ b/senna/src/deconvolve/project.rs
@@ -1,0 +1,58 @@
+//! Project bulk samples into the shared embedding latent and initialize
+//! cell-type fractions.
+//!
+//! The bulk-into-embedding projection is the cross-platform bridge: each bulk
+//! sample is embedded by the same frozen-ρ Poisson solver
+//! ([`graph_embedding_util::cell_projection::project_cells`]) that placed the
+//! reference cells, so bulk, cells, and anchors share one geometry. The
+//! projected position also seeds the Gibbs sampler via a simplex fit against
+//! the anchor rows.
+
+use crate::embed_common::{DVec, Mat};
+use graph_embedding_util::cell_projection::project_cells;
+use matrix_util::archetypal::simplex_lsq;
+
+/// Project each bulk sample (a column of `bulk`, genes × samples) into the ρ
+/// latent under the Poisson rate `μ = exp(ρ·z + a_g + b_s)`. Returns the `S×H`
+/// sample embeddings; the per-sample depth intercept is fitted internally and
+/// discarded (it only absorbs library size).
+#[must_use]
+pub fn project_bulk(rho: &Mat, gene_offset: &DVec, bulk: &Mat, ridge: f64) -> Mat {
+    let (d, h) = (rho.nrows(), rho.ncols());
+    let s = bulk.ncols();
+
+    // project_cells wants ρ row-major [D×H] + per-sample sparse (gene, count)
+    // lists. `Mat` is column-major, so ρᵀ's buffer is exactly the row-major ρ.
+    let rho_rm = rho.transpose();
+    let frozen_b: Vec<f32> = gene_offset.iter().copied().collect();
+    let per_cell: Vec<Vec<(u32, f32)>> = (0..s)
+        .map(|si| {
+            (0..d)
+                .filter_map(|g| {
+                    let y = bulk[(g, si)];
+                    (y > 0.0).then_some((g as u32, y))
+                })
+                .collect()
+        })
+        .collect();
+
+    let (e, _b_cell) = project_cells(rho_rm.as_slice(), &frozen_b, &per_cell, h, ridge, None);
+    Mat::from_row_slice(s, h, &e)
+}
+
+/// Warm-start fractions `w` `[S×C]`: each sample's projected position is fit as
+/// a simplex combination of the anchor rows (`anchor_mean` `[C×H]`). A small
+/// floor keeps every type strictly positive for the Gamma sampler.
+#[must_use]
+pub fn init_fractions(anchor_mean: &Mat, z: &Mat, fw_iters: usize) -> Mat {
+    let (s, c, h) = (z.nrows(), anchor_mean.nrows(), z.ncols());
+    let mut w = Mat::zeros(s, c);
+    for si in 0..s {
+        let x = DVec::from_iterator(h, z.row(si).iter().copied());
+        let a = simplex_lsq(anchor_mean, &x, fw_iters);
+        for ct in 0..c {
+            w[(si, ct)] = a[ct].max(1e-6);
+        }
+    }
+    w
+}

--- a/senna/src/deconvolve/source.rs
+++ b/senna/src/deconvolve/source.rs
@@ -1,0 +1,187 @@
+//! Resolve a per-gene embedding + reconstruction offset from an upstream run
+//! manifest, abstracting over the two supported feature-embedding sources.
+//!
+//! - **`bge --skip-etm`** (exact): the raw Poisson ρ = `e_feat` is persisted as
+//!   `dictionary.parquet`; the co-embedding (genes on the cell manifold) is
+//!   `feature_embedding.parquet` and grounds the marker anchors; the per-gene
+//!   Poisson offset is `feature_bias.parquet`. Detected by `kind == Bge` with
+//!   NO `cell_embedding` output (ETM mode records one and overwrites ρ with β).
+//! - **`masked-topic`** (approximate): `feature_embedding.parquet` IS the raw
+//!   learned ρ `[D,H]` (used for both projection and anchors); ρ was trained
+//!   under a softmax-ETM head, so projecting it through the Poisson solver is a
+//!   transfer approximation. The gene offset is the log topic-averaged gene
+//!   marginal from the β `dictionary.parquet`.
+
+use crate::embed_common::{DVec, Mat};
+use crate::run_manifest::{self, RunKind, RunManifest};
+use anyhow::{Context, Result};
+use log::info;
+use matrix_util::dmatrix_io::DMatrix;
+use matrix_util::traits::{IoOps, MatWithNames};
+use std::path::Path;
+
+/// Everything the deconvolution needs from the upstream embedding run.
+pub struct EmbeddingSource {
+    /// `D×H` embedding used for the Poisson projection and the reconstruction
+    /// `μ_{g,c} = exp(ρ_g·t_c + a_g)`.
+    pub rho: Mat,
+    /// `D×H` embedding whose marker-weighted centroids define the anchors
+    /// (co-embedding for bge; identical to `rho` for masked-topic).
+    pub anchor_emb: Mat,
+    /// `D` per-gene log-offset `a_g` in the Poisson rate.
+    pub gene_offset: DVec,
+    /// `D` gene names (row order of `rho`).
+    pub feature_names: Vec<Box<str>>,
+    /// Embedding dimension `H`.
+    pub h: usize,
+    /// Source run kind (for logging).
+    pub kind: RunKind,
+    /// True when the projection geometry is exact (bge) vs. approximate (masked-topic).
+    pub exact: bool,
+}
+
+impl EmbeddingSource {
+    pub fn load(from: &str) -> Result<Self> {
+        let (manifest, dir) = RunManifest::load(Path::new(from))?;
+        info!(
+            "deconvolve: loaded manifest ({from}): kind={}",
+            manifest.kind
+        );
+        let resolve = |rel: &str| -> String {
+            run_manifest::resolve(&dir, rel)
+                .to_string_lossy()
+                .into_owned()
+        };
+
+        match manifest.kind {
+            RunKind::Bge => Self::from_bge(&manifest, &resolve),
+            RunKind::Topic | RunKind::Itopic | RunKind::JointTopic => {
+                Self::from_masked_topic(&manifest, &resolve)
+            }
+            other => anyhow::bail!(
+                "deconvolve: unsupported source kind `{other}` — use `senna bge --skip-etm` \
+                 (exact) or `senna masked-topic` (approximate)"
+            ),
+        }
+    }
+
+    /// `bge --skip-etm`: dictionary = raw ρ, feature_embedding = co-embed anchors.
+    fn from_bge(m: &RunManifest, resolve: &impl Fn(&str) -> String) -> Result<Self> {
+        anyhow::ensure!(
+            m.outputs.cell_embedding.is_none(),
+            "deconvolve: this bge run resolved the ETM topic layer, so `dictionary.parquet` is β \
+             (not the raw Poisson ρ). Re-run `senna bge --skip-etm` so the raw ρ is persisted."
+        );
+        let dict_rel =
+            m.outputs.dictionary.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("bge manifest has no `outputs.dictionary` (raw ρ)")
+            })?;
+        let coembed_rel = m.outputs.feature_embedding.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("bge manifest has no `outputs.feature_embedding` (co-embed anchors)")
+        })?;
+
+        let dict_path = resolve(dict_rel);
+        let rho = load_mat(&dict_path, "raw ρ (dictionary)")?;
+        let coembed = load_mat(&resolve(coembed_rel), "co-embedding")?;
+        // feature_bias sits beside the dictionary; it is not recorded in the manifest.
+        let bias_path = sibling(&dict_path, ".dictionary.parquet", ".feature_bias.parquet")?;
+        let gene_offset = load_mat(&bias_path, "feature_bias")?
+            .mat
+            .column(0)
+            .into_owned();
+
+        Self::assemble(rho, coembed.mat, gene_offset, RunKind::Bge, true)
+    }
+
+    /// `masked-topic`: feature_embedding = raw ρ (also the anchor space); the
+    /// per-gene offset is the log topic-averaged marginal of β.
+    fn from_masked_topic(m: &RunManifest, resolve: &impl Fn(&str) -> String) -> Result<Self> {
+        let feat_rel = m.outputs.feature_embedding.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "manifest has no `outputs.feature_embedding` — a plain `topic` run has no per-gene \
+                 embedding ρ. Train with `senna masked-topic` (or use `bge --skip-etm`)."
+            )
+        })?;
+        let rho = load_mat(&resolve(feat_rel), "feature embedding ρ")?;
+
+        // Offset a_g = ln(mean_k β[g,k]): the gene marginal under uniform topics.
+        let dict_rel = m.outputs.dictionary.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("masked-topic manifest has no `outputs.dictionary` (β) for the offset")
+        })?;
+        let beta = load_mat(&resolve(dict_rel), "β dictionary")?;
+        anyhow::ensure!(
+            beta.mat.nrows() == rho.mat.nrows(),
+            "masked-topic: β genes ({}) != ρ genes ({})",
+            beta.mat.nrows(),
+            rho.mat.nrows()
+        );
+        let k = beta.mat.ncols().max(1) as f32;
+        let gene_offset = DVec::from_iterator(
+            beta.mat.nrows(),
+            beta.mat.row_iter().map(|r| (r.sum() / k + 1e-8).ln()),
+        );
+
+        // Anchors share ρ's space; clone the matrix for the (identical) anchor role.
+        let anchor_mat = rho.mat.clone();
+        Self::assemble(rho, anchor_mat, gene_offset, RunKind::Topic, false)
+    }
+
+    fn assemble(
+        rho: MatWithNames<Mat>,
+        anchor_mat: Mat,
+        gene_offset: DVec,
+        kind: RunKind,
+        exact: bool,
+    ) -> Result<Self> {
+        let h = rho.mat.ncols();
+        anyhow::ensure!(
+            anchor_mat.ncols() == h,
+            "deconvolve: anchor embedding H={} != ρ H={h}",
+            anchor_mat.ncols()
+        );
+        anyhow::ensure!(
+            anchor_mat.nrows() == rho.mat.nrows(),
+            "deconvolve: anchor genes ({}) != ρ genes ({})",
+            anchor_mat.nrows(),
+            rho.mat.nrows()
+        );
+        anyhow::ensure!(
+            gene_offset.len() == rho.mat.nrows(),
+            "deconvolve: gene offset ({}) != ρ genes ({})",
+            gene_offset.len(),
+            rho.mat.nrows()
+        );
+        info!(
+            "deconvolve: ρ [{} genes × {h}], {} source{}",
+            rho.mat.nrows(),
+            kind,
+            if exact {
+                ""
+            } else {
+                " (approximate projection)"
+            }
+        );
+        Ok(Self {
+            rho: rho.mat,
+            anchor_emb: anchor_mat,
+            gene_offset,
+            feature_names: rho.rows,
+            h,
+            kind,
+            exact,
+        })
+    }
+}
+
+/// Read a matrix parquet with a descriptive error context.
+fn load_mat(path: &str, what: &str) -> Result<MatWithNames<Mat>> {
+    DMatrix::<f32>::from_parquet(path).with_context(|| format!("reading {what} {path}"))
+}
+
+/// Derive a sibling artifact path by swapping a known suffix on the last path
+/// component (e.g. `foo.dictionary.parquet` → `foo.feature_bias.parquet`).
+fn sibling(path: &str, from_suffix: &str, to_suffix: &str) -> Result<String> {
+    path.strip_suffix(from_suffix)
+        .map(|stem| format!("{stem}{to_suffix}"))
+        .ok_or_else(|| anyhow::anyhow!("expected `{from_suffix}` suffix on `{path}`"))
+}

--- a/senna/src/deconvolve/tests.rs
+++ b/senna/src/deconvolve/tests.rs
@@ -1,0 +1,159 @@
+//! Deterministic recovery tests for the deconvolution Gibbs sampler.
+
+use super::anchors::AnchorPrior;
+use super::args::SamplerConfig;
+use super::gibbs::run_gibbs;
+use super::source::EmbeddingSource;
+use crate::embed_common::Mat;
+use crate::run_manifest::RunKind;
+
+/// Build a synthetic problem: known ρ, anchors, and abundances w*, with bulk
+/// counts = Σ_c w*_c μ_{g,c} at large depth (near-noiseless).
+fn synthetic() -> (EmbeddingSource, AnchorPrior, Mat, Mat) {
+    let (d, h, c, s) = (48usize, 4usize, 3usize, 5usize);
+
+    // ρ: deterministic pseudo-random rows.
+    let rho = Mat::from_fn(d, h, |g, j| (((g * 7 + j * 13) % 11) as f32 / 11.0) - 0.5);
+    let gene_offset =
+        crate::embed_common::DVec::from_fn(d, |g, _| (((g * 5) % 7) as f32 / 7.0) - 0.3);
+
+    // Well-separated anchors.
+    let anchors = Mat::from_fn(c, h, |ct, j| if j == ct { 0.9 } else { -0.2 });
+
+    // True abundances (distinct per sample).
+    let w_true = Mat::from_fn(s, c, |si, ct| {
+        20.0 + 60.0 * (((si + 2 * ct) % 4) as f32) + 5.0
+    });
+
+    // μ and bulk counts (scaled to large depth).
+    let sc = &rho * anchors.transpose();
+    let mu = Mat::from_fn(d, c, |g, ct| (sc[(g, ct)] + gene_offset[g]).exp());
+    let bulk = Mat::from_fn(d, s, |g, si| {
+        let mut y = 0f32;
+        for ct in 0..c {
+            y += w_true[(si, ct)] * mu[(g, ct)];
+        }
+        y.round()
+    });
+
+    let names: Vec<Box<str>> = (0..c).map(|ct| format!("T{ct}").into_boxed_str()).collect();
+    let feature_names: Vec<Box<str>> = (0..d).map(|g| format!("g{g}").into_boxed_str()).collect();
+
+    let src = EmbeddingSource {
+        rho: rho.clone(),
+        anchor_emb: rho,
+        gene_offset,
+        feature_names,
+        h,
+        kind: RunKind::Bge,
+        exact: true,
+    };
+    // Anchors pinned near truth (tiny prior spread) so we isolate fraction recovery.
+    let prior = AnchorPrior {
+        mean: anchors,
+        names,
+        sigma: vec![1e-4; c],
+        chol: None,
+    };
+    (src, prior, bulk, w_true)
+}
+
+fn cfg_tau(tau: f32) -> SamplerConfig {
+    SamplerConfig {
+        warmup: 150,
+        draws: 200,
+        thin: 1,
+        seed: 1,
+        a0: 1.0,
+        b0: 1.0,
+        project_ridge: 1.0,
+        init_iters: 50,
+        // Perfectly-specified synthetic reference → test the core estimator in
+        // the Poisson limit (r fixed large).
+        nb_r: 1e4,
+        tau,
+    }
+}
+
+fn cfg() -> SamplerConfig {
+    cfg_tau(1.0)
+}
+
+#[test]
+fn recovers_fractions() {
+    let (src, prior, bulk, w_true) = synthetic();
+    let (s, c) = (bulk.ncols(), prior.mean.nrows());
+    let init_w = Mat::from_element(s, c, 1.0); // neutral start
+    let res = run_gibbs(&src, &bulk, &prior, &init_w, &cfg()).unwrap();
+
+    // True count-fractions.
+    let mut f_true = Mat::zeros(s, c);
+    for si in 0..s {
+        let tot: f32 = (0..c).map(|ct| w_true[(si, ct)]).sum();
+        for ct in 0..c {
+            f_true[(si, ct)] = w_true[(si, ct)] / tot;
+        }
+    }
+
+    // Correlation between recovered and true fractions across all (s,c).
+    let n = (s * c) as f32;
+    let (mut sx, mut sy, mut sxx, mut syy, mut sxy) = (0f32, 0f32, 0f32, 0f32, 0f32);
+    let mut max_abs = 0f32;
+    for si in 0..s {
+        for ct in 0..c {
+            let x = res.fractions_mean[(si, ct)];
+            let y = f_true[(si, ct)];
+            sx += x;
+            sy += y;
+            sxx += x * x;
+            syy += y * y;
+            sxy += x * y;
+            max_abs = max_abs.max((x - y).abs());
+        }
+    }
+    let corr = (sxy - sx * sy / n) / (((sxx - sx * sx / n) * (syy - sy * sy / n)).sqrt() + 1e-9);
+    assert!(corr > 0.9, "fraction recovery corr too low: {corr:.3}");
+    assert!(
+        max_abs < 0.15,
+        "fraction max abs error too high: {max_abs:.3}"
+    );
+}
+
+#[test]
+fn tempering_widens_posterior() {
+    // Lower τ (fewer effective counts) must widen the fraction posterior.
+    let (src, prior, bulk, _) = synthetic();
+    let (s, c) = (bulk.ncols(), prior.mean.nrows());
+    let init_w = Mat::from_element(s, c, 1.0);
+    let mean_sd = |cfg| {
+        let res = run_gibbs(&src, &bulk, &prior, &init_w, &cfg).unwrap();
+        res.fractions_sd.iter().sum::<f32>() / (s * c) as f32
+    };
+    let tight = mean_sd(cfg_tau(1.0));
+    let loose = mean_sd(cfg_tau(0.02));
+    assert!(
+        loose > 2.0 * tight,
+        "tempering did not widen posterior: sd(τ=1)={tight:.5}, sd(τ=0.02)={loose:.5}"
+    );
+}
+
+#[test]
+fn expression_conserves_counts() {
+    let (src, prior, bulk, _) = synthetic();
+    let (s, c) = (bulk.ncols(), prior.mean.nrows());
+    let d = bulk.nrows();
+    let init_w = Mat::from_element(s, c, 1.0);
+    let res = run_gibbs(&src, &bulk, &prior, &init_w, &cfg()).unwrap();
+
+    // Σ_c E[Z_{s,c,g}] ≈ y_{s,g}: the gene split apportions all observed counts.
+    for si in 0..s {
+        for g in (0..d).step_by(7) {
+            let split: f32 = (0..c).map(|ct| res.expression[ct][(g, si)]).sum();
+            let y = bulk[(g, si)];
+            assert!(
+                (split - y).abs() <= 0.02 * y + 1.0,
+                "count conservation violated at (g={g}, s={si}): split={split:.2} y={y:.2}"
+            );
+        }
+    }
+}

--- a/senna/src/main.rs
+++ b/senna/src/main.rs
@@ -38,6 +38,7 @@ mod cluster_aggregation;
 mod cluster_bhc;
 mod clustering;
 mod cnv_pseudobulk;
+mod deconvolve;
 mod embed_common;
 mod empirical_dict;
 mod eval_topic;
@@ -70,6 +71,7 @@ use annotate::{
 };
 use bge::{fit_bge, BgeArgs};
 use clustering::*;
+use deconvolve::DeconvolveArgs;
 use embed_common::*;
 use eval_topic::*;
 use fne::{fit_fne, FneArgs};
@@ -403,6 +405,22 @@ enum Commands {
     AnnotateByProjection(AnnotateProjectionArgs),
 
     #[command(
+        name = "deconvolve",
+        visible_aliases = ["deconv", "deconvolution"],
+        about = "Deconvolve bulk samples into cell-type fractions + per-type expression.",
+        long_about = "Projection-based hierarchical-Bayes bulk deconvolution built on a feature\n\
+                      embedding (`senna bge --skip-etm`, exact; or `masked-topic`, approximate).\n\
+                      Reconstructs each cell type's gene profile from the embedding, projects\n\
+                      bulk samples into the shared latent, and runs a full Gibbs sampler\n\
+                      (Gamma-Poisson fractions + multinomial gene split + elliptical-slice anchor\n\
+                      updates that carry annotate-by-projection uncertainty).\n\n\
+                      Usage: senna deconvolve --from run.senna.json -m markers.tsv --bulk bulk.parquet\n\
+                      Writes {out}.{fractions,fractions_ci,abundance,residual}.tsv,\n\
+                      {out}.{sample_embedding,anchors}.parquet, {out}.expression/*.parquet."
+    )]
+    Deconvolve(DeconvolveArgs),
+
+    #[command(
         about = "Pseudotime via Monocle-3-style principal graph (SimplePPT) on the latent.",
         long_about = "Port of Mao et al. 2015 SimplePPT applied to `manifest.outputs.latent`.\n\n\
                       (1) k-means init K centroids,\n\
@@ -540,6 +558,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::AnnotateByProjection(args) => {
             annotate_by_projection(args)?;
+        }
+        Commands::Deconvolve(args) => {
+            deconvolve::run(args)?;
         }
         Commands::Predict(args) => {
             predict_model(args)?;


### PR DESCRIPTION
Add `senna deconvolve` (0.7.0): BayesPrism-style bulk deconvolution built on a feature embedding (`bge --skip-etm`, exact; or `masked-topic`, approximate). Reconstructs per-cell-type gene profiles mu_gc = exp(rho_g·t_c + a_g) from the embedding, projects bulk samples into the shared latent, and runs a hierarchical Gibbs sampler: Gamma-Poisson conjugate fractions + multinomial gene split + NB overdispersion + likelihood tempering (power posterior) + elliptical-slice anchor updates that carry annotate-by-projection uncertainty. Emits per-sample cell-type fractions with credible intervals and a per-cell-type expression tensor for within-type DE.

matrix-util (0.3.8):
- add running_quantile: P2 streaming quantile (Jain-Chlamtac 1985) + RunningQuantiles; fraction CIs computed online, no stored per-draw arrays
- expose simplex_lsq (Frank-Wolfe) for fraction initialization

Reuses graph_embedding_util::cell_projection, marker_support, mcmc-util elliptical slice sampling, and the embed_common bulk loader. Includes deterministic recovery/tempering/count-conservation tests and a benchmark scoring example (examples/bench_tool).