### PR TITLE
feat(senna): stick-breaking-process (sbp) latent head + held-out imputation eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "candle-util"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "approx",
@@ -5079,7 +5079,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "senna"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "approx",

--- a/candle-util/Cargo.toml
+++ b/candle-util/Cargo.toml
@@ -4,7 +4,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
-version = "0.2.7"
+version = "0.2.8"
 
 [dependencies]
 

--- a/candle-util/src/encoder/indexed.rs
+++ b/candle-util/src/encoder/indexed.rs
@@ -8,6 +8,11 @@ use crate::value_transform::anscombe_lite;
 use candle_core::{Result, Tensor};
 use candle_nn::{ops, Linear, ModuleT, VarBuilder, VarMap};
 
+/// Symmetric clamp on the masked-encoder's per-topic logits (`z_mean`, and the
+/// Gaussian head's `z_lnvar`): keeps `exp`/`softmax`/stick-breaking numerically
+/// bounded. Shared by every masked head so the bound can't drift between them.
+const MASKED_LOGIT_CLAMP: f64 = 8.0;
+
 /// Indexed embedding encoder over packed top-K input.
 ///
 /// Consumes `(indices [N, K], values [N, K], values_null [N, K]?)` directly:
@@ -259,13 +264,11 @@ impl IndexedEmbeddingEncoder {
         pooled_nh.broadcast_mul(&has_visible_n1) // [N, H]
     }
 
-    /// Deterministic masked-encoder forward → `log θ [N, K_topics]`.
-    ///
-    /// Pools the **visible** genes, runs FC + BN, and returns
-    /// `log_softmax(z_mean)` — **no reparameterization, no KL**. This is the
-    /// masked-imputation topic model's encoder: `θ` is a point estimate, so
-    /// there is no posterior-collapse pressure.
-    pub fn forward_indexed_masked(
+    /// Shared masked-encoder trunk: visible-pool → FC → BN → `bn_nl [N, L]`.
+    /// All three masked heads (softmax / stick-breaking / Gaussian) branch off
+    /// this — only the final projection differs — so the pooling + FC + BN wiring
+    /// lives in exactly one place.
+    fn masked_hidden(
         &self,
         indices: &Tensor,
         values: &Tensor,
@@ -282,9 +285,84 @@ impl IndexedEmbeddingEncoder {
             visible_mask,
         )?;
         let fc_nl = self.fc.forward_t(&h_nh, train)?;
-        let bn_nl = self.bn_z.forward_t(&fc_nl, train)?;
-        let z_mean_nk = self.z_mean.forward_t(&bn_nl, train)?.clamp(-8.0, 8.0)?;
+        self.bn_z.forward_t(&fc_nl, train)
+    }
+
+    /// Clamped per-topic logits `z_mean [N, K]` from the masked trunk — the
+    /// pre-activation the simplex heads map to `log θ`.
+    fn masked_logits(
+        &self,
+        indices: &Tensor,
+        values: &Tensor,
+        values_null: Option<&Tensor>,
+        values_mean: Option<&Tensor>,
+        visible_mask: &Tensor,
+        train: bool,
+    ) -> Result<Tensor> {
+        let bn_nl = self.masked_hidden(
+            indices,
+            values,
+            values_null,
+            values_mean,
+            visible_mask,
+            train,
+        )?;
+        self.z_mean
+            .forward_t(&bn_nl, train)?
+            .clamp(-MASKED_LOGIT_CLAMP, MASKED_LOGIT_CLAMP)
+    }
+
+    /// Deterministic masked-encoder forward → `log θ [N, K_topics]`.
+    ///
+    /// Pools the **visible** genes, runs the shared trunk, and returns
+    /// `log_softmax(z_mean)` — **no reparameterization, no KL**. This is the
+    /// masked-imputation topic model's encoder: `θ` is a point estimate, so
+    /// there is no posterior-collapse pressure.
+    pub fn forward_indexed_masked(
+        &self,
+        indices: &Tensor,
+        values: &Tensor,
+        values_null: Option<&Tensor>,
+        values_mean: Option<&Tensor>,
+        visible_mask: &Tensor,
+        train: bool,
+    ) -> Result<Tensor> {
+        let z_mean_nk = self.masked_logits(
+            indices,
+            values,
+            values_null,
+            values_mean,
+            visible_mask,
+            train,
+        )?;
         ops::log_softmax(&z_mean_nk, 1)
+    }
+
+    /// Deterministic **stick-breaking** masked-encoder forward → `log θ [N,K]`.
+    ///
+    /// Same shared trunk as [`Self::forward_indexed_masked`]; only the final
+    /// simplex map differs — the pre-activation logits go through
+    /// [`crate::vae::stick_breaking_log_simplex`] instead of `log_softmax`.
+    /// Ordered, exchangeability-broken topics with a self-pruning tail, still a
+    /// point estimate (no reparameterization, no KL).
+    pub fn forward_indexed_masked_stick(
+        &self,
+        indices: &Tensor,
+        values: &Tensor,
+        values_null: Option<&Tensor>,
+        values_mean: Option<&Tensor>,
+        visible_mask: &Tensor,
+        train: bool,
+    ) -> Result<Tensor> {
+        let z_mean_nk = self.masked_logits(
+            indices,
+            values,
+            values_null,
+            values_mean,
+            visible_mask,
+            train,
+        )?;
+        crate::vae::stick_breaking_log_simplex(&z_mean_nk)
     }
 
     /// Latent Gaussian params `(z_mean, z_lnvar)` from the **visible-pooled**
@@ -299,17 +377,22 @@ impl IndexedEmbeddingEncoder {
         visible_mask: &Tensor,
         train: bool,
     ) -> Result<(Tensor, Tensor)> {
-        let h_nh = self.preprocess_indexed_masked(
+        let bn_nl = self.masked_hidden(
             indices,
             values,
             values_null,
             values_mean,
             visible_mask,
+            train,
         )?;
-        let fc_nl = self.fc.forward_t(&h_nh, train)?;
-        let bn_nl = self.bn_z.forward_t(&fc_nl, train)?;
-        let z_mean_nk = self.z_mean.forward_t(&bn_nl, train)?.clamp(-8.0, 8.0)?;
-        let z_lnvar_nk = self.z_lnvar.forward_t(&bn_nl, train)?.clamp(-8.0, 8.0)?;
+        let z_mean_nk = self
+            .z_mean
+            .forward_t(&bn_nl, train)?
+            .clamp(-MASKED_LOGIT_CLAMP, MASKED_LOGIT_CLAMP)?;
+        let z_lnvar_nk = self
+            .z_lnvar
+            .forward_t(&bn_nl, train)?
+            .clamp(-MASKED_LOGIT_CLAMP, MASKED_LOGIT_CLAMP)?;
         Ok((z_mean_nk, z_lnvar_nk))
     }
 

--- a/candle-util/src/vae/masked_topic.rs
+++ b/candle-util/src/vae/masked_topic.rs
@@ -113,18 +113,41 @@ pub enum MaskedLikelihood {
     Multinomial,
 }
 
+/// Which latent head the masked encoder uses to turn pooled visible genes into
+/// the per-topic log-intensity `log θ` the NB/multinomial imputation head reads.
+///
+/// `Softmax` and `StickBreaking` are both deterministic point estimates with no
+/// KL (the masked objective alone prevents collapse); they differ only in the
+/// simplex parameterization. `Gaussian` is the true variational bottleneck.
+///
+/// This is a pure identity tag — a `Copy`, round-trippable value used by the
+/// train dispatch, the inference dispatch, and model persistence alike. The
+/// Gaussian KL weight is a train-only hyperparameter and lives on
+/// [`MaskedTrainOpts::kl_weight`], not in the tag, so the inference/persistence
+/// sites never fabricate a placeholder weight.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LatentHead {
+    /// Deterministic simplex `log_softmax(z)` — exchangeable topics. The legacy
+    /// masked-topic default.
+    Softmax,
+    /// Deterministic **stick-breaking** simplex — ordered, exchangeability-
+    /// broken topics with a self-pruning tail. Same no-KL objective as
+    /// `Softmax`, only the final simplex map differs.
+    StickBreaking,
+    /// Reparameterized **Gaussian** latent `z` (no simplex projection) plus a
+    /// `kl_weight · KL(z ‖ N(0, I))` term. `exp(z)` drives the NB head's
+    /// per-topic intensities, so the decoder is reused unchanged.
+    Gaussian,
+}
+
 pub struct MaskedTrainOpts {
     pub mask_schedule: MaskSchedule,
     /// Per-gene likelihood for the masked imputation loss.
     pub likelihood: MaskedLikelihood,
-    /// **Masked-VAE mode.** When `true`, the encoder emits a reparameterized
-    /// **Gaussian** latent `z` (no log-softmax simplex projection) and the loss
-    /// gains a `kl_weight · KL(z)` term. `exp(z)` then plays the role of the
-    /// per-topic intensities in the NB head (`μ_g = ℓ·Σ_t exp(z_t)·β_{t,g}`), so
-    /// the decoder is reused unchanged. `false` = the legacy simplex-`θ`
-    /// masked-topic model (deterministic, no KL). NB head only.
-    pub latent_gaussian: bool,
-    /// KL weight `β` for the Gaussian latent (ignored unless `latent_gaussian`).
+    /// Latent head: simplex (softmax / stick-breaking, deterministic no-KL) or
+    /// Gaussian (reparameterized + KL). See [`LatentHead`].
+    pub latent: LatentHead,
+    /// KL weight `β` for the Gaussian latent. Ignored unless `latent == Gaussian`.
     pub kl_weight: f64,
 }
 
@@ -133,9 +156,73 @@ impl Default for MaskedTrainOpts {
         Self {
             mask_schedule: MaskSchedule::Fixed,
             likelihood: MaskedLikelihood::Nb,
-            latent_gaussian: false,
+            latent: LatentHead::Softmax,
             kl_weight: 1.0,
         }
+    }
+}
+
+/// Borrowed masked-encoder inputs: the per-cell packed top-K plus the
+/// visible-slot mask. Grouping them lets the trainer and encoder-only inference
+/// share one dispatch entry point ([`masked_encode`]) instead of spelling the
+/// six-argument encoder call out per head at each site.
+pub struct MaskedEncoderInput<'a> {
+    pub indices: &'a Tensor,
+    pub values: &'a Tensor,
+    pub values_null: Option<&'a Tensor>,
+    pub values_mean: Option<&'a Tensor>,
+    pub visible_mask: &'a Tensor,
+}
+
+/// Run the masked encoder under `head`, returning the raw per-topic latent
+/// `[N, K]` (`log θ` for the simplex heads, `z` for Gaussian) and — only for
+/// `Gaussian` — the per-cell KL `[N]`.
+///
+/// Single source of truth for the head → encoder-forward dispatch shared by
+/// [`train_masked`] and senna's encoder-only inference. The encoder itself
+/// stays head-agnostic (three plain forwards, no `LatentHead` dependency).
+/// Callers own their post-processing: the trainer smooths the simplex heads
+/// (`kl.is_none()`) and adds the KL term; inference discards the KL.
+pub fn masked_encode(
+    encoder: &IndexedEmbeddingEncoder,
+    head: LatentHead,
+    input: &MaskedEncoderInput,
+    train: bool,
+) -> candle_core::Result<(Tensor, Option<Tensor>)> {
+    match head {
+        LatentHead::Gaussian => {
+            let (z, kl) = encoder.forward_indexed_masked_gaussian(
+                input.indices,
+                input.values,
+                input.values_null,
+                input.values_mean,
+                input.visible_mask,
+                train,
+            )?;
+            Ok((z, Some(kl)))
+        }
+        LatentHead::StickBreaking => Ok((
+            encoder.forward_indexed_masked_stick(
+                input.indices,
+                input.values,
+                input.values_null,
+                input.values_mean,
+                input.visible_mask,
+                train,
+            )?,
+            None,
+        )),
+        LatentHead::Softmax => Ok((
+            encoder.forward_indexed_masked(
+                input.indices,
+                input.values,
+                input.values_null,
+                input.values_mean,
+                input.visible_mask,
+                train,
+            )?,
+            None,
+        )),
     }
 }
 
