### PR TITLE
feat(pinto)!: default --knn-expr to 0 with --coord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,7 +4274,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinto"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "approx",

--- a/pinto/Cargo.toml
+++ b/pinto/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.6.9"
+version = "0.6.10"
 
 [[bin]]
 name = "pinto"

--- a/pinto/src/cell_activity_graph_embedding/fit.rs
+++ b/pinto/src/cell_activity_graph_embedding/fit.rs
@@ -314,6 +314,7 @@ pub fn fit_cell_activity_graph_embedding(
         batch_membership,
         batch_effects: batch_db,
         graph,
+        knn,
         spatial_graph,
         edge_source,
         cell_proj: shared_cell_proj,
@@ -481,10 +482,11 @@ pub fn fit_cell_activity_graph_embedding(
 
     let cell_proj = match hvg_weights.as_deref() {
         // HVG weighting makes this a genuinely different projection, so the
-        // shared one cannot stand in for it. Preprocessing skips taking one
-        // in this case, but `--knn-expr` needs an unweighted projection for
-        // its own graph and takes one anyway, so drop it rather than carry a
-        // second full matrix through training.
+        // shared one cannot stand in for it. Preprocessing skips taking one in
+        // this case, and with `--knn-expr` off there is nothing to drop. When
+        // it IS asked for, preprocessing takes an unweighted projection for the
+        // expression graph, and this drops it rather than carry a second full
+        // matrix through training.
         Some(w) => {
             drop(shared_cell_proj);
             data_vec.project_columns_weighted(c.proj_dim, c.block_size, batch_arg, w)?
@@ -1831,6 +1833,7 @@ pub fn fit_cell_activity_graph_embedding(
                 n_cells,
                 n_genes,
                 n_edges: n_fine_edges,
+                graph: (&knn).into(),
                 k: n_edge_clusters,
             },
             batch_db.is_some(),

--- a/pinto/src/link_community/fit.rs
+++ b/pinto/src/link_community/fit.rs
@@ -67,6 +67,7 @@ pub fn fit_srt_link_community(args: &SrtLinkCommunityArgs) -> anyhow::Result<()>
         batch_membership,
         batch_effects: _,
         graph,
+        knn,
         spatial_graph,
         edge_source,
         cell_proj,
@@ -618,6 +619,7 @@ pub fn fit_srt_link_community(args: &SrtLinkCommunityArgs) -> anyhow::Result<()>
                 n_genes,
                 n_edges: edges.len(),
                 k,
+                graph: (&knn).into(),
             },
             merge_summary,
             // `lc` runs no splice sampler, so the three `delta_*` fields stay

--- a/pinto/src/lr_activity/io.rs
+++ b/pinto/src/lr_activity/io.rs
@@ -50,7 +50,13 @@ pub fn read_link_community(file_path: &str) -> anyhow::Result<Vec<EdgeRecord>> {
         .get("community")
         .ok_or_else(|| anyhow::anyhow!("community missing in {file_path}"))?;
     // Absent on a run that predates pair-graph augmentation, and on any run
-    // that did not augment. Both mean every pair is a spatial one.
+    // that did not augment — which, with `--knn-expr` defaulting off, is the
+    // common case rather than the exception. Both mean every pair is spatial.
+    //
+    // On an expression-mode run there is no adjacency at all, and every pair
+    // still reads as spatial here. That is deliberate: the coordinates such a
+    // run carries ARE the layout its pairs are adjacent in, and treating them
+    // as expression pairs would drop all of them from the test.
     let ki = name_to_idx.get("edge_kind").copied();
 
     let mut out = Vec::new();

--- a/pinto/src/svd/fit.rs
+++ b/pinto/src/svd/fit.rs
@@ -136,6 +136,7 @@ pub fn fit_srt_delta_svd(args: &SrtDeltaSvdArgs) -> anyhow::Result<()> {
         batch_membership,
         batch_effects: batch_db,
         graph,
+        knn,
         spatial_graph,
         edge_source,
         cell_proj: _,
@@ -158,8 +159,9 @@ pub fn fit_srt_delta_svd(args: &SrtDeltaSvdArgs) -> anyhow::Result<()> {
         //
         // Note this is a request, not a contract: preprocessing still takes one
         // when `--knn-expr` needs it for the expression graph, and that one is
-        // dropped here. Combining `--knn-expr` with coordinates therefore costs
-        // two projection passes.
+        // dropped here. Asking for `--knn-expr` alongside coordinates therefore
+        // costs two projection passes — but it is off by default, so the
+        // default path pays for one.
         cell_projection: false,
         feature_kind: None,
     })?;
@@ -342,6 +344,7 @@ pub fn fit_srt_delta_svd(args: &SrtDeltaSvdArgs) -> anyhow::Result<()> {
             n_cells,
             n_genes: data_vec.num_rows(),
             n_edges: edges.len(),
+            graph: (&knn).into(),
             k: n_clusters,
         });
         let meta_path = std::path::PathBuf::from(format!("{}.pinto.json", c.out));

--- a/pinto/src/util/input.rs
+++ b/pinto/src/util/input.rs
@@ -226,28 +226,47 @@ pub struct SrtInputArgs {
     #[arg(
         short = 'k',
         long,
-        default_value_t = 5,
-        help = "KNN: neighbours per cell for cell-pair graph",
-        long_help = "Neighbours per cell when building the cell-pair graph.\n\
-                     Each cell connects to its K closest neighbours.\n\
-                     Search runs over an HNSW index in Euclidean distance.\n\
+        help = "KNN: neighbours per cell for the spatial graph [default: 5]",
+        long_help = "Neighbours per cell when building the SPATIAL cell-pair graph.\n\
+                     Each cell connects to its K closest neighbours in coordinate\n\
+                     space. Search runs over an HNSW index in Euclidean distance.\n\
+                     Defaults to 5.\n\
                      \n\
-                     With --coord, neighbours live in coordinate space. Without it,\n\
-                     they live in expression embedding space.\n\
+                     The resulting edges are the cell pairs used downstream.\n\
+                     Typical range: 3-20.\n\
                      \n\
-                     The resulting edges are the cell pairs used downstream. Typical range:\n\
-                     3-20 spatial, 10-30 expression."
+                     This flag is about coordinates. Without --coord the graph comes\n\
+                     from expression instead, and --knn-expr sizes it. Passing -k\n\
+                     there still works, and says so, but --knn-expr is the name for\n\
+                     that job. Passing both without --coord is an error when\n\
+                     --knn-expr is positive: they would be naming the same\n\
+                     graph. --knn-expr 0 asks for no expression pairs, so it\n\
+                     leaves -k to size the graph and stays legal."
     )]
-    pub knn_spatial: usize,
+    pub knn_spatial: Option<usize>,
 
     #[arg(
         long,
-        default_value_t = 5,
-        help = "KNN: expression-similar neighbours added to the pair graph (0 = off)",
-        long_help = "Neighbours per cell in a second, non-spatial KNN graph built on\n\
-                     random-projected expression.\n\
-                     Its edges are added to the spatial ones, so the cell pairs\n\
-                     downstream are the union of both.\n\
+        help = "KNN: expression neighbours [default: 0 with --coord, else -k or 5]",
+        long_help = "Neighbours per cell in a KNN graph built on random-projected\n\
+                     expression. What this graph IS depends on --coord.\n\
+                     \n\
+                     WITH --coord it is a second graph, and its edges are added to\n\
+                     the spatial ones, so the cell pairs downstream are the union of\n\
+                     both. Defaults to 0, i.e. off: the run then pays only for the\n\
+                     spatial pairs. This is also how to reproduce a run made before\n\
+                     the union existed.\n\
+                     \n\
+                     WITHOUT --coord it is the ONLY graph — there is nothing to union\n\
+                     into — and it defaults to 5, or to -k when only that was given.\n\
+                     Typical range there is 10-30: expression neighbours agree with\n\
+                     each other less often than spatial ones, so a small k fragments\n\
+                     the graph, and components become batches in that mode.\n\
+                     Note it also sets the k of the force-directed layout, so it\n\
+                     decides pc_1/pc_2, the coordinates written to\n\
+                     coord_pairs.parquet, and what `pinto plot` draws.\n\
+                     \n\
+                     The rest of this applies to the --coord case.\n\
                      \n\
                      Expression-similar pairs are the same cell type by construction.\n\
                      They act as a reference for what a same-type pair looks like,\n\
@@ -260,22 +279,15 @@ pub struct SrtInputArgs {
                      This is not symmetric with -k: expression neighbours agree with\n\
                      each other less often, so fewer of their edges collapse together\n\
                      and the same K adds more pairs than the spatial graph holds.\n\
-                     Runtime and peak memory both rise with the resulting pair count.\n\
-                     \n\
-                     Ignored without --coord, where the graph already comes from\n\
-                     expression.\n\
-                     \n\
-                     On by default. It roughly doubles runtime and peak memory,\n\
-                     because it roughly doubles the pairs. Set it to 0 for the\n\
-                     spatial pairs alone, which is also the way to reproduce a run\n\
-                     made before this existed.\n\
+                     Runtime and peak memory both rise with the resulting pair\n\
+                     count, and at the same K that count more than doubles.\n\
                      \n\
                      lc models every pair. cage's chain training only samples pairs\n\
                      that share a super-cell at each chain level and a batch, so\n\
                      distant expression pairs reach its pair outputs and propensity\n\
                      but largely not its chain loss; the dropped counts are logged."
     )]
