### PR TITLE
feat(geu): phase-2 progress bars; clear clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,7 +2613,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graph-embedding-util"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "auxiliary-data",

--- a/graph-embedding-util/Cargo.toml
+++ b/graph-embedding-util/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.2.30"
+version = "0.2.31"
 
 [lib]
 name = "graph_embedding_util"

--- a/graph-embedding-util/src/ash.rs
+++ b/graph-embedding-util/src/ash.rs
@@ -127,13 +127,13 @@ pub fn ash_normal(betahat: &[f64], se_init: f64, opts: &AshOpts) -> AshResult {
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let quantile = |p: f64| sorted[((p * n as f64) as usize).min(n - 1)];
     let mut centre = vec![0.0f64; m];
-    for j in 1..m {
+    for (j, c) in centre.iter_mut().enumerate().skip(1) {
         let p = if k == 1 {
             0.5
         } else {
             0.05 + 0.90 * (j - 1) as f64 / (k as f64 - 1.0)
         };
-        centre[j] = quantile(p);
+        *c = quantile(p);
     }
     let mut z = vec![0usize; n];
     let mut cnt = vec![0.0f64; m];
@@ -143,8 +143,8 @@ pub fn ash_normal(betahat: &[f64], se_init: f64, opts: &AshOpts) -> AshResult {
         let xi = betahat[i];
         let mut best = 0usize;
         let mut bd = (xi - centre[0]).abs();
-        for j in 1..m {
-            let d = (xi - centre[j]).abs();
+        for (j, &c) in centre.iter().enumerate().skip(1) {
+            let d = (xi - c).abs();
             if d < bd {
                 bd = d;
                 best = j;
@@ -204,9 +204,9 @@ pub fn ash_normal(betahat: &[f64], se_init: f64, opts: &AshOpts) -> AshResult {
             // Softmax (shared by the lfdr accumulation and the assignment draw).
             let mx = logw.iter().copied().fold(f64::NEG_INFINITY, f64::max);
             let mut sum = 0.0f64;
-            for j in 0..m {
-                logw[j] = (logw[j] - mx).exp();
-                sum += logw[j];
+            for w in &mut logw {
+                *w = (*w - mx).exp();
+                sum += *w;
             }
             let inv = 1.0 / sum.max(1e-300);
             if collect {
@@ -215,8 +215,8 @@ pub fn ash_normal(betahat: &[f64], se_init: f64, opts: &AshOpts) -> AshResult {
             // Draw z_i.
             let mut u = rng.random::<f64>() * sum;
             let mut zi = m - 1;
-            for j in 0..m {
-                u -= logw[j];
+            for (j, &w) in logw.iter().enumerate() {
+                u -= w;
                 if u <= 0.0 {
                     zi = j;
                     break;

--- a/graph-embedding-util/src/cell_projection.rs
+++ b/graph-embedding-util/src/cell_projection.rs
@@ -256,7 +256,7 @@ pub fn velocity_operator(
     let d = DMatrix::<f64>::from_fn(n_genes, h, |i, j| f64::from(delta_g[i * h + j]));
     let mut gram = bs.tr_mul(&bs); // Bₛᵀ Bₛ  [h×h]
     let rhs = bs.tr_mul(&d); //       Bₛᵀ D   [h×h]
-    // Ridge scaled to the mean Gram diagonal keeps `lambda` dimensionless and the solve PD.
+                             // Ridge scaled to the mean Gram diagonal keeps `lambda` dimensionless and the solve PD.
     let scale = (gram.diagonal().sum() / h as f64).max(1e-12);
     for k in 0..h {
         gram[(k, k)] += lambda * scale;
@@ -441,7 +441,10 @@ mod tests {
             .zip(&m)
             .map(|(a, b)| (a - b).abs())
             .fold(0f32, f32::max);
-        assert!(err < 1e-2, "operator did not recover the planted map (max err={err:.4})");
+        assert!(
+            err < 1e-2,
+            "operator did not recover the planted map (max err={err:.4})"
+        );
     }
 
     #[test]

--- a/graph-embedding-util/src/fit/feature_projection.rs
+++ b/graph-embedding-util/src/fit/feature_projection.rs
@@ -636,7 +636,9 @@ pub(crate) fn select_features_by_lrt(
             live.iter().filter(|&&l| l).count(),
             null_fdr,
             (0..n_genes).filter(|&i| n_detected[i] == 0).count(),
-            (0..n_genes).filter(|&i| n_detected[i] > 0 && lrt[i] < 0.0).count(),
+            (0..n_genes)
+                .filter(|&i| n_detected[i] > 0 && lrt[i] < 0.0)
+                .count(),
         );
     } else {
         live.fill(true);

--- a/graph-embedding-util/src/fit/lineage.rs
+++ b/graph-embedding-util/src/fit/lineage.rs
@@ -230,7 +230,11 @@ fn build_theta_dag_level(
     vel: &PbLineageLevel,
 ) -> PbLineageLevel {
     if n == 0 {
-        return PbLineageLevel { n_pb: 0, edges: vec![], velocity: vec![] };
+        return PbLineageLevel {
+            n_pb: 0,
+            edges: vec![],
+            velocity: vec![],
+        };
     }
     let k = knn.min(n.saturating_sub(1));
     // Symmetric θ-KNN adjacency, θ-distance edge weights (the manifold metric).
@@ -269,7 +273,11 @@ fn build_theta_dag_level(
             }
         }
     }
-    PbLineageLevel { n_pb: n, edges, velocity }
+    PbLineageLevel {
+        n_pb: n,
+        edges,
+        velocity,
+    }
 }
 
 /// Net velocity source of a directed level: the node with max `(out − in)` degree
@@ -324,7 +332,11 @@ fn theta_pseudotime(adj: &[Vec<(usize, f32)>], root: usize, n: usize) -> Vec<f32
             }
         }
     }
-    let max_finite = dist.iter().copied().filter(|x| x.is_finite()).fold(0.0f32, f32::max);
+    let max_finite = dist
+        .iter()
+        .copied()
+        .filter(|x| x.is_finite())
+        .fold(0.0f32, f32::max);
     for d in dist.iter_mut() {
         if !d.is_finite() {
             *d = max_finite + 1.0;

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -28,7 +28,7 @@ use crate::loss::{
 use crate::model::{FactoredInit, JointEmbedModel, ModelArgs, ModelInit, ShareFeaturesArgs};
 use crate::training::{
     train_composite, AxisSampler, CompositeAxis, CompositeMode, CompositeTrainContext, PbDagParams,
-    PbDagTerm, PbSemTerm,
+    PbDagTerm, PbDagTermSpec, PbSemTerm,
 };
 use candle_util::candle_nn::{AdamW, Optimizer, ParamsAdamW, VarBuilder, VarMap};
 use data_beans_alg::collapse_data::{collapse_columns_multilevel_with_hierarchy, MultilevelParams};
@@ -592,7 +592,10 @@ pub fn fit(unified: &mut UnifiedData, mut config: FitConfig) -> anyhow::Result<F
                     // θ-pseudotime DAG per level (τ-forward θ-KNN + gradient ĝ): supplies the
                     // unified `W`'s θ-topology (weighted L1) and the δ-sparse-fallback drift.
                     let theta_dag = lineage::build_theta_dag(
-                        &warmup_vel, &knn_init, h, lineage::DEFAULT_LINEAGE_KNN,
+                        &warmup_vel,
+                        &knn_init,
+                        h,
+                        lineage::DEFAULT_LINEAGE_KNN,
                     );
                     // learned-DAG: one UNIFIED `PbDagTerm` per pb level — a single `W`
                     // explaining BOTH structures (θ-weighted-L1 topology + δ/θ-gated drift).
@@ -604,16 +607,16 @@ pub fn fit(unified: &mut UnifiedData, mut config: FitConfig) -> anyhow::Result<F
                     }
                     for (i, lvl) in warmup_vel.iter().enumerate() {
                         let w0 = knn_init[i].to_dense();
-                        dag_terms.push(PbDagTerm::new(
-                            lvl,
-                            &theta_dag[i],
+                        dag_terms.push(PbDagTerm::new(PbDagTermSpec {
+                            vel: lvl,
+                            theta_dag: &theta_dag[i],
                             h,
-                            &PbDagParams::default(),
-                            &format!("dag_l{i}_w"),
-                            &varmap,
-                            &config.device,
-                            Some(&w0),
-                        )?);
+                            params: PbDagParams::default(),
+                            var_name: &format!("dag_l{i}_w"),
+                            varmap: &varmap,
+                            dev: &config.device,
+                            w_init: Some(&w0),
+                        })?);
                     }
                     let n_dag = dag_terms.iter().filter(|t| t.is_some()).count();
                     info!(
@@ -680,7 +683,12 @@ pub fn fit(unified: &mut UnifiedData, mut config: FitConfig) -> anyhow::Result<F
                     );
                     // Second lineage term: the θ-pseudotime DAG (see the learned branch).
                     let theta_terms = build_theta_sem_terms(
-                        &warmup_vel, &levels, h, use_cell_axis, num_levels, &config.device,
+                        &warmup_vel,
+                        &levels,
+                        h,
+                        use_cell_axis,
+                        num_levels,
+                        &config.device,
                     )?;
                     let mut opt2 = AdamW::new(varmap.all_vars(), adamw_params())?;
                     refine_loss = train_composite(

--- a/graph-embedding-util/src/fit/projection.rs
+++ b/graph-embedding-util/src/fit/projection.rs
@@ -145,8 +145,10 @@ pub(crate) fn project_cells_phase2(
     batch_divisor: Option<CellBatchDivisor>,
     unspliced_rows: Option<&[bool]>,
 ) -> anyhow::Result<(Vec<f32>, Option<Vec<f32>>)> {
+    use crate::progress::new_progress_bar;
     use anyhow::Context;
     use candle_util::candle_core::Tensor;
+    use indicatif::ParallelProgressIterator;
     use rayon::prelude::*;
 
     let h = model.embedding_dim;
@@ -165,8 +167,13 @@ pub(crate) fn project_cells_phase2(
         "Phase 2 per-cell solve over {n_cells} cells ({} rayon threads) ...",
         rayon::current_num_threads()
     );
+    // Bar spans the *active* cells actually walked (the samplers' union), which
+    // can be fewer than `n_cells` when some cells carry no edges.
+    let solve_bar = new_progress_bar(cells.len() as u64);
+    solve_bar.set_message("phase-2 per-cell Poisson MAP");
     let solved: Vec<SolvedCell> = cells
         .par_iter()
+        .progress_with(solve_bar.clone())
         .map(|&(cell, feats, counts)| {
             // Batch-divide the counts (μ_residual fold-factor) when correction is
             // on, then project. The fitted intercept `b_c` absorbs library size
@@ -205,6 +212,7 @@ pub(crate) fn project_cells_phase2(
             }
         })
         .collect();
+    solve_bar.finish_and_clear();
 
     let split = unspliced_rows.is_some();
     let mut velocity_flat = split.then(|| vec![0f32; n_cells * h]);
@@ -318,7 +326,15 @@ pub(crate) fn project_pbs_phase2(
     unspliced_rows: &[bool],
     lambda: f64,
 ) -> anyhow::Result<Vec<PbLevelVelocity>> {
+    use crate::progress::new_progress_bar;
+    use indicatif::ParallelProgressIterator;
     use rayon::prelude::*;
+
+    // One bar across every level's nodes, so the sequential level loop reads as a
+    // single span of work rather than a bar that restarts per level.
+    let solve_bar =
+        new_progress_bar(pb_blobs.iter().map(UnifiedData::n_cells).sum::<usize>() as u64);
+    solve_bar.set_message("phase-2 per-pseudobulk Poisson MAP");
 
     let mut out = Vec::with_capacity(pb_blobs.len());
     for pb in pb_blobs {
@@ -330,6 +346,7 @@ pub(crate) fn project_pbs_phase2(
         }
         let solved: Vec<(Vec<f32>, Vec<f32>)> = per_pb
             .par_iter()
+            .progress_with(solve_bar.clone())
             .map(|edges| {
                 let (theta, _n, _b, delta) =
                     solve_node_splice(edges, unspliced_rows, frozen_e, frozen_b, h, lambda);
@@ -347,6 +364,7 @@ pub(crate) fn project_pbs_phase2(
         }
         out.push(PbLevelVelocity { n_pb, theta, delta });
     }
+    solve_bar.finish_and_clear();
     Ok(out)
 }
 

--- a/graph-embedding-util/src/lib.rs
+++ b/graph-embedding-util/src/lib.rs
@@ -49,9 +49,9 @@ pub use eval::{
 };
 pub use feature_qc::{hvg_feature_qc, FeatureQcConfig, FeatureQcResult};
 pub use fit::{
-    fit, load_feature_network, CalibrationDiag, CalibrationKind, CellLineage,
-    FeatFactorSpec, FeatureNetworkArgs, FeatureProjection, FeatureProjectionConfig, FitConfig,
-    FitOutput, LineageQc, PbLevelVelocity, DEFAULT_PROJECTION_CALIB_RIDGE, DEFAULT_PROJECTION_RIDGE,
+    fit, load_feature_network, CalibrationDiag, CalibrationKind, CellLineage, FeatFactorSpec,
+    FeatureNetworkArgs, FeatureProjection, FeatureProjectionConfig, FitConfig, FitOutput,
+    LineageQc, PbLevelVelocity, DEFAULT_PROJECTION_CALIB_RIDGE, DEFAULT_PROJECTION_RIDGE,
 };
 pub use model::JointEmbedModel;
 pub use postprocess::{cell_clusters, feature_coembedding};

--- a/graph-embedding-util/src/loss/feat.rs
+++ b/graph-embedding-util/src/loss/feat.rs
@@ -831,7 +831,9 @@ pub fn nce_loss(
     let e_cell_pos = e_cell_u.index_select(&cell_idx_t, 0)?;
     let b_cell_pos = b_cell_u.index_select(&cell_idx_t, 0)?;
 
-    nce_loss_with_cell_side(model, batch, e_cell_pos, b_cell_pos, smoother, objective, dev)
+    nce_loss_with_cell_side(
+        model, batch, e_cell_pos, b_cell_pos, smoother, objective, dev,
+    )
 }
 
 /// Fast path for the identity-coarsening case (every "pb-sample" is
@@ -855,7 +857,9 @@ pub fn nce_loss_identity(
     let cell_idx_t = Tensor::from_slice(&batch.coarse_cells, b, dev)?;
     let e_cell_pos = model.e_cell.index_select(&cell_idx_t, 0)?;
     let b_cell_pos = model.b_cell.index_select(&cell_idx_t, 0)?;
-    nce_loss_with_cell_side(model, batch, e_cell_pos, b_cell_pos, smoother, objective, dev)
+    nce_loss_with_cell_side(
+        model, batch, e_cell_pos, b_cell_pos, smoother, objective, dev,
+    )
 }
 
 /// Shared tail of [`nce_loss`] / [`nce_loss_identity`]: feature-side

--- a/graph-embedding-util/src/loss/mod.rs
+++ b/graph-embedding-util/src/loss/mod.rs
@@ -104,7 +104,7 @@ pub fn softmax_nce(pos: &Tensor, negs: &[Tensor]) -> Result<Tensor> {
     cols.push(pos.unsqueeze(1)?);
     cols.extend(negs.iter().cloned());
     let logits = Tensor::cat(&cols, 1)?; // [B, 1 + ΣK]
-    // Numerically-stable logsumexp over the candidates (subtract the row max).
+                                         // Numerically-stable logsumexp over the candidates (subtract the row max).
     let m = logits.max_keepdim(1)?; // [B, 1]
     let lse = ((logits.broadcast_sub(&m)?).exp()?.sum_keepdim(1)?.log()? + m)?; // [B, 1]
     lse.squeeze(1)?.sub(pos)

--- a/graph-embedding-util/src/training.rs
+++ b/graph-embedding-util/src/training.rs
@@ -337,23 +337,47 @@ pub struct PbDagTerm {
     p: usize,
 }
 
+/// Inputs to [`PbDagTerm::new`] for one pb level: the warm-up structures the term
+/// is built from (`vel`, `theta_dag`), the hyperparameters, and where to register
+/// the learnable `W` (`var_name` in `varmap`, on `dev`).
+pub struct PbDagTermSpec<'a> {
+    /// Phase-2 warm-up readout for this level — `theta` fixes the topology and
+    /// `delta` the orientation.
+    pub vel: &'a PbLevelVelocity,
+    /// θ-pseudotime lineage DAG for the same level: unions in the forward
+    /// candidates the velocity mask misses, and supplies the fallback drift
+    /// gradient where δ is absent.
+    pub theta_dag: &'a crate::fit::lineage::PbLineageLevel,
+    /// Embedding dimension `H`.
+    pub h: usize,
+    /// Step size and the SEM / L1 / acyclicity weights.
+    pub params: PbDagParams,
+    /// Name the learnable `W` Var is registered under in `varmap`.
+    pub var_name: &'a str,
+    pub varmap: &'a VarMap,
+    pub dev: &'a Device,
+    /// Warm-start for `W` (`[p×p]` row-major); `None` zero-initializes.
+    pub w_init: Option<&'a [f32]>,
+}
+
 impl PbDagTerm {
     /// Build the learnable term for one level, registering the `W` Var under
-    /// `var_name`. Returns `None` when the level has fewer than two nodes. The
+    /// `spec.var_name`. Returns `None` when the level has fewer than two nodes. The
     /// forward-orientation mask and drift are fixed from the warm-up velocity/identity
     /// (`vel.theta` / `vel.delta`). `w_init` warm-starts `W` from a fixed structure
     /// (the velocity-oriented KNN, `[p×p]` row-major) so SGD refines from a correctly-
     /// oriented start; `None` zero-initializes (the DAGMA-clean but unstable start).
-    pub fn new(
-        vel: &PbLevelVelocity,
-        theta_dag: &crate::fit::lineage::PbLineageLevel,
-        h: usize,
-        params: &PbDagParams,
-        var_name: &str,
-        varmap: &VarMap,
-        dev: &Device,
-        w_init: Option<&[f32]>,
-    ) -> anyhow::Result<Option<Self>> {
+    pub fn new(spec: PbDagTermSpec<'_>) -> anyhow::Result<Option<Self>> {
+        let PbDagTermSpec {
+            vel,
+            theta_dag,
+            h,
+            params,
+            var_name,
+            varmap,
+            dev,
+            w_init,
+        } = spec;
         let p = vel.n_pb;
         if p < 2 {
             return Ok(None);
@@ -456,7 +480,7 @@ impl PbDagTerm {
             eye: Tensor::from_vec(eye, (p, p), dev)?,
             fwd_mask: Tensor::from_vec(fwd, (p, p), dev)?,
             dtheta: Tensor::from_vec(dtheta, (p, p), dev)?,
-            params: *params,
+            params,
             p,
         }))
     }
@@ -971,7 +995,14 @@ fn single_axis_step(
     let bip_loss = if axis.cell_axis.is_identity {
         nce_loss_identity(axis.model, batch, smoother, params.objective, dev)?
     } else {
-        nce_loss(axis.model, batch, &cc.coarse_to_fine, smoother, params.objective, dev)?
+        nce_loss(
+            axis.model,
+            batch,
+            &cc.coarse_to_fine,
+            smoother,
+            params.objective,
+            dev,
+        )?
     };
     Ok(Some(bip_loss))
 }

--- a/graph-embedding-util/src/training/tests.rs
+++ b/graph-embedding-util/src/training/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the velocity-drift SEM residual and the learnable pb-DAG term.
 
-use super::{acyclicity_series, sem_penalty, PbDagParams, PbDagTerm, PbSemTerm};
+use super::{acyclicity_series, sem_penalty, PbDagParams, PbDagTerm, PbDagTermSpec, PbSemTerm};
 use crate::fit::lineage::PbLineageLevel;
 use crate::fit::projection::PbLevelVelocity;
 use candle_util::candle_core::{Device, Tensor, Var};
@@ -146,16 +146,16 @@ fn dag_term_builds_and_loss_is_differentiable() {
         edges: vec![(0, 1, 1.0), (1, 2, 1.0)],
         velocity: vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
     };
-    let term = PbDagTerm::new(
-        &vel,
-        &theta_dag,
+    let term = PbDagTerm::new(PbDagTermSpec {
+        vel: &vel,
+        theta_dag: &theta_dag,
         h,
-        &PbDagParams::default(),
-        "dag_test_w",
-        &vm,
-        &dev,
-        None,
-    )
+        params: PbDagParams::default(),
+        var_name: "dag_test_w",
+        varmap: &vm,
+        dev: &dev,
+        w_init: None,
+    })
     .unwrap()
     .unwrap();
     // W starts at zero (clean DAGMA start).

--- a/graph-embedding-util/src/type_annotation/hub_call.rs
+++ b/graph-embedding-util/src/type_annotation/hub_call.rs
@@ -116,6 +116,10 @@ pub(super) fn zero_hub_parked(
         })
         .sum::<f32>()
         / n as f32;
+    // Deliberately negated, not `radius <= 0.0`: this must also catch a NaN radius
+    // (a NaN anywhere in `cell_emb` propagates here), which `<=` would let through
+    // and turn every downstream `d2 < cutoff` test into a silent false.
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     if !(radius > 0.0) {
         // Every cell is at the same point; there is no cloud, so there is no hub to call against.
         return 0;


### PR DESCRIPTION
hub_call keeps its negated NaN guard behind an allow: `radius <= 0.0` would let NaN through and silently disable every downstream cutoff test.