@@ -604,29 +691,28 @@ pub fn train_masked(
                 let visible = (&real - &masked)?;
 
                 // Masked-VAE: reparameterized Gaussian `z` (no softmax) + KL.
-                // Legacy masked-topic: deterministic simplex `log θ`, no KL.
-                // In both cases the NB head reads this as its per-topic
-                // intensity log — `exp(z)` for the VAE, `θ` for the topic model.
-                let (log_z, kl_opt) = if opts.latent_gaussian {
-                    let (z, kl) = encoder.forward_indexed_masked_gaussian(
-                        &mb.input_indices,
-                        &mb.input_values,
-                        mb.input_values_null.as_ref(),
-                        mb.input_values_mean.as_ref(),
-                        &visible,
-                        true,
-                    )?;
-                    (z, Some(kl))
+                // Masked-topic: deterministic simplex `log θ` (softmax or
+                // stick-breaking), no KL. In all cases the NB head reads this as
+                // its per-topic intensity log — `exp(z)` for the VAE, `θ` for
+                // the topic models.
+                let (raw_z, kl_opt) = masked_encode(
+                    encoder,
+                    opts.latent,
+                    &MaskedEncoderInput {
+                        indices: &mb.input_indices,
+                        values: &mb.input_values,
+                        values_null: mb.input_values_null.as_ref(),
+                        values_mean: mb.input_values_mean.as_ref(),
+                        visible_mask: &visible,
+                    },
+                    true,
+                )?;
+                // Simplex heads (`kl_opt` None) get topic smoothing; the Gaussian
+                // `z` is a raw log-intensity, not a log-simplex, so it's left as-is.
+                let log_z = if kl_opt.is_some() {
+                    raw_z
                 } else {
-                    let log_z = encoder.forward_indexed_masked(
-                        &mb.input_indices,
-                        &mb.input_values,
-                        mb.input_values_null.as_ref(),
-                        mb.input_values_mean.as_ref(),
-                        &visible,
-                        true,
-                    )?;
-                    (smooth_topics(log_z, config.topic_smoothing)?, None)
+                    smooth_topics(raw_z, config.topic_smoothing)?
                 };
 
                 // full_kd (α·ρᵀ [K,D]) — the per-topic log-partition for the NB
@@ -657,7 +743,8 @@ pub fn train_masked(
                     let c = masked.sum_all()?.to_scalar::<f32>()?;
                     (llik.mean_all()?.neg()?, m, c)
                 };
-                // Masked-VAE KL bottleneck: β · mean_N KL(z ‖ N(0, I)).
+                // Masked-VAE KL bottleneck: β · mean_N KL(z ‖ N(0, I)). `kl_opt`
+                // is `Some` only on the Gaussian head, so no head re-check needed.
                 if let Some(kl) = kl_opt {
                     kl_tot += kl.sum_all()?.to_scalar::<f32>()?;
                     kl_cnt += kl.dim(0)? as f32;
@@ -704,7 +791,7 @@ pub fn train_masked(
         kl_trace.push(per_kl);
         prog_bar.inc(1);
         if log::log_enabled!(log::Level::Info) {
-            let kl_msg = if opts.latent_gaussian {
+            let kl_msg = if matches!(opts.latent, LatentHead::Gaussian) {
                 format!(" kl/cell={per_kl:.4}")
             } else {
                 String::new()

--- a/candle-util/src/vae/mod.rs
+++ b/candle-util/src/vae/mod.rs
@@ -31,6 +31,39 @@ pub fn smooth_topics(log_z_nk: Tensor, alpha: f64) -> candle_core::Result<Tensor
     }
 }
 
+/// Deterministic stick-breaking map `logits [N,K] → log θ [N,K]` on the simplex.
+///
+/// Interprets the first `K−1` columns as stick logits `η_k`; the stick
+/// fractions are `v_k = σ(η_k)` and `θ_k = v_k ∏_{j<k}(1−v_j)`, with the last
+/// topic taking the closing mass `θ_{K−1} = ∏_{j<K}(1−v_j)`. Computed entirely
+/// in log-space (`log σ` via [`crate::loss::log_sigmoid`] + an inclusive cumsum
+/// of `log(1−v)`), so it is numerically stable for `|η|` up to the encoder
+/// clamp (±8) and any `K`. Rows sum to 1 exactly by telescoping — no explicit
+/// normalization.
+///
+/// A drop-in for `log_softmax` on the masked head: no sampling, no KL, still a
+/// point estimate. Unlike softmax it **breaks topic exchangeability** — early
+/// sticks carry more mass a priori, giving an intrinsic ordering and a
+/// self-pruning tail (later topics shrink toward 0 unless the data needs them).
+pub fn stick_breaking_log_simplex(logits_nk: &Tensor) -> candle_core::Result<Tensor> {
+    let k = logits_nk.dim(1)?;
+    if k == 1 {
+        // Degenerate simplex: θ ≡ 1, so log θ ≡ 0.
+        return logits_nk.zeros_like();
+    }
+    // θ_k = v_k·∏_{j<k}(1−v_j), v_k = σ(η_k). Using the identity
+    // log σ(η) − log σ(−η) = η, the log-simplex collapses to
+    // log θ_k = η_k + Σ_{j≤k} log(1−v_j) — so only a single `log σ` (for
+    // `log(1−v)`) and its inclusive cumsum are needed; `log v` and the
+    // exclusive-cumsum subtraction both drop out.
+    let eta = logits_nk.narrow(1, 0, k - 1)?; // [N, K−1] stick logits (strided view)
+    let log_1mv = crate::loss::log_sigmoid(&eta.neg()?)?; // log(1−v_k) = log σ(−η_k)
+    let incl = log_1mv.cumsum(1)?; // inclusive: Σ_{j≤k} log(1−v_j)
+    let head = (&eta + &incl)?; // log θ_0..θ_{K−2} = η_k + Σ_{j≤k} log(1−v_j)
+    let tail = incl.narrow(1, k - 2, 1)?; // log θ_{K−1} = full remaining mass [N, 1]
+    Tensor::cat(&[&head, &tail], 1) // [N, K], rows sum to 1
+}
+
 /// Wall-clock breakdown of the indexed-topic training hot loop.
 ///
 /// Candle's CPU backend is eager, so an `Instant` straddling each phase
@@ -148,3 +181,50 @@ pub fn clip_and_step_dense(
 ///
 /// Signature: `(loss, level) -> extended_loss`.
 pub type LevelLossHook<'a> = dyn Fn(Tensor, usize) -> anyhow::Result<Tensor> + 'a;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    /// Hand-computed reference for the stick-breaking map. With logits
+    /// `η = [0, ln2, *]` (the 3rd column is ignored — only the first K−1 are
+    /// sticks): `v₀ = σ(0) = 1/2`, `v₁ = σ(ln2) = 2/3`, so
+    /// `θ = [v₀, v₁(1−v₀), (1−v₀)(1−v₁)] = [1/2, 1/3, 1/6]`.
+    #[test]
+    fn stick_breaking_matches_reference_and_normalizes() {
+        let dev = Device::Cpu;
+        let ln2 = std::f32::consts::LN_2;
+        // Row 0: the reference case. Row 1: arbitrary logits → check it still
+        // normalizes. The last column (999.0 / −999.0) must not affect output.
+        let logits =
+            Tensor::from_vec(vec![0.0f32, ln2, 999.0, -1.5, 2.0, -999.0], (2, 3), &dev).unwrap();
+
+        let log_theta = stick_breaking_log_simplex(&logits).unwrap();
+        assert_eq!(log_theta.dims(), &[2, 3]);
+        let theta = log_theta.exp().unwrap().to_vec2::<f32>().unwrap();
+
+        // Row 0 matches the closed form.
+        let expect0 = [0.5f32, 1.0 / 3.0, 1.0 / 6.0];
+        for (got, want) in theta[0].iter().zip(expect0.iter()) {
+            assert!((got - want).abs() < 1e-5, "θ₀ {got} vs {want}");
+        }
+        // Both rows lie on the simplex (sum to 1) despite the huge 3rd logit.
+        for row in &theta {
+            let sum: f32 = row.iter().sum();
+            assert!((sum - 1.0).abs() < 1e-5, "row sum {sum} ≠ 1");
+            assert!(row.iter().all(|&p| p > 0.0), "non-positive θ entry");
+        }
+    }
+
+    /// `K = 1` is a degenerate simplex: θ ≡ 1, log θ ≡ 0.
+    #[test]
+    fn stick_breaking_k1_is_degenerate() {
+        let dev = Device::Cpu;
+        let logits = Tensor::from_vec(vec![3.7f32, -2.0], (2, 1), &dev).unwrap();
+        let log_theta = stick_breaking_log_simplex(&logits).unwrap();
+        for v in log_theta.flatten_all().unwrap().to_vec1::<f32>().unwrap() {
+            assert_eq!(v, 0.0, "K=1 log θ must be 0");
+        }
+    }
+}

--- a/senna/Cargo.toml
+++ b/senna/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.7.0"
+version = "0.7.1"
 
 [lib]
 name = "senna"

--- a/senna/src/main.rs
+++ b/senna/src/main.rs
@@ -213,20 +213,21 @@ enum Commands {
     MaskedVae(MaskedTopicArgs),
 
     #[command(
-        name = "masked-stick",
-        about = "Train a masked-imputation topic model with a stick-breaking simplex.",
-        long_about = "Stick-breaking sibling of `masked-topic`: same masked-imputation\n\
-                      pipeline (shared per-gene ρ embedding, NB ETM head, deterministic\n\
-                      no-KL objective, encoder-only inference), but the encoder maps its\n\
-                      logits through a stick-breaking simplex θ_k = v_k·∏_{j<k}(1−v_j),\n\
-                      v_k = σ(η_k), instead of softmax. Topics are no longer exchangeable:\n\
-                      early sticks carry more mass a priori, giving an intrinsic ordering\n\
-                      and a self-pruning tail (later topics shrink toward 0 unless the data\n\
-                      needs them) — a soft, differentiable way to over-provision K and\n\
-                      prune. Writes the same artifacts as `masked-topic`.",
-        visible_aliases = ["mstick"]
+        name = "masked-sbp",
+        about = "Train a masked-imputation topic model with a stick-breaking-process simplex.",
+        long_about = "Stick-breaking-process (SBP) sibling of `masked-topic`: same\n\
+                      masked-imputation pipeline (shared per-gene ρ embedding, NB ETM head,\n\
+                      deterministic no-KL objective, encoder-only inference), but the\n\
+                      encoder maps its logits through a stick-breaking simplex\n\
+                      θ_k = v_k·∏_{j<k}(1−v_j), v_k = σ(η_k), instead of softmax. Topics\n\
+                      are no longer exchangeable: early sticks carry more mass a priori,\n\
+                      giving an intrinsic ordering and a self-pruning tail (later topics\n\
+                      shrink toward 0 unless the data needs them) — a soft, differentiable\n\
+                      way to over-provision K and prune. Writes the same artifacts as\n\
+                      `masked-topic`.",
+        visible_aliases = ["sbp"]
     )]
-    MaskedStick(MaskedTopicArgs),
+    MaskedSbp(MaskedTopicArgs),
 
     #[command(
         about = "Train an scVI-style Gaussian VAE (continuous factor model).",
@@ -559,8 +560,8 @@ fn main() -> anyhow::Result<()> {
         Commands::MaskedVae(args) => {
             fit_masked_vae_model(args)?;
         }
-        Commands::MaskedStick(args) => {
-            fit_masked_stick_model(args)?;
+        Commands::MaskedSbp(args) => {
+            fit_masked_sbp_model(args)?;
         }
         Commands::Vae(args) => {
             fit_vae_model(args)?;

--- a/senna/src/main.rs
+++ b/senna/src/main.rs
@@ -213,6 +213,22 @@ enum Commands {
     MaskedVae(MaskedTopicArgs),
 
     #[command(
+        name = "masked-stick",
+        about = "Train a masked-imputation topic model with a stick-breaking simplex.",
+        long_about = "Stick-breaking sibling of `masked-topic`: same masked-imputation\n\
+                      pipeline (shared per-gene ρ embedding, NB ETM head, deterministic\n\
+                      no-KL objective, encoder-only inference), but the encoder maps its\n\
+                      logits through a stick-breaking simplex θ_k = v_k·∏_{j<k}(1−v_j),\n\
+                      v_k = σ(η_k), instead of softmax. Topics are no longer exchangeable:\n\
+                      early sticks carry more mass a priori, giving an intrinsic ordering\n\
+                      and a self-pruning tail (later topics shrink toward 0 unless the data\n\
+                      needs them) — a soft, differentiable way to over-provision K and\n\
+                      prune. Writes the same artifacts as `masked-topic`.",
+        visible_aliases = ["mstick"]
+    )]
+    MaskedStick(MaskedTopicArgs),
+
+    #[command(
         about = "Train an scVI-style Gaussian VAE (continuous factor model).",
         long_about = "Gaussian (scVI-style) VAE — the continuous-latent sibling of\n\
                       `topic`. Same pipeline (batch-aware pseudobulk collapse → dense VAE),\n\
@@ -542,6 +558,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::MaskedVae(args) => {
             fit_masked_vae_model(args)?;
+        }
+        Commands::MaskedStick(args) => {
+            fit_masked_stick_model(args)?;
         }
         Commands::Vae(args) => {
             fit_vae_model(args)?;

--- a/senna/src/masked_topic.rs
+++ b/senna/src/masked_topic.rs
@@ -10,6 +10,7 @@ use crate::topic::train_masked::{
 
 use candle_util::decoder::EmbeddedNbTopicDecoder;
 use candle_util::encoder::*;
+use candle_util::vae::masked_topic::LatentHead;
 use log::warn;
 
 /// Mask-rate schedule (CLI surface for `MaskSchedule`).
@@ -538,9 +539,17 @@ impl From<FeatureNameKindArg> for Option<auxiliary_data::feature_names::FeatureN
     }
 }
 
-/// `senna masked-topic` — simplex-`θ`, deterministic (no-KL) masked ETM.
+/// `senna masked-topic` — softmax simplex-`θ`, deterministic (no-KL) masked ETM.
 pub fn fit_masked_topic_model(args: &MaskedTopicArgs) -> anyhow::Result<()> {
-    fit_masked_model(args, false)
+    fit_masked_model(args, LatentHead::Softmax)
+}
+
+/// `senna masked-stick` — **stick-breaking** simplex-`θ`, deterministic (no-KL)
+/// masked ETM. Same pipeline as `masked-topic`; the encoder maps its logits
+/// through a stick-breaking simplex instead of softmax, giving ordered,
+/// exchangeability-broken topics with a self-pruning tail.
+pub fn fit_masked_stick_model(args: &MaskedTopicArgs) -> anyhow::Result<()> {
+    fit_masked_model(args, LatentHead::StickBreaking)
 }
 
 /// `senna masked-vae` — Gaussian-latent (reparam + KL) masked VAE. Shares the
@@ -548,10 +557,10 @@ pub fn fit_masked_topic_model(args: &MaskedTopicArgs) -> anyhow::Result<()> {
 /// the encoder emits a reparameterized `z` (no softmax) and the loss gains a KL
 /// term. `exp(z)` plays the role of the per-topic intensities in the NB head.
 pub fn fit_masked_vae_model(args: &MaskedTopicArgs) -> anyhow::Result<()> {
-    fit_masked_model(args, true)
+    fit_masked_model(args, LatentHead::Gaussian)
 }
 
-fn fit_masked_model(args: &MaskedTopicArgs, latent_gaussian: bool) -> anyhow::Result<()> {
+fn fit_masked_model(args: &MaskedTopicArgs, head: LatentHead) -> anyhow::Result<()> {
     mkdir_parent(&args.out)?;
 
     let k = args.n_latent_topics;
@@ -803,7 +812,9 @@ fn fit_masked_model(args: &MaskedTopicArgs, latent_gaussian: bool) -> anyhow::Re
             &parameters,
             prefix,
             &WarmStartCheck {
-                model_type_expected: crate::topic::model_metadata::MODEL_TYPE_INDEXED_MASKED,
+                // Warm-start from a checkpoint of the same head — the z_mean
+                // semantics differ per head, so `--init-from` must match.
+                model_type_expected: crate::topic::model_metadata::masked_model_type(head),
                 n_topics,
                 n_features_full,
                 n_features_encoder: n_features_full,
@@ -901,7 +912,7 @@ fn fit_masked_model(args: &MaskedTopicArgs, latent_gaussian: bool) -> anyhow::Re
             },
         },
         likelihood: args.masked_likelihood.to_lib(),
-        latent_gaussian,
+        latent: head,
         kl_weight: args.kl_weight,
     };
 
@@ -924,23 +935,16 @@ fn fit_masked_model(args: &MaskedTopicArgs, latent_gaussian: bool) -> anyhow::Re
     // Persist trainable weights, model architecture, and shortlist weights
     // so `senna predict` (and `--init-from` re-runs) can rebuild this model.
     use crate::topic::model_metadata::{
-        save_feature_mean, save_parameters, save_shortlist_weights, TopicModelMetadata,
+        masked_decoder_type, masked_model_type, save_feature_mean, save_parameters,
+        save_shortlist_weights, TopicModelMetadata,
     };
 
     // No feature graph is persisted on the masked path (GCN diffusion is not
     // wired into the masked encoder — see the encoder construction above).
     save_parameters(&parameters, &args.out)?;
     let mut metadata = TopicModelMetadata {
-        model_type: if latent_gaussian {
-            crate::topic::model_metadata::MODEL_TYPE_MASKED_VAE.into()
-        } else {
-            crate::topic::model_metadata::MODEL_TYPE_INDEXED_MASKED.into()
-        },
-        decoder_types: vec![if latent_gaussian {
-            "nb_masked_vae".into()
-        } else {
-            "nb_masked".into()
-        }],
+        model_type: masked_model_type(head).into(),
+        decoder_types: vec![masked_decoder_type(head).into()],
         decoder_weights: vec![1.0],
         n_features_encoder: n_features_full,
         n_features_full,
@@ -1001,7 +1005,7 @@ fn fit_masked_model(args: &MaskedTopicArgs, latent_gaussian: bool) -> anyhow::Re
         enc_context_size: args.context_size,
         shortlist_weights: &shortlist_weights,
         feature_mean: &feature_mean,
-        latent_gaussian,
+        head,
     };
     let z_nk = evaluate_latent_masked(&data_vec, &cpu_encoder, &eval_config, delta.as_ref(), None)?;
 

--- a/senna/src/masked_topic.rs
+++ b/senna/src/masked_topic.rs
@@ -306,6 +306,28 @@ pub struct MaskedTopicArgs {
 
     #[arg(
         long,
+        default_value_t = 0.0,
+        help = "Held-out imputation eval: fraction to hold out after training (0 = off)",
+        long_help = "After training, run a held-out masked-imputation evaluation and\n\
+                     log the mean log-likelihood per held-out gene. For each cell this\n\
+                     fraction of its observed genes is hidden, the rest encode a latent,\n\
+                     and the trained decoder imputes the hidden genes. Unlike the\n\
+                     per-epoch training likelihood this is not optimized, so it\n\
+                     distinguishes real structure from overfitting. Use a fixed\n\
+                     --eval-seed to compare heads on the same held-out positions.\n\
+                     0 disables (default)."
+    )]
+    eval_mask_fraction: f64,
+
+    #[arg(
+        long,
+        default_value_t = 42,
+        help = "Seed for the held-out imputation mask (see --eval-mask-fraction)"
+    )]
+    eval_seed: u64,
+
+    #[arg(
+        long,
         default_value_t = 1.0,
         help = "KL weight β for the Gaussian latent (masked-vae only; default 1.0)",
         long_help = "KL weight β for the Gaussian latent (masked-vae only; ignored by\n\
@@ -544,11 +566,11 @@ pub fn fit_masked_topic_model(args: &MaskedTopicArgs) -> anyhow::Result<()> {
     fit_masked_model(args, LatentHead::Softmax)
 }
 
-/// `senna masked-stick` — **stick-breaking** simplex-`θ`, deterministic (no-KL)
-/// masked ETM. Same pipeline as `masked-topic`; the encoder maps its logits
-/// through a stick-breaking simplex instead of softmax, giving ordered,
+/// `senna masked-sbp` — **stick-breaking process** simplex-`θ`, deterministic
+/// (no-KL) masked ETM. Same pipeline as `masked-topic`; the encoder maps its
+/// logits through a stick-breaking simplex instead of softmax, giving ordered,
 /// exchangeability-broken topics with a self-pruning tail.
-pub fn fit_masked_stick_model(args: &MaskedTopicArgs) -> anyhow::Result<()> {
+pub fn fit_masked_sbp_model(args: &MaskedTopicArgs) -> anyhow::Result<()> {
     fit_masked_model(args, LatentHead::StickBreaking)
 }
 
@@ -931,6 +953,51 @@ fn fit_masked_model(args: &MaskedTopicArgs, head: LatentHead) -> anyhow::Result<
     let finest_decoder = decoders.last().unwrap();
     write_masked_dictionary(finest_decoder, &gene_names, &args.out)?;
     write_feature_embedding(base_encoder.feature_embeddings(), &gene_names, &args.out)?;
+
+    // Optional held-out masked-imputation evaluation — the un-optimized
+    // generalization metric (see `--eval-mask-fraction`). Runs on the training
+    // device with the in-memory encoder + finest decoder, before the CPU move.
+    if args.eval_mask_fraction > 0.0 {
+        use crate::topic::eval_indexed::{evaluate_holdout_imputation, HoldoutEvalConfig};
+        let delta_train = match args.adj_method {
+            AdjMethod::Batch => finest_collapsed.delta.as_ref(),
+            AdjMethod::Residual => finest_collapsed.mu_residual.as_ref(),
+        }
+        .map(|x| {
+            x.posterior_mean()
+                .to_tensor(&dev)
+                .expect("delta to tensor")
+                .transpose(0, 1)
+                .expect("transpose")
+                .contiguous()
+                .expect("contiguous")
+        });
+        let holdout_cfg = HoldoutEvalConfig {
+            dev: &dev,
+            adj_method: &args.adj_method,
+            minibatch_size: args.minibatch_size,
+            enc_context_size: args.context_size,
+            shortlist_weights: &shortlist_weights,
+            feature_mean: &feature_mean,
+            head,
+            likelihood: args.masked_likelihood.to_lib(),
+            topic_smoothing: args.topic_smoothing,
+            mask_fraction: args.eval_mask_fraction,
+            seed: args.eval_seed,
+        };
+        let holdout_llik = evaluate_holdout_imputation(
+            &data_vec,
+            &base_encoder,
+            finest_decoder,
+            &holdout_cfg,
+            delta_train.as_ref(),
+        )?;
+        info!(
+            "Held-out imputation: mean log-likelihood/gene = {holdout_llik:.4} \
+             (mask={}, seed={})",
+            args.eval_mask_fraction, args.eval_seed
+        );
+    }
 
     // Persist trainable weights, model architecture, and shortlist weights
     // so `senna predict` (and `--init-from` re-runs) can rebuild this model.

--- a/senna/src/predict.rs
+++ b/senna/src/predict.rs
@@ -243,18 +243,21 @@ pub fn predict_model(args: &PredictArgs) -> anyhow::Result<()> {
     }
 
     use crate::topic::model_metadata::{
-        MODEL_TYPE_INDEXED_MASKED, MODEL_TYPE_MASKED_VAE, MODEL_TYPE_TOPIC, MODEL_TYPE_VAE,
+        masked_head_from_model_type, MODEL_TYPE_INDEXED_MASKED, MODEL_TYPE_MASKED_STICK,
+        MODEL_TYPE_MASKED_VAE, MODEL_TYPE_TOPIC, MODEL_TYPE_VAE,
     };
+    // All masked heads (softmax / stick-breaking / Gaussian) share the
+    // encoder-only path; `masked_head_from_model_type` recovers which one.
+    if let Some(head) = masked_head_from_model_type(&metadata.model_type) {
+        return predict_masked(args, &metadata, head);
+    }
     match metadata.model_type.as_ref() {
         MODEL_TYPE_TOPIC => predict_dense(args, &metadata),
-        // Both masked models share the encoder-only path; the Gaussian latent
-        // only switches which encoder forward (simplex vs raw z) is run.
-        MODEL_TYPE_INDEXED_MASKED => predict_masked(args, &metadata, false),
-        MODEL_TYPE_MASKED_VAE => predict_masked(args, &metadata, true),
         MODEL_TYPE_VAE => predict_vae(args, &metadata),
         other => anyhow::bail!(
             "predict: unsupported model_type '{other}' (expected '{MODEL_TYPE_TOPIC}', \
-             '{MODEL_TYPE_INDEXED_MASKED}', '{MODEL_TYPE_MASKED_VAE}', or '{MODEL_TYPE_VAE}')",
+             '{MODEL_TYPE_INDEXED_MASKED}', '{MODEL_TYPE_MASKED_STICK}', \
+             '{MODEL_TYPE_MASKED_VAE}', or '{MODEL_TYPE_VAE}')",
         ),
     }
 }
@@ -728,10 +731,11 @@ fn remap_and_coarsen_dense(
 fn predict_masked(
     args: &PredictArgs,
     metadata: &TopicModelMetadata,
-    latent_gaussian: bool,
+    head: candle_util::vae::masked_topic::LatentHead,
 ) -> anyhow::Result<()> {
     use crate::topic::eval_indexed::{evaluate_latent_masked, EvaluateLatentMaskedConfig};
     use crate::topic::model_metadata::load_feature_mean;
+    use crate::topic::model_metadata::masked_head_label;
 
     let embedding_dim = metadata
         .embedding_dim
@@ -800,7 +804,7 @@ fn predict_masked(
         enc_context_size,
         shortlist_weights: &shortlist_weights,
         feature_mean: &feature_mean,
-        latent_gaussian,
+        head,
     };
     let z_nk = evaluate_latent_masked(
         &data_vec,
@@ -813,11 +817,7 @@ fn predict_masked(
     let cell_names = data_vec.column_names()?;
     // Inference: emit a row per query cell (no QC dropping).
     crate::output_helpers::save_latent(&args.out, &z_nk, &cell_names, None)?;
-    let model_label = if latent_gaussian {
-        "masked-vae"
-    } else {
-        "masked-topic"
-    };
+    let model_label = masked_head_label(head);
     info!(
         "Wrote {}.latent.parquet ({model_label}, encoder-only)",
         args.out

--- a/senna/src/predict.rs
+++ b/senna/src/predict.rs
@@ -243,7 +243,7 @@ pub fn predict_model(args: &PredictArgs) -> anyhow::Result<()> {
     }
 
     use crate::topic::model_metadata::{
-        masked_head_from_model_type, MODEL_TYPE_INDEXED_MASKED, MODEL_TYPE_MASKED_STICK,
+        masked_head_from_model_type, MODEL_TYPE_INDEXED_MASKED, MODEL_TYPE_MASKED_SBP,
         MODEL_TYPE_MASKED_VAE, MODEL_TYPE_TOPIC, MODEL_TYPE_VAE,
     };
     // All masked heads (softmax / stick-breaking / Gaussian) share the
@@ -256,7 +256,7 @@ pub fn predict_model(args: &PredictArgs) -> anyhow::Result<()> {
         MODEL_TYPE_VAE => predict_vae(args, &metadata),
         other => anyhow::bail!(
             "predict: unsupported model_type '{other}' (expected '{MODEL_TYPE_TOPIC}', \
-             '{MODEL_TYPE_INDEXED_MASKED}', '{MODEL_TYPE_MASKED_STICK}', \
+             '{MODEL_TYPE_INDEXED_MASKED}', '{MODEL_TYPE_MASKED_SBP}', \
              '{MODEL_TYPE_MASKED_VAE}', or '{MODEL_TYPE_VAE}')",
         ),
     }

--- a/senna/src/topic/eval_indexed.rs
+++ b/senna/src/topic/eval_indexed.rs
@@ -3,8 +3,14 @@ use crate::embed_common::*;
 
 use candle_core::{Device, Tensor};
 use candle_util::data::csc_columns_to_indexed_samples;
+use candle_util::decoder::{EmbeddedNbTopicDecoder, MaskedNbTarget};
 use candle_util::traits::*;
-use candle_util::vae::masked_topic::{masked_encode, LatentHead, MaskedEncoderInput};
+use candle_util::vae::masked_topic::{
+    masked_encode, LatentHead, MaskedEncoderInput, MaskedLikelihood,
+};
+use candle_util::vae::smooth_topics;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
 
 /// Packed top-K representation consumed by the masked encoder.
 ///
@@ -197,5 +203,135 @@ pub(crate) fn evaluate_latent_masked(
         )?;
         let z_nk = latent_nk.to_device(&candle_core::Device::Cpu)?;
         Ok((lb, Mat::from_tensor(&z_nk)?))
+    })
+}
+
+/// Config for [`evaluate_holdout_imputation`].
+pub(crate) struct HoldoutEvalConfig<'a> {
+    pub dev: &'a Device,
+    pub adj_method: &'a AdjMethod,
+    pub minibatch_size: usize,
+    pub enc_context_size: usize,
+    pub shortlist_weights: &'a [f32],
+    pub feature_mean: &'a [f32],
+    /// Latent head the model was trained with (matches the persisted model).
+    pub head: LatentHead,
+    /// Per-gene likelihood — must match training for a comparable number.
+    pub likelihood: MaskedLikelihood,
+    /// Topic smoothing applied to the simplex heads, mirroring training.
+    pub topic_smoothing: f64,
+    /// Fraction of each cell's observed genes to hold out and score.
+    pub mask_fraction: f64,
+    /// Seed for the hold-out mask. A fixed seed masks the **same** per-cell
+    /// positions across heads, so the comparison is apples-to-apples.
+    pub seed: u64,
+}
+
+/// Held-out masked-imputation likelihood: for each cell, hide `mask_fraction`
+/// of its observed genes, encode from the **visible** genes, impute the hidden
+/// ones with the trained NB/multinomial ETM decoder, and return the mean
+/// log-likelihood per held-out gene.
+///
+/// This is the honest generalization metric the per-epoch training likelihood
+/// can't provide: the scored positions are never encoder inputs on their own
+/// forward pass, and individual cells enter training only via their pseudobulk
+/// aggregate — so a model that merely memorizes the training pseudobulks cannot
+/// score well here. Runs one no-gradient pass; the decoder's `β = α·ρᵀ` (and
+/// its log-partition) are fixed, so they are computed once.
+pub(crate) fn evaluate_holdout_imputation(
+    data_vec: &SparseIoVec,
+    encoder: &candle_util::encoder::IndexedEmbeddingEncoder,
+    decoder: &EmbeddedNbTopicDecoder,
+    config: &HoldoutEvalConfig,
+    delta: Option<&Tensor>,
+) -> anyhow::Result<f32> {
+    let ntot = data_vec.num_columns();
+    let full_kd = decoder.full_logits_kd()?;
+    let logz_11k = EmbeddedNbTopicDecoder::log_partition_from_logits(&full_kd)?;
+
+    let mut llik_sum = 0f64;
+    let mut mask_cnt = 0f64;
+    for (lb, ub) in create_jobs(ntot, 0, Some(config.minibatch_size)) {
+        let x_dn = data_vec.read_columns_csc(lb..ub)?;
+        let x0_nd = delta
+            .map(|delta_bm| {
+                expand_delta_for_block(data_vec, delta_bm, config.adj_method, lb, ub, config.dev)
+            })
+            .transpose()?;
+
+        let ctx = PerGeneContext {
+            feature_mean: Some(config.feature_mean),
+        };
+        let enc_pack = csc_to_indexed(
+            &x_dn,
+            config.enc_context_size,
+            config.shortlist_weights,
+            None,
+            ctx,
+            config.dev,
+        )?;
+        let values_null = x0_nd
+            .as_ref()
+            .map(|x0| gather_null_at_indices(x0, &enc_pack.indices, config.dev))
+            .transpose()?;
+
+        // Seeded hold-out mask over the cell's real (value>0) top-K positions.
+        // Host-side RNG keyed by `seed ^ lb` so the masked set is deterministic
+        // and identical across heads for a fixed seed.
+        let (n, k) = enc_pack.values.dims2()?;
+        let values_host: Vec<f32> = enc_pack.values.flatten_all()?.to_vec1()?;
+        let mut rng = StdRng::seed_from_u64(config.seed ^ (lb as u64));
+        let mut mask_buf = vec![0f32; n * k];
+        for (slot, &v) in values_host.iter().enumerate() {
+            if v > 0.0 && rng.random::<f64>() < config.mask_fraction {
+                mask_buf[slot] = 1.0;
+            }
+        }
+        let masked = Tensor::from_vec(mask_buf, (n, k), config.dev)?;
+        let real = enc_pack.values.gt(0.0)?.to_dtype(candle_core::DType::F32)?;
+        let visible = (&real - &masked)?;
+
+        // Encode from the visible genes only, mirroring the training split
+        // (including the simplex-head topic smoothing).
+        let (raw_z, kl_opt) = masked_encode(
+            encoder,
+            config.head,
+            &MaskedEncoderInput {
+                indices: &enc_pack.indices,
+                values: &enc_pack.values,
+                values_null: values_null.as_ref(),
+                values_mean: enc_pack.values_mean.as_ref(),
+                visible_mask: &visible,
+            },
+            false,
+        )?;
+        let log_z = if kl_opt.is_some() {
+            raw_z
+        } else {
+            smooth_topics(raw_z, config.topic_smoothing)?
+        };
+
+        let lib_n1 = (enc_pack.values.sum_keepdim(1)? + 1.0)?;
+        let target = MaskedNbTarget {
+            indices: &enc_pack.indices,
+            residual: values_null.as_ref(),
+            values: &enc_pack.values,
+            lib: &lib_n1,
+            mask: &masked,
+        };
+        let llik = match config.likelihood {
+            MaskedLikelihood::Nb => decoder.impute_masked_nb(&log_z, &target, &logz_11k)?,
+            MaskedLikelihood::Multinomial => {
+                decoder.impute_masked_multinomial(&log_z, &target, &logz_11k)?
+            }
+        };
+        llik_sum += f64::from(llik.sum_all()?.to_scalar::<f32>()?);
+        mask_cnt += f64::from(masked.sum_all()?.to_scalar::<f32>()?);
+    }
+
+    Ok(if mask_cnt > 0.0 {
+        (llik_sum / mask_cnt) as f32
+    } else {
+        f32::NAN
     })
 }

--- a/senna/src/topic/eval_indexed.rs
+++ b/senna/src/topic/eval_indexed.rs
@@ -4,6 +4,7 @@ use crate::embed_common::*;
 use candle_core::{Device, Tensor};
 use candle_util::data::csc_columns_to_indexed_samples;
 use candle_util::traits::*;
+use candle_util::vae::masked_topic::{masked_encode, LatentHead, MaskedEncoderInput};
 
 /// Packed top-K representation consumed by the masked encoder.
 ///
@@ -133,10 +134,11 @@ pub(crate) struct EvaluateLatentMaskedConfig<'a> {
     pub enc_context_size: usize,
     pub shortlist_weights: &'a [f32],
     pub feature_mean: &'a [f32],
-    /// Masked-VAE: use the Gaussian masked forward (posterior-mean `z`, no
-    /// softmax) instead of the simplex `log θ` forward. The latent semantics
-    /// differ but the eval path (all genes visible, no decoder) is identical.
-    pub latent_gaussian: bool,
+    /// Latent head to run at inference — must match the head the model was
+    /// trained with. The eval path (all genes visible, no decoder) is identical
+    /// across heads; only the final simplex/latent map differs. The Gaussian
+    /// arm returns the posterior mean `z` (train=false → reparam returns mean).
+    pub head: LatentHead,
 }
 
 /// Encoder-only latent inference for the masked-imputation topic model.
@@ -179,27 +181,20 @@ pub(crate) fn evaluate_latent_masked(
             .map(|x0| gather_null_at_indices(x0, &enc_pack.indices, config.dev))
             .transpose()?;
         let visible = enc_pack.values.gt(0.0)?.to_dtype(candle_core::DType::F32)?;
-        let latent_nk = if config.latent_gaussian {
-            // Posterior mean `z` (train=false → reparam returns the mean).
-            let (z, _kl) = encoder.forward_indexed_masked_gaussian(
-                &enc_pack.indices,
-                &enc_pack.values,
-                enc_values_null.as_ref(),
-                enc_pack.values_mean.as_ref(),
-                &visible,
-                false,
-            )?;
-            z
-        } else {
-            encoder.forward_indexed_masked(
-                &enc_pack.indices,
-                &enc_pack.values,
-                enc_values_null.as_ref(),
-                enc_pack.values_mean.as_ref(),
-                &visible,
-                false,
-            )?
-        };
+        // Encoder-only inference: `train = false` (Gaussian returns its posterior
+        // mean), and the KL is discarded — the latent alone is written out.
+        let (latent_nk, _kl) = masked_encode(
+            encoder,
+            config.head,
+            &MaskedEncoderInput {
+                indices: &enc_pack.indices,
+                values: &enc_pack.values,
+                values_null: enc_values_null.as_ref(),
+                values_mean: enc_pack.values_mean.as_ref(),
+                visible_mask: &visible,
+            },
+            false,
+        )?;
         let z_nk = latent_nk.to_device(&candle_core::Device::Cpu)?;
         Ok((lb, Mat::from_tensor(&z_nk)?))
     })