-    pub knn_expr: usize,
+    pub knn_expr: Option<usize>,
 
     #[arg(
         long,
@@ -283,6 +295,12 @@ pub struct SrtInputArgs {
         default_value_t = KnnExprScope::Global,
         help = "Whether expression neighbours may cross disconnected tissue",
         long_help = "Where --knn-expr searches for expression neighbours.\n\
+                     \n\
+                     Only `within` has preconditions, and it needs both: --coord,\n\
+                     because it scopes by the SPATIAL graph's components, and a\n\
+                     positive --knn-expr, because it scopes a search that would\n\
+                     otherwise not run. Missing either is refused rather than\n\
+                     silently ignored.\n\
                      \n\
                      global (default): anywhere on the slide. Asking for expression\n\
                      neighbours at all means wanting a reference for what a cell type\n\
@@ -306,8 +324,10 @@ pub struct SrtInputArgs {
     #[arg(
         long,
         default_value_t = false,
-        help = "Use reciprocal (mutual) KNN matching for spatial graph",
-        long_help = "Use reciprocal (mutual) KNN matching for the spatial graph.\n\
+        help = "Use reciprocal (mutual) KNN matching for every graph",
+        long_help = "Use reciprocal (mutual) KNN matching for every KNN graph this\n\
+                     run builds — the spatial one, the expression one, and the\n\
+                     --knn-expr augmentation alike.\n\
                      The default is union matching.\n\
                      There an edge (i,j) exists if i is in j's KNN list, or j is in i's.\n\
                      Reciprocal matching requires both.\n\
@@ -320,10 +340,210 @@ pub struct SrtInputArgs {
     pub qc: data_beans::qc_lib::QcArgs,
 }
 