--- a/senna/src/topic/model_metadata.rs
+++ b/senna/src/topic/model_metadata.rs
@@ -11,12 +11,12 @@ pub const MODEL_TYPE_TOPIC: &str = "topic";
 /// Inference is encoder-only (no decoder refinement). The retired generative
 /// indexed-topic model used `"indexed_topic_packed"`; that path is gone.
 pub const MODEL_TYPE_INDEXED_MASKED: &str = "indexed_topic_masked";
-/// Masked **stick-breaking** topic model (`senna masked-stick`): same masked-
-/// imputation ETM pipeline as [`MODEL_TYPE_INDEXED_MASKED`] (deterministic, no
-/// KL), but the encoder maps its logits through a stick-breaking simplex instead
-/// of softmax — ordered, exchangeability-broken topics with a self-pruning tail.
-/// Inference is encoder-only.
-pub const MODEL_TYPE_MASKED_STICK: &str = "masked_stick";
+/// Masked **stick-breaking process** topic model (`senna masked-sbp`): same
+/// masked-imputation ETM pipeline as [`MODEL_TYPE_INDEXED_MASKED`]
+/// (deterministic, no KL), but the encoder maps its logits through a
+/// stick-breaking simplex instead of softmax — ordered, exchangeability-broken
+/// topics with a self-pruning tail. Inference is encoder-only.
+pub const MODEL_TYPE_MASKED_SBP: &str = "masked_sbp";
 /// Masked **Gaussian VAE** (`senna masked-vae`): same masked-imputation ETM
 /// pipeline as [`MODEL_TYPE_INDEXED_MASKED`], but the encoder emits a
 /// reparameterized Gaussian latent `z` (no simplex softmax) regularized by a KL
@@ -39,7 +39,7 @@ use candle_util::vae::masked_topic::LatentHead;
 pub fn masked_model_type(head: LatentHead) -> &'static str {
     match head {
         LatentHead::Softmax => MODEL_TYPE_INDEXED_MASKED,
-        LatentHead::StickBreaking => MODEL_TYPE_MASKED_STICK,
+        LatentHead::StickBreaking => MODEL_TYPE_MASKED_SBP,
         LatentHead::Gaussian => MODEL_TYPE_MASKED_VAE,
     }
 }
@@ -49,7 +49,7 @@ pub fn masked_model_type(head: LatentHead) -> &'static str {
 pub fn masked_head_from_model_type(model_type: &str) -> Option<LatentHead> {
     match model_type {
         MODEL_TYPE_INDEXED_MASKED => Some(LatentHead::Softmax),
-        MODEL_TYPE_MASKED_STICK => Some(LatentHead::StickBreaking),
+        MODEL_TYPE_MASKED_SBP => Some(LatentHead::StickBreaking),
         MODEL_TYPE_MASKED_VAE => Some(LatentHead::Gaussian),
         _ => None,
     }
@@ -59,7 +59,7 @@ pub fn masked_head_from_model_type(model_type: &str) -> Option<LatentHead> {
 pub fn masked_head_label(head: LatentHead) -> &'static str {
     match head {
         LatentHead::Softmax => "masked-topic",
-        LatentHead::StickBreaking => "masked-stick",
+        LatentHead::StickBreaking => "masked-sbp",
         LatentHead::Gaussian => "masked-vae",
     }
 }

--- a/senna/src/topic/model_metadata.rs
+++ b/senna/src/topic/model_metadata.rs
@@ -11,6 +11,12 @@ pub const MODEL_TYPE_TOPIC: &str = "topic";
 /// Inference is encoder-only (no decoder refinement). The retired generative
 /// indexed-topic model used `"indexed_topic_packed"`; that path is gone.
 pub const MODEL_TYPE_INDEXED_MASKED: &str = "indexed_topic_masked";
+/// Masked **stick-breaking** topic model (`senna masked-stick`): same masked-
+/// imputation ETM pipeline as [`MODEL_TYPE_INDEXED_MASKED`] (deterministic, no
+/// KL), but the encoder maps its logits through a stick-breaking simplex instead
+/// of softmax — ordered, exchangeability-broken topics with a self-pruning tail.
+/// Inference is encoder-only.
+pub const MODEL_TYPE_MASKED_STICK: &str = "masked_stick";
 /// Masked **Gaussian VAE** (`senna masked-vae`): same masked-imputation ETM
 /// pipeline as [`MODEL_TYPE_INDEXED_MASKED`], but the encoder emits a
 /// reparameterized Gaussian latent `z` (no simplex softmax) regularized by a KL
@@ -23,6 +29,50 @@ pub const MODEL_TYPE_MASKED_VAE: &str = "masked_vae";
 /// library·π`, NB). The latent is continuous factors, not simplex topic
 /// proportions; the dictionary is gene × factor loadings.
 pub const MODEL_TYPE_VAE: &str = "vae";
+
+use candle_util::vae::masked_topic::LatentHead;
+
+/// Single source of truth for the masked-model head ↔ persisted `model_type`
+/// ↔ CLI label mapping. Every site (metadata write, `predict` dispatch, log
+/// labels, warm-start expectation) derives from these three functions instead
+/// of re-spelling the mapping, so a new head is added in one place.
+pub fn masked_model_type(head: LatentHead) -> &'static str {
+    match head {
+        LatentHead::Softmax => MODEL_TYPE_INDEXED_MASKED,
+        LatentHead::StickBreaking => MODEL_TYPE_MASKED_STICK,
+        LatentHead::Gaussian => MODEL_TYPE_MASKED_VAE,
+    }
+}
+
+/// Inverse of [`masked_model_type`]: recover the head from a persisted
+/// `model_type`, or `None` for a non-masked model (`topic` / `vae`).
+pub fn masked_head_from_model_type(model_type: &str) -> Option<LatentHead> {
+    match model_type {
+        MODEL_TYPE_INDEXED_MASKED => Some(LatentHead::Softmax),
+        MODEL_TYPE_MASKED_STICK => Some(LatentHead::StickBreaking),
+        MODEL_TYPE_MASKED_VAE => Some(LatentHead::Gaussian),
+        _ => None,
+    }
+}
+
+/// Human-facing CLI/log label for a masked head (the subcommand name).
+pub fn masked_head_label(head: LatentHead) -> &'static str {
+    match head {
+        LatentHead::Softmax => "masked-topic",
+        LatentHead::StickBreaking => "masked-stick",
+        LatentHead::Gaussian => "masked-vae",
+    }
+}
+
+/// Decoder-type label persisted for a masked head. The NB ETM decoder is
+/// identical across the two deterministic simplex heads; only the Gaussian VAE
+/// gets a distinct label.
+pub fn masked_decoder_type(head: LatentHead) -> &'static str {
+    match head {
+        LatentHead::Gaussian => "nb_masked_vae",
+        LatentHead::Softmax | LatentHead::StickBreaking => "nb_masked",
+    }
+}
 
 /// Metadata needed to reconstruct a trained topic model for inference.
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
## What