+/// Neighbours per cell when neither `-k` nor `--knn-expr` says otherwise.
+///
+/// Spelled out by hand in the `-k` and `--knn-expr` help text: dropping
+/// `default_value_t` means clap no longer renders it, so those strings are the
+/// only place a user learns this and the only place it can drift.
+const DEFAULT_KNN: usize = 5;
+
+/// The graph spec a run's flags resolve to.
+///
+/// Produced only by [`SrtInputArgs::resolve_knn`], which validates and logs on
+/// the way, so holding one is evidence those ran. Carried on the preprocessing
+/// output rather than re-derived, so the manifest cannot drift from the graph
+/// that was actually built.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedKnn {
+    /// Neighbours per cell in the base graph: spatial under `--coord`,
+    /// expression without it.
+    pub base: usize,
+    /// Neighbours per cell in the expression graph unioned in; `0` for none.
+    pub augment: usize,
+    /// Where the expression search looked. Meaningful only when `augment > 0`.
+    pub scope: KnnExprScope,
+    /// Mutual-KNN instead of union-KNN, for every graph this run builds.
+    pub reciprocal: bool,
+}
+
 impl SrtInputArgs {
     /// Whether spatial coordinate files were provided.
     pub fn has_coordinates(&self) -> bool {
         !self.coord_files.is_empty()
+    }
+
+    //////////////////////////////////////////////////////
+    // -k and --knn-expr, resolved into the two k's the  //
+    // pipeline uses. Two flags, two graphs, and which   //
+    // flag sizes which depends on --coord.              //
+    //////////////////////////////////////////////////////
+
+    /// `--knn-expr` as a REQUEST for expression pairs.
+    ///
+    /// `Some(0)` is not a request for a 0-sized graph, it is the absence of a
+    /// request, so it collapses to `None` here. Every question of the form
+    /// "did the user ask for expression pairs?" goes through this, so the
+    /// predicate has one spelling and one meaning.
+    fn requested_expr_knn(&self) -> Option<usize> {
+        self.knn_expr.filter(|&k| k > 0)
+    }
+
+    /// Neighbours per cell for the BASE graph — the spatial one under
+    /// `--coord`, the expression one without it.
+    ///
+    /// `--knn-expr` wins in expression mode because that is the graph it names
+    /// there. `-k` is still honoured when it is the only one given, so an
+    /// existing command line keeps building the graph it always built: k moves
+    /// the force-directed layout, so re-sizing it silently would move every
+    /// plot. Setting both is refused rather than resolved.
+    pub fn base_knn(&self) -> usize {
+        if self.has_coordinates() {
+            self.knn_spatial.unwrap_or(DEFAULT_KNN)
+        } else {
+            self.requested_expr_knn()
+                .or(self.knn_spatial)
+                .unwrap_or(DEFAULT_KNN)
+        }
+    }
+
+    /// Neighbours per cell for the expression graph unioned into the base one.
+    /// `0` means no augmentation.
+    ///
+    /// Always `0` without coordinates. That is not a shortcut: there the base
+    /// graph already IS the expression graph, so a union would be a self-union.
+    /// Every caller that asks whether augmentation runs must read THIS, never
+    /// `knn_expr` directly, or the two questions drift apart.
+    pub fn augment_knn(&self) -> usize {
+        if self.has_coordinates() {
+            self.knn_expr.unwrap_or(0)
+        } else {
+            0
+        }
+    }
+
+    /// The flag that supplied [`Self::base_knn`], for error messages.
+    ///
+    /// One source of truth for the precedence. Re-deriving it at each use site
+    /// lets the two drift: flip the precedence in `base_knn` and the messages
+    /// keep naming the old flag with nothing failing.
+    fn base_knn_flag(&self) -> &'static str {
+        // Nothing typed points at `--knn-expr` too: in expression mode that is
+        // the flag naming this graph, not the one the help calls spatial.
+        if self.has_coordinates()
+            || (self.requested_expr_knn().is_none() && self.knn_spatial.is_some())
+        {
+            "-k"
+        } else {
+            "--knn-expr"
+        }
+    }
+
+    /// Reject the flag combinations that need no data to judge.
+    ///
+    /// Split from the bounds check so a typo fails before the run reads a
+    /// single file: these depend only on argv, while the `< n_cells` bounds
+    /// cannot be judged until QC has settled the cell count.
+    pub fn validate_knn_flags(&self) -> anyhow::Result<()> {
+        if !self.has_coordinates() {
+            // The two flags name the same graph here, and the choice is not
+            // cosmetic: component count is k-dependent, components become
+            // batches, and batches decide whether batch-effect estimation runs
+            // at all. Too load-bearing to settle with a warning.
+            anyhow::ensure!(
+                !(self.knn_spatial.is_some() && self.requested_expr_knn().is_some()),
+                "-k and --knn-expr both set without --coord: they name the same \
+                 graph there. Pass only --knn-expr."
+            );
+            // Same condition as the guard below, kept separate for its message
+            // and ordered first. That ordering is load-bearing: the other
+            // message's remedy (pass --knn-expr N) is wrong here, where
+            // --knn-expr sizes the base graph and still runs no scoped search.
+            anyhow::ensure!(
+                self.knn_expr_scope == KnnExprScope::Global,
+                "--knn-expr-scope needs --coord: it scopes the search by the \
+                 spatial graph's components, and there is no spatial graph here."
+            );
+        }
+        anyhow::ensure!(self.base_knn() > 0, "{} must be > 0", self.base_knn_flag());
+        Ok(())
+    }
+
+    /// Resolve both k's, checking the data-dependent bounds and logging any
+    /// flag whose role this run changed.
+    ///
+    /// The one way to obtain a k. Validation, the migration notice and the
+    /// resolution are one call because they are one decision: a caller that
+    /// could take the k's without them would silently skip both.
+    ///
+    /// The upper bound is a sanity check, not an OOM guard: the builder clamps
+    /// to `n_cells - 1`, and that graph is already complete, so a `k` large
+    /// enough to hurt is accepted. It catches the transposed-argument class of
+    /// mistake, where `k` exceeds the cell count outright.
+    pub fn resolve_knn(&self, n_cells: usize) -> anyhow::Result<ResolvedKnn> {
+        self.validate_knn_flags()?;
+
+        let base = self.base_knn();
+        anyhow::ensure!(
+            base < n_cells,
+            "{} ({base}) must be < number of cells ({n_cells})",
+            self.base_knn_flag()
+        );
+
+        // 0 is how augmentation is turned off, so only the upper bound applies.
+        let augment = self.augment_knn();
+        anyhow::ensure!(
+            augment < n_cells,
+            "--knn-expr ({augment}) must be < number of cells ({n_cells})"
+        );
+
+        // Last, because it is the least fatal: an unusable k makes the run
+        // impossible, while a scope with nothing to scope only makes a flag
+        // inert. Reporting the scope first would send the user round twice.
+        // Reachable only WITH coordinates — see `validate_knn_flags`.
+        anyhow::ensure!(
+            self.knn_expr_scope == KnnExprScope::Global || augment > 0,
+            "--knn-expr-scope scopes the expression search, and --knn-expr is 0 \
+             so no expression search runs. Pass --knn-expr N to ask for one."
+        );
+
+        self.warn_knn_flag_use(base);
+        Ok(ResolvedKnn {
+            base,
+            augment,
+            scope: self.knn_expr_scope,
+            reciprocal: self.reciprocal,
+        })
+    }
+
+    /// Say so when this run gives a flag a role it did not have before.
+    ///
+    /// Private and called from [`Self::resolve_knn`] only: it must fire once
+    /// per run, and a separately-callable version would be both forgettable
+    /// and, at the three manifest sites, repeatable.
+    fn warn_knn_flag_use(&self, k: usize) {
+        if self.has_coordinates() {
+            return;
+        }
+        if self.requested_expr_knn().is_some() {
+            // `--knn-expr` used to be inert without --coord, so a command line
+            // carrying it built a DEFAULT-sized graph. It sizes the graph now,
+            // and k moves the component count, the batch partition and the
+            // layout. `warn`, not `info`, because the default log filter is
+            // `warn` and this genuinely changed.
+            log::warn!(
+                "--knn-expr sizes the expression graph on this run (k={k}); \
+                 before it was ignored without --coord and -k sized it."
+            );
+        } else if self.knn_spatial.is_some() {
+            // Unchanged behaviour: -k sized this graph before and still does.
+            // An info, not a warning — CI that greps for WARN should not start
+            // failing on runs that did not change.
+            log::info!(
+                "-k names the spatial graph, and this run has no --coord. \
+                 Building the expression graph with k={k}; --knn-expr {k} is \
+                 the name for that job (pass it INSTEAD of -k)."
+            );
+        }
     }
 
     /// Comma-joined string of coordinate file paths, or `None` when the