Adds a third latent head to the masked-imputation topic model (alongside softmax and Gaussian): a **deterministic stick-breaking simplex**, exposed as `senna masked-sbp` (alias `sbp`, "stick-breaking process"). Also adds an opt-in **held-out masked-imputation evaluation** (`--eval-mask-fraction` / `--eval-seed`).

Because the masked objective is off the ELBO, the latent "type" is just a choice of output-layer map — no reparameterization/KL machinery. Stick-breaking becomes a log-space `logits → log θ` transform (via `log σ(η) − log σ(−η) = η`, it reduces to `η + inclusive-cumsum(log σ(−η))`) that drops in for `log_softmax`. It **breaks topic exchangeability**: early sticks carry more mass a priori, giving an intrinsic ordering and a self-pruning tail — a soft, differentiable auto-K.

## Evaluation — what we can and can't claim

Tested on 10k BMMNC (8,313 cells, K=12, 300 epochs). **Training here is non-deterministic** (Kaiming init, unseeded per-minibatch masking, HNSW), and the head-to-head differences turn out to be **within run-to-run variance**: two runs of the identical config produced opposite train-fit and effective-topic orderings between sbp and softmax.

On held-out masked imputation (hide 30% of each cell's genes, impute from the rest — the metric that isn't optimized), one run each:

| head (K=12, 300ep) | held-out llik/gene ↑ |
|---|---|
| softmax (anchor on) | −4.70 |
| masked-sbp (anchor off) | −4.82 |
| softmax (anchor off) | −4.83 |

All three are within ~0.13 nats. **There is no demonstrated held-out advantage for stick-breaking** — sbp ≈ softmax-off, and softmax+anchor is marginally best. So this PR adds sbp as a sound, correctly-implemented *option*, not a claimed improvement over softmax. Separating a real effect from the training variance would require a multi-seed study (out of scope here).

The held-out eval was added precisely to check this, and it did its job — an earlier single-run training-likelihood gap did not survive contact with a held-out metric.

## Changes

**candle-util**
- `stick_breaking_log_simplex` (+ unit tests: hand-computed reference, simplex normalization, K=1 degenerate) and `IndexedEmbeddingEncoder::forward_indexed_masked_stick`.
- The three masked forwards share a `masked_hidden`/`masked_logits` trunk with a single `MASKED_LOGIT_CLAMP`.
- `MaskedTrainOpts.latent_gaussian: bool` → field-less `LatentHead { Softmax, StickBreaking, Gaussian }` tag, with `kl_weight` as a sibling field (no inference-time placeholder).
- `masked_encode` + `MaskedEncoderInput`: single head→forward dispatch shared by the trainer and encoder-only inference (encoder stays head-agnostic).

**senna**
- `senna masked-sbp` subcommand, `MODEL_TYPE_MASKED_SBP`, single head↔model_type↔label bijection in `model_metadata`.
- `--eval-mask-fraction` / `--eval-seed`: post-training held-out imputation eval (`evaluate_holdout_imputation`), logs mean llik per held-out gene.
- **Fix:** the shared `fit_masked_model` hardcoded `MODEL_TYPE_INDEXED_MASKED` for the warm-start check, breaking `--init-from` for sbp-from-sbp (and pre-existing vae-from-vae); it now derives the expected type from the head.

## Reviewer notes

- Behavior-preserving refactors verified end-to-end: build + `fmt` + `clippy -D warnings` clean; unit tests pass; a train→predict round-trip yields **bit-identical** fit-time and predict latents on the same data.
- pinto's `MaskedTrainOpts { ..default() }` is unaffected (defaults to `Softmax`).
- Follow-up worth doing (not here): add a `--seed` to the masked trainer for reproducible runs, which a proper multi-seed comparison would need.
- Versions: candle-util 0.2.7 → 0.2.8, senna 0.7.0 → 0.7.1.