--- a/pinto/src/util/metadata.rs
+++ b/pinto/src/util/metadata.rs
@@ -31,6 +31,11 @@ pub struct PintoMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n_communities: Option<usize>,
 
+    /// Which graph the pairs came from. Absent on manifests written before
+    /// this was recorded, and on runs that build no graph.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graph: Option<GraphParams>,
+
     /// Present only when the input's feature axis carried
     /// `{gene}/count/{spliced,unspliced}` rows. Absent means "no channels",
     /// which is not the same as "no genes identified" — see
@@ -42,6 +47,78 @@ pub struct PintoMetadata {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub levels: Option<Vec<LevelInfo>>,
+}
+
+/// The k's that decided the cell-pair graph.
+///
+/// `n_edges` says how many pairs a run produced; this says why. Without it the
+/// only way to tell a spatial-only run from an augmented one is to open
+/// `coord_pairs.parquet` and notice that `edge_kind` is missing — the column is
+/// written only when a union happened. Recording the inputs makes a run
+/// reproducible from its manifest alone.
+///
+/// To replay: `knn_base` is `-k` when the run had `coord_file`, and
+/// `--knn-expr` when it did not — those are the same graph either way, since
+/// without coordinates the expression graph IS the base graph. `knn_expr` is
+/// the augmentation, and is meaningful only alongside a `coord_file`.
+///
+/// Every field is `#[serde(default)]`: this block gains fields over time, and
+/// a manifest written by an older build must stay readable rather than
+/// failing the WHOLE file — `PintoMetadata::backfill_output` swallows a read
+/// error at debug level, so a hard failure here is silent.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct GraphParams {
+    /// Neighbours per cell in the base graph: spatial under `--coord`,
+    /// expression without it.
+    ///
+    /// `0` only ever means "an older writer omitted this" — no run builds a
+    /// 0-NN graph, and `resolve_knn` refuses one.
+    pub knn_base: usize,
+    /// Neighbours per cell in the expression graph unioned in. `0` means none,
+    /// which is the default under `--coord` and always the case without it.
+    /// So `knn_expr > 0` is the test for "this run was augmented" — there is
+    /// no second field saying so, because a stored copy could contradict this
+    /// one under `#[serde(default)]`.
+    ///
+    /// This is what was ASKED FOR, not what the union yielded: a scoped search
+    /// whose every component is smaller than k contributes no edges and still
+    /// reports a positive k here. Read `n_edges` against an unaugmented
+    /// control to learn what the union actually added.
+    pub knn_expr: usize,
+    /// `--knn-expr-scope`, as its CLI spelling. Absent when no expression
+    /// search ran — recording it there would assert a scoping decision the run
+    /// never made.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub knn_expr_scope: Option<String>,
+    /// `--reciprocal`: mutual-KNN instead of union-KNN. Applies to every graph
+    /// the run builds and changes the edge set, so two runs differing only in
+    /// this would otherwise emit identical blocks with different `n_edges`.
+    pub reciprocal: bool,
+}
+
+impl From<&crate::util::input::ResolvedKnn> for GraphParams {
+    /// Built from the RESOLVED spec, not the raw flags, so the manifest records
+    /// what the run did rather than what was typed. Those differ on every
+    /// defaulted run, which is most of them.
+    fn from(knn: &crate::util::input::ResolvedKnn) -> Self {
+        use clap::ValueEnum;
+        Self {
+            knn_base: knn.base,
+            knn_expr: knn.augment,
+            // Only recorded when a search actually ran. Writing it
+            // unconditionally would assert a scoping decision the run never
+            // made, which is the whole failure this struct exists to prevent.
+            knn_expr_scope: (knn.augment > 0).then(|| {
+                knn.scope
+                    .to_possible_value()
+                    .expect("KnnExprScope has no skipped variants")
+                    .get_name()
+                    .to_string()
+            }),
+            reciprocal: knn.reciprocal,
+        }
+    }
 }
 
 /// The base track for `delta` — see [`SpliceTrackInfo::delta_base`].
@@ -331,6 +408,10 @@ pub struct RunInputs<'a> {
     pub n_edges: usize,
     /// Number of communities (lc) / clusters (dsvd) — same K dim either way.
     pub k: usize,
+    /// Which graph produced `n_edges`. Not optional: every builder taking
+    /// `RunInputs` builds a graph. `pinto prop` re-cuts an existing pair table
+    /// and has none, but it does not go through here.
+    pub graph: GraphParams,
 }
 
 /// Helper to create metadata for `pinto lc` runs.
@@ -377,6 +458,7 @@ pub fn create_lc_metadata(
         n_genes: inputs.n_genes,
         n_edges: Some(inputs.n_edges),
         n_communities: Some(inputs.k),
+        graph: Some(inputs.graph.clone()),
         splice,
         outputs: OutputFiles {
             coord_pairs: Some(format!("{prefix}.coord_pairs.parquet")),
@@ -417,6 +499,7 @@ pub fn create_dsvd_metadata(inputs: &RunInputs<'_>) -> PintoMetadata {
         n_genes: inputs.n_genes,
         n_edges: Some(inputs.n_edges),
         n_communities: Some(inputs.k),
+        graph: Some(inputs.graph.clone()),
         splice: None,
         outputs: OutputFiles {
             coord_pairs: Some(format!("{prefix}.coord_pairs.parquet")),
@@ -460,6 +543,7 @@ pub fn create_cage_metadata(
         n_genes: inputs.n_genes,
         n_edges: Some(inputs.n_edges),
         n_communities: Some(inputs.k),
+        graph: Some(inputs.graph.clone()),
         splice,
         outputs: OutputFiles {
             coord_pairs: Some(format!("{prefix}.coord_pairs.parquet")),
@@ -511,6 +595,7 @@ pub fn create_prop_metadata(
         n_cells: n_vertices,
         n_genes: 0,
         n_edges: None,
+        graph: None,
         n_communities: Some(n_clusters),
         splice: None,
         outputs: OutputFiles {

--- a/pinto/src/util/srt_pipeline.rs
+++ b/pinto/src/util/srt_pipeline.rs
@@ -19,7 +19,7 @@ use crate::util::common::*;
 use crate::util::gene_axis::GeneAxis;
 use crate::util::input::{
     auto_batch_from_components, read_data_with_coordinates, read_data_without_coordinates,
-    KnnExprScope, SRTData, SrtInputArgs,
+    KnnExprScope, ResolvedKnn, SRTData, SrtInputArgs,
 };
 use crate::util::knn_graph::KnnGraph;
 use auxiliary_data::feature_names::FeatureNameKind;
@@ -80,8 +80,12 @@ pub struct SrtPreprocessed {
     /// when single-batch.
     pub batch_effects: Option<Mat>,
     pub graph: KnnGraph,
+    /// The k's [`Self::graph`] was actually built with. Carried rather than
+    /// re-derived from the args, so a manifest cannot describe a graph the run
+    /// did not build.
+    pub knn: ResolvedKnn,
     /// The pre-augmentation SPATIAL graph, `Some` only when `--knn-expr`
-    /// added expression edges. Prefer [`Self::topology_graph`] over reaching
+    /// added expression edges. Prefer [`topology_graph`] over reaching
     /// for this directly.
     pub spatial_graph: Option<KnnGraph>,
     /// Which graph each edge of [`Self::graph`] came from, parallel to
@@ -131,6 +135,10 @@ pub struct SrtPreprocessed {
 /// depends on `--knn-expr` and on the data; the point is that neither question
 /// is being asked about adjacency any more. Both take the spatial graph.
 ///
+/// In expression mode this hands back the expression graph, because that is
+/// the only graph there is. Nothing is lost: a run without `--coord` has no
+/// adjacency to preserve, so there is no distinction for this to draw.
+///
 /// A free function rather than a method because every caller destructures
 /// [`SrtPreprocessed`] field by field, which is deliberate: adding a field
 /// should force each call site to say what it wants.
@@ -154,6 +162,12 @@ pub fn topology_graph<'a>(
 /// correction (batch effects haven't been estimated yet at this point).
 pub fn preprocess_srt(cfg: SrtPreprocessConfig<'_>) -> anyhow::Result<SrtPreprocessed> {
     let c = cfg.common;
+
+    // Argv-only, so it runs BEFORE anything is read. A typo like a
+    // `--knn-expr-scope` without `--coord` needs no data to judge, and making
+    // the user wait through a load, a possible zarr conversion and a full QC
+    // pass to hear about it is time spent on an answer already known.
+    c.validate_knn_flags()?;
 
     info!("Loading data files...");
     let has_coords = c.has_coordinates();
@@ -223,28 +237,26 @@ pub fn preprocess_srt(cfg: SrtPreprocessConfig<'_>) -> anyhow::Result<SrtPreproc
     let n_cells = data_vec.num_columns();
 
     anyhow::ensure!(c.proj_dim > 0, "proj_dim must be > 0");
-    anyhow::ensure!(c.knn_spatial > 0, "knn_spatial must be > 0");
-    anyhow::ensure!(
-        c.knn_spatial < n_cells,
-        "knn_spatial ({}) must be < number of cells ({})",
-        c.knn_spatial,
-        n_cells
-    );
+    // Both k's resolve here, before either graph is built. The KNN builder
+    // floors k at 1 and clamps it to n_cells-1 rather than rejecting either
+    // extreme, so nothing downstream would catch a 0 or an over-large k.
+    let knn = c.resolve_knn(n_cells)?;
+    let base_knn = knn.base;
 
     let graph = if has_coords {
-        info!("Building spatial KNN graph (k={})...", c.knn_spatial);
+        info!("Building spatial KNN graph (k={})...", base_knn);
         build_spatial_graph(
             &coordinates,
             SrtCellPairsArgs {
-                knn: c.knn_spatial,
+                knn: base_knn,
                 block_size: c.block_size,
-                reciprocal: c.reciprocal,
+                reciprocal: knn.reciprocal,
             },
         )?
     } else {
         info!(
             "Building expression KNN graph (k={}, proj_dim={})...",
-            c.knn_spatial, c.proj_dim
+            base_knn, c.proj_dim
         );
         let cell_proj_pre = data_vec.project_columns_with_batch_correction(
             c.proj_dim,
@@ -254,9 +266,9 @@ pub fn preprocess_srt(cfg: SrtPreprocessConfig<'_>) -> anyhow::Result<SrtPreproc
         let (g, embedding) = build_expression_graph(
             &cell_proj_pre.proj,
             SrtCellPairsArgs {
-                knn: c.knn_spatial,
+                knn: base_knn,
                 block_size: c.block_size,
-                reciprocal: c.reciprocal,
+                reciprocal: knn.reciprocal,
             },
         )?;
         coordinates = embedding;
@@ -295,44 +307,44 @@ pub fn preprocess_srt(cfg: SrtPreprocessConfig<'_>) -> anyhow::Result<SrtPreproc
     // skipped, and every tissue core lands in one frame downstream. That
     // failure is silent, which is why the ordering here is load-bearing.
     //
+    // That argument is about the UNION, and so about spatial runs. In
+    // expression mode the base graph is itself an expression graph and
+    // auto-batch sees it by construction — there a component is not a section
+    // and was never claimed to be, which is why that path folds no fragments.
+    //
     // And the expression graph should be built on a batch-corrected
     // projection, or its neighbours match batch rather than cell type.
     let batch_arg: Option<&[Box<str>]> = batch_effects
         .is_some()
         .then_some(batch_membership.as_slice());
 
-    let cell_proj = if cfg.cell_projection || (c.knn_expr > 0 && has_coords) {
+    // `ResolvedKnn::augment` is already 0 without coordinates, so these two
+    // tests stay in step by construction rather than by both remembering to
+    // say `&& has_coords`. That agreement is what the `expect` below rests on.
+    let augment_knn = knn.augment;
+
+    let cell_proj = if cfg.cell_projection || augment_knn > 0 {
         Some(data_vec.project_columns_with_batch_correction(c.proj_dim, c.block_size, batch_arg)?)
     } else {
         None
     };
 
-    let (graph, spatial_graph, edge_source) = if c.knn_expr == 0 {
-        (graph, None, None)
-    } else if !has_coords {
-        // The base graph already IS the expression graph, so a union would be
-        // a self-union. The flag defaults on, so this fires on every
-        // expression-mode run: an info note, not a warning about user error.
-        info!(
-            "--knn-expr {} has no effect without --coord: the cell-pair graph is \
-             already built from expression",
-            c.knn_expr
-        );
+    let (graph, spatial_graph, edge_source) = if augment_knn == 0 {
         (graph, None, None)
     } else {
         info!(
             "Adding expression KNN edges (k={}, proj_dim={})...",
-            c.knn_expr, c.proj_dim
+            augment_knn, c.proj_dim
         );
         let proj = cell_proj
             .as_ref()
-            .expect("a projection is taken whenever knn_expr > 0 and coordinates exist");
+            .expect("the projection above is taken whenever augment_knn() > 0");
         let knn_args = SrtCellPairsArgs {
-            knn: c.knn_expr,
+            knn: augment_knn,
             block_size: c.block_size,
-            reciprocal: c.reciprocal,
+            reciprocal: knn.reciprocal,
         };
-        let expr_graph = match c.knn_expr_scope {
+        let expr_graph = match knn.scope {
             KnnExprScope::Global => build_expression_knn(&proj.proj, knn_args)?,
             KnnExprScope::Within => {
                 let (component_of_cell, n_components) = connected_components(&graph);
@@ -418,6 +430,7 @@ pub fn preprocess_srt(cfg: SrtPreprocessConfig<'_>) -> anyhow::Result<SrtPreproc
         batch_membership,
         batch_effects,
         graph,
+        knn,
         spatial_graph,
         edge_source,
         cell_proj,

--- a/pinto/src/util/tests/knn_resolution.rs
+++ b/pinto/src/util/tests/knn_resolution.rs
@@ -1,0 +1,255 @@
+//! How `-k` and `--knn-expr` resolve into the two k's the pipeline actually
+//! uses, and which combinations are refused.
+//!
+//! Two flags, two graphs, and the mapping between them depends on whether
+//! `--coord` was given. `-k` sizes the BASE graph; `--knn-expr` sizes the
+//! expression graph that is unioned into it. Without coordinates there is
+//! nothing to union into, so `--knn-expr` sizes the base graph instead and the
+//! augmentation is off.
+//!
+//! The failures these guard are silent ones. A `k` of 0 does not build an empty
+//! graph, it floors to 1-NN, which then fragments into hundreds of components
+//! and — in expression mode, where component folding is off — hundreds of
+//! batches. And a resolution that returned the same number for both roles would
+//! union the expression graph with itself.
+
+use crate::util::input::{KnnExprScope, SrtInputArgs};
+use crate::util::metadata::GraphParams;
+use clap::Parser;
+
+/// Parse an argv the way a subcommand would, minus the subcommand.
+fn args(extra: &[&str]) -> SrtInputArgs {
+    let mut argv = vec!["pinto", "d.zarr", "-o", "out"];
+    argv.extend_from_slice(extra);
+    SrtInputArgs::try_parse_from(argv).expect("args should parse")
+}
+
+/// Enough cells that no bound fires, so those rows test resolution alone.
+const PLENTY: usize = 1000;
+
+/// The resolution table, as a table.
+///
+/// Rows are `(argv, base, augment)`. Those two columns are the whole contract:
+/// which k builds the base graph, and which k (if any) is unioned into it.
+#[test]
+fn flags_resolve_to_the_two_ks_the_pipeline_uses() {
+    let rows: &[(&[&str], usize, usize)] = &[
+        // With coordinates: `-k` sizes the spatial graph, `--knn-expr` the
+        // union. Nothing set is the new default — spatial pairs only.
+        (&["-c", "coords.csv"], 5, 0),
+        (&["-c", "coords.csv", "-k", "12"], 12, 0),
+        // Asking for expression pairs is what turns the union on; the spatial
+        // side keeps its own default.
+        (&["-c", "coords.csv", "--knn-expr", "7"], 5, 7),
+        (&["-c", "coords.csv", "-k", "12", "--knn-expr", "7"], 12, 7),
+        // Without coordinates the base graph IS the expression graph, so the
+        // base must never come out as 0 and the augmentation is always 0.
+        (&[], 5, 0),
+        // An existing `-k` keeps building the graph it always built: k moves
+        // the force-directed layout, so re-sizing it would move every plot.
+        (&["-k", "20"], 20, 0),
+        // `--knn-expr` is the expression-mode knob.
+        (&["--knn-expr", "20"], 20, 0),
+        // `--knn-expr 0` asks for no expression pairs. There are none to turn
+        // off here, so it falls through rather than sizing the graph at 0.
+        (&["--knn-expr", "0"], 5, 0),
+        (&["--knn-expr", "0", "-k", "12"], 12, 0),
+    ];
+    for (argv, base, augment) in rows {
+        let c = args(argv);
+        assert_eq!(c.base_knn(), *base, "base for {argv:?}");
+        assert_eq!(c.augment_knn(), *augment, "augment for {argv:?}");
+        let knn = c
+            .resolve_knn(PLENTY)
+            .unwrap_or_else(|e| panic!("{argv:?} should resolve: {e}"));
+        assert_eq!(knn.base, *base, "resolved base for {argv:?}");
+        assert_eq!(knn.augment, *augment, "resolved augment for {argv:?}");
+    }
+}
+
+/// Absence must be distinguishable from the default value, or the resolution
+/// above cannot tell rows apart. A stray `default_value_t` would make this
+/// `Some(5)` and every "was it set?" branch would silently take the wrong arm.
+#[test]
+fn unset_flags_parse_as_none() {
+    let c = args(&["-c", "coords.csv"]);
+    assert_eq!(c.knn_spatial, None);
+    assert_eq!(c.knn_expr, None);
+}
+
+/// `-k` and `--knn-expr` both set without coordinates name the same graph.
+/// This has to be refused rather than warned about: the choice changes the
+/// connected-component count, which in expression mode becomes the batch
+/// partition, which decides whether batch-effect estimation runs at all.
+#[test]
+fn no_coords_with_both_flags_is_an_error() {
+    let err = args(&["-k", "20", "--knn-expr", "7"])
+        .resolve_knn(PLENTY)
+        .expect_err("must refuse");
+    let msg = err.to_string();
+    assert!(msg.starts_with("-k and --knn-expr"), "{msg}");
+    assert!(msg.contains("Pass only --knn-expr"), "{msg}");
+}
+
+/// A base k of 0 must be refused. The KNN builder floors k at 1 rather than
+/// rejecting it, so nothing downstream will catch this.
+///
+/// Asserted with `starts_with`, not `contains`: `"--knn-expr".contains("-k")`
+/// is true, so a `contains` check here could not fail.
+#[test]
+fn a_zero_base_is_refused() {
+    for argv in [vec!["-c", "coords.csv", "-k", "0"], vec!["-k", "0"]] {
+        let err = args(&argv).resolve_knn(PLENTY).expect_err("must refuse");
+        assert!(err.to_string().starts_with("-k "), "for {argv:?}: {err}");
+    }
+}
+
+/// Errors must name the flag that actually supplied the value, so the remedy
+/// is one the user can act on. Asserted through the messages rather than the
+/// private resolver, because the messages are the whole reason it exists.
+#[test]
+fn errors_name_the_flag_that_supplied_the_value() {
+    // A cell count small enough that the upper bound fires on the default k,
+    // so every row reaches a message that names a flag.
+    let cases: &[(&[&str], &str)] = &[
+        (&["-c", "coords.csv"], "-k "),
+        (&["-c", "coords.csv", "-k", "9"], "-k "),
+        (&["-k", "9"], "-k "),
+        (&["--knn-expr", "9"], "--knn-expr "),
+        // Nothing typed: in expression mode the knob to point at is the one
+        // that names this graph, not the one the help calls spatial.
+        (&[], "--knn-expr "),
+    ];
+    for (argv, want) in cases {
+        let err = args(argv).resolve_knn(3).expect_err("bound must fire");
+        assert!(
+            err.to_string().starts_with(want),
+            "for {argv:?} wanted {want:?}, got: {err}"
+        );
+    }
+}
+
+/// 0 means "no expression pairs" and stays legal when there is a spatial graph
+/// to fall back on. The `augment` assertion is the point: without it a slip
+/// that read 0 as "unset" would silently re-enable augmentation at k=5.
+#[test]
+fn a_zero_augmentation_is_legal_with_coords() {
+    let knn = args(&["-c", "coords.csv", "--knn-expr", "0"])
+        .resolve_knn(PLENTY)
+        .expect("0 turns augmentation off");
+    assert_eq!(knn.augment, 0, "and it must actually be off");
+    assert_eq!(knn.base, 5, "the spatial side is untouched");
+}
+
+/// k at or above the cell count asks for a complete graph, in either role.
+#[test]
+fn a_k_beyond_the_cell_count_is_refused() {
+    for argv in [
+        vec!["-c", "coords.csv", "-k", "1000"],
+        vec!["-c", "coords.csv", "--knn-expr", "5000"],
+        vec!["--knn-expr", "1000"],
+    ] {
+        assert!(
+            args(&argv).resolve_knn(PLENTY).is_err(),
+            "{argv:?} must be refused"
+        );
+    }
+}
+
+/// A fatal k outranks a scope complaint: fixing the scope first would only
+/// earn the user a second error on the next run.
+#[test]
+fn a_fatal_k_is_reported_before_a_scope_complaint() {
+    let err = args(&["-c", "coords.csv", "-k", "0", "--knn-expr-scope", "within"])
+        .resolve_knn(PLENTY)
+        .expect_err("must refuse");
+    assert!(err.to_string().starts_with("-k "), "{err}");
+}
+
+/// `within` scopes the search to components of the SPATIAL graph. Without
+/// coordinates there is none, and the flag cannot be given a meaning there:
+/// every cell's k-NN already sit inside its own component.
+#[test]
+fn within_scope_without_coords_is_an_error() {
+    let c = args(&["--knn-expr-scope", "within"]);
+    assert_eq!(c.knn_expr_scope, KnnExprScope::Within);
+    let err = c.resolve_knn(PLENTY).expect_err("must refuse");
+    assert!(err.to_string().contains("needs --coord"), "{err}");
+}
+
+/// The case the 0 default creates: coordinates present, but no expression
+/// pairs to scope. The flag would scope nothing and say nothing, which is the
+/// silent-ignore this validation exists to refuse.
+#[test]
+fn within_scope_without_expression_pairs_is_an_error() {
+    let err = args(&["-c", "coords.csv", "--knn-expr-scope", "within"])
+        .resolve_knn(PLENTY)
+        .expect_err("must refuse");
+    // `--knn-expr` is a substring of `--knn-expr-scope`, which this message
+    // opens with, so a bare `contains` could not fail. Match the remedy.
+    assert!(
+        err.to_string().contains("Pass --knn-expr N"),
+        "must name the flag to add: {err}"
+    );
+}
+
+/// The same scope is fine when there is a spatial graph to partition AND
+/// expression pairs to scope.
+#[test]
+fn within_scope_with_coords_and_pairs_is_fine() {
+    args(&[
+        "-c",
+        "coords.csv",
+        "--knn-expr",
+        "5",
+        "--knn-expr-scope",
+        "within",
+    ])
+    .resolve_knn(PLENTY)
+    .expect("within is what this flag is for");
+}
+
+/// What the manifest records, taken through the real conversion rather than a
+/// hand-built struct. Without this the resolution-to-manifest mapping is
+/// unpinned: inverting the scope predicate would swap which runs claim a scope
+/// and leave every serde round-trip test green.
+#[test]
+fn graph_params_record_what_the_run_did() {
+    let params = |argv: &[&str]| -> GraphParams {
+        (&args(argv).resolve_knn(PLENTY).expect("should resolve")).into()
+    };
+
+    let augmented = params(&[
+        "-c",
+        "coords.csv",
+        "--knn-expr",
+        "7",
+        "--knn-expr-scope",
+        "within",
+    ]);
+    assert_eq!(augmented.knn_base, 5);
+    assert_eq!(augmented.knn_expr, 7);
+    assert!(augmented.knn_expr > 0, "this run unioned expression pairs in");
+    assert_eq!(
+        augmented.knn_expr_scope.as_deref(),
+        Some("within"),
+        "the CLI spelling, not the Debug name"
+    );
+
+    let spatial_only = params(&["-c", "coords.csv"]);
+    assert_eq!(spatial_only.knn_expr, 0);
+
+    assert_eq!(
+        spatial_only.knn_expr_scope, None,
+        "no search ran, so no scope may be claimed"
+    );
+
+    // Expression mode: the k that built the graph is the base, and there is
+    // no augmentation to report.
+    let expression = params(&["--knn-expr", "20"]);
+    assert_eq!(expression.knn_base, 20);
+    assert_eq!(expression.knn_expr, 0);
+
+
+    assert!(params(&["-c", "coords.csv", "--reciprocal"]).reciprocal);
+}

--- a/pinto/src/util/tests/metadata.rs
+++ b/pinto/src/util/tests/metadata.rs
@@ -22,6 +22,7 @@ fn metadata_roundtrip_lc() {
             n_genes: 18000,
             n_edges: 55555,
             k: 12,
+            graph: GraphParams::default(),
         },
         Some(DictMergeSummary {
             min_nnz: 1,
@@ -94,6 +95,7 @@ fn metadata_roundtrip_cage() {
             n_genes: 20000,
             n_edges: 5000,
             k: 16, // edge clusters
+            graph: GraphParams::default(),
         },
         true,
         Some(SpliceTrackInfo {
@@ -175,6 +177,7 @@ fn metadata_roundtrip_cage_no_batch() {
             n_genes: 200,
             n_edges: 300,
             k: 8,
+            graph: GraphParams::default(),
         },
         false,
         None,
@@ -203,6 +206,7 @@ fn metadata_roundtrip_lc_merge_no_collapse() {
             n_genes: 200,
             n_edges: 300,
             k: 8,
+            graph: GraphParams::default(),
         },
         None,
         None,
@@ -216,4 +220,100 @@ fn metadata_roundtrip_lc_merge_no_collapse() {
     assert_eq!(levels.len(), 1);
     assert_eq!(levels[0].tag, "final");
     assert!(back.outputs.dict_merge.is_none());
+}
+
+/// Round-trip one `GraphParams` through `create_lc_metadata` and the JSON.
+///
+/// The `TempDir` comes back with it: dropping it would delete the file the
+/// read went through, and the two tests below differ only in the block and the
+/// assertions, not the scaffolding.
+fn roundtrip_graph(graph: GraphParams) -> (tempfile::TempDir, GraphParams) {
+    let dir = tempfile::tempdir().unwrap();
+    let prefix = dir.path().join("run").to_string_lossy().to_string();
+    let data_files: Vec<Box<str>> = vec!["a.h5".into()];
+    let coord_cols: Vec<Box<str>> = vec!["x".into(), "y".into()];
+    let meta = create_lc_metadata(
+        &RunInputs {
+            prefix: &prefix,
+            data_files: &data_files,
+            coord_file: Some("a.tsv"),
+            coord_columns: &coord_cols,
+            n_cells: 1234,
+            n_genes: 18000,
+            n_edges: 55555,
+            k: 12,
+            graph,
+        },
+        None,
+        None,
+        &[0],
+    );
+    let path = dir.path().join("run.pinto.json");
+    meta.write(&path).unwrap();
+    let back = PintoMetadata::read(&path)
+        .unwrap()
+        .graph
+        .expect("graph parameters must round-trip");
+    (dir, back)
+}
+
+/// Which graph produced the pairs must survive into the manifest.
+///
+/// Without this the flipped `--knn-expr` default is unreproducible from
+/// artifacts: a run's pair count is recorded, but not the two k's that decided
+/// it, so the only way to tell an augmented run from a spatial-only one is to
+/// open the parquet and notice a missing column.
+#[test]
+fn metadata_records_the_graph_parameters() {
+    let (_dir, g) = roundtrip_graph(GraphParams {
+        knn_base: 5,
+        knn_expr: 7,
+        knn_expr_scope: Some("global".to_string()),
+        reciprocal: false,
+    });
+    assert_eq!(g.knn_base, 5);
+    assert_eq!(g.knn_expr, 7);
+    assert_eq!(g.knn_expr_scope.as_deref(), Some("global"));
+    assert!(g.knn_expr > 0, "this run unioned expression pairs in");
+}
+
+/// The default spatial run is the one that must be distinguishable. Its
+/// omitted scope has to survive `skip_serializing_if` and come back `None`
+/// rather than defaulting to a scope no search used.
+#[test]
+fn metadata_records_an_unaugmented_run_as_such() {
+    let (_dir, g) = roundtrip_graph(GraphParams {
+        knn_base: 5,
+        knn_expr: 0,
+        knn_expr_scope: None,
+        reciprocal: false,
+    });
+    assert_eq!(g.knn_expr, 0);
+    assert_eq!(g.knn_expr, 0, "and no union is recorded");
+    assert_eq!(g.knn_expr_scope, None, "no search ran, so no scope is claimed");
+}
+
+/// A `graph` block written by an older build must not sink the whole manifest.
+///
+/// This block gains fields over time, and `PintoMetadata::backfill_output`
+/// swallows a read error at debug level — so a missing-field failure here is
+/// silent, and `pinto plot --from` / `pinto lra --from` abort outright on a
+/// manifest they should have read.
+#[test]
+fn an_older_graph_block_still_deserializes() {
+    let json = r#"{
+        "command": "lc",
+        "version": "0.6.9",
+        "timestamp": "0",
+        "prefix": "run",
+        "n_cells": 10,
+        "n_genes": 10,
+        "graph": {"knn_base": 5, "knn_expr": 0, "augmented": false},
+        "outputs": {}
+    }"#;
+    let back: PintoMetadata = serde_json::from_str(json).expect("must stay readable");
+    let g = back.graph.expect("the block that was present must survive");
+    assert_eq!(g.knn_base, 5);
+    assert!(!g.reciprocal, "a field the writer never knew about defaults");
+    assert_eq!(g.knn_expr, 0, "no union, however the block was written");
 }

--- a/pinto/src/util/tests/mod.rs
+++ b/pinto/src/util/tests/mod.rs
@@ -3,4 +3,5 @@ mod graph_augmentation;
 mod graph_coarsen;
 mod graph_dc_poisson_refine;
 mod graph_refine;
+mod knn_resolution;
 mod metadata;


### PR DESCRIPTION
`--knn-expr` unions a second, expression-based KNN graph into the spatial pair
graph. It defaulted to 5, so every spatial run paid for the extra pairs — and
with them the extra runtime and peak memory — whether or not it wanted them.
It now defaults to 0 under `--coord`. The flip also drops a projection pass
from the default `dsvd` and HVG-`cage` paths, where preprocessing took one
those subcommands immediately discarded.

**Breaking:** spatial runs now build spatial pairs only. Pass `--knn-expr 5`
to restore the old behaviour.

Without `--coord` the flag takes over sizing the expression graph, a job `-k`
did double duty for. That split is the part worth reviewing, because it is
where a command line could quietly change meaning — so none of them do:

- `-k` alone still sizes the graph, and says `--knn-expr` is the name for it.
- `--knn-expr` now sizes it where it used to be ignored, and **warns**: k
  moves the component count, and there components become batches, which
  decides whether batch-effect estimation runs at all. It also moves the
  force-directed layout, so plots shift.
- `-k` with a positive `--knn-expr` name the same graph and are refused.
- `--knn-expr 0` stays a no-op in both modes, so scripts pinning it survive.
- `--knn-expr-scope within` is refused when no expression search will run,
  instead of scoping nothing in silence.

Both flags become `Option<usize>` so "set" is distinguishable from
"defaulted", and one `resolve_knn` validates, logs and resolves as a single
decision. Its `ResolvedKnn` rides on `SrtPreprocessed`, so the manifest
records the graph the pipeline built rather than re-deriving it from args.

The manifest gains a `graph` block (both k's, scope, `--reciprocal`).
Previously a `.pinto.json` said how many pairs a run produced but not why —
telling an augmented run from a spatial-only one meant opening the parquet and
noticing a missing `edge_kind` column. Every field is `#[serde(default)]`:
`backfill_output` swallows a read error at `debug!`, so one missing field
would silently take down `plot --from` and `lra --from` for the whole file.
There is a regression test for an older-shape block.

Two notes. `--reciprocal`'s help called it spatial-only though it applies to
every graph a run builds — help fixed, behaviour unchanged. And `lr-activity`
is unaffected: it already excludes expression edges from the tested set (they
are community anchors, never tested), so this changes neither its results nor
its runtime.

`cargo test -p pinto` (184), clippy clean but for one pre-existing warning,
`cargo check --workspace`. New `knn_resolution.rs` covers the resolution
table, every refusal, and the args-to-manifest mapping. Checked end to end on
a spatial dataset: the default run reproduces the schema of a pre-augmentation
run, and its pairs are exactly the spatial subset of a same-binary
`--knn-expr 5` control.