### PR TITLE
refactor(projection): the frozen projector owns its own group size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graph-embedding-util"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "auxiliary-data",
@@ -4994,7 +4994,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "senna"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "approx",

--- a/graph-embedding-util/Cargo.toml
+++ b/graph-embedding-util/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.3.18"
+version = "0.3.19"
 
 [lib]
 name = "graph_embedding_util"

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -30,8 +30,7 @@ use nalgebra::DMatrix;
 use config::{stage_params, LINEAGE_WARMUP_FRAC};
 use projection::{project_cells_phase2, project_pbs_phase2, CellBatchDivisor, PHASE2_RIDGE};
 pub use projection::{
-    project_onto_frozen, FrozenProjection, FrozenProjectionArgs,
-    PHASE2_RIDGE as PROJECTION_RIDGE_SGD,
+    FrozenProjection, FrozenProjectionArgs, FrozenProjector, PHASE2_RIDGE as PROJECTION_RIDGE_SGD,
 };
 use selection::{install_selection, run_selection_pass, SelectionPassInput};
 

--- a/graph-embedding-util/src/fit/projection.rs
+++ b/graph-embedding-util/src/fit/projection.rs
@@ -75,7 +75,7 @@ pub(crate) fn cell_edges(
 // Projecting onto a frozen dictionary //
 /////////////////////////////////////////
 
-/// Inputs for [`project_onto_frozen`].
+/// Inputs for [`FrozenProjector::new`].
 pub struct FrozenProjectionArgs<'a> {
     /// Frozen dictionary, row-major `[n_features × h]`.
     pub feat: &'a [f32],
@@ -93,46 +93,129 @@ pub struct FrozenProjection {
     pub b_node: Vec<f32>,
 }
 
-/// Project nodes onto a **frozen** feature side with the same block SGD phase 2
-/// uses, for callers outside the fit — `senna predict` on a bge model.
+/// A frozen feature side with its projection design already built — the entry
+/// point for projecting nodes that are not part of a fit (`senna predict` on a bge
+/// model, and any future streaming caller).
 ///
-/// # Why not the Newton solver in [`crate::cell_projection`]
+/// # Why a projector and not a function
+///
+/// Everything the block SGD needs that depends only on `(feat, b_feat)` — the
+/// augmented design in both orientations, the live-feature scan and gate fold, the
+/// null normalizer, the auto-scaled learning rate — is built by [`Self::new`] and
+/// reused by every [`Self::project`] call. A per-call function rebuilt all of it
+/// per call, which pushed the cost of a small call onto the *caller*: it had to
+/// hand over enough nodes to hide the setup, and the only way to know "enough" was
+/// to guess against constants inside the engine it could not see. There is nothing
+/// left to hide, so a caller sizes its groups for its own memory — and can ask
+/// [`Self::group_nodes`] for a size derived from the block budget rather than
+/// guessing at it.
+///
+/// # Why this solver
 ///
 /// A run's own `cell_embedding.parquet` comes from `project_cells_phase2`, i.e.
-/// this solver: Adam over cell blocks against the **full** log-partition. The
-/// Newton/IRLS path fits a node's observed features only and lets a ridge stand
-/// in for the partition, which is why the per-cell phase 2 was moved off it —
-/// `‖θ‖` runs away. Projecting held-out cells with the other solver would put
-/// train and test latents in different spaces and quietly confound any
-/// train/test comparison built on them. One estimator, both halves.
+/// this same block SGD: Adam over cell blocks against the **full** log-partition.
+/// The Newton/IRLS path in [`crate::cell_projection`] fits a node's observed
+/// features only and lets a ridge stand in for the partition, which is why the
+/// per-cell phase 2 was moved off it — `‖θ‖` runs away. Projecting held-out cells
+/// with the other solver would put train and test latents in different spaces and
+/// quietly confound any train/test comparison built on them. One estimator, both
+/// halves.
 ///
 /// `gauge_fix` is **off** here, unlike training: the gauge shift is a
-/// (θ, b_feat) pair, and `b_feat` is frozen at predict time — re-centring θ
-/// alone would break its correspondence with the dictionary it is scored
-/// against.
-pub fn project_onto_frozen(
-    args: &FrozenProjectionArgs<'_>,
-    nodes: &[(u32, &[u32], &[f32])],
-    n_nodes: usize,
-) -> anyhow::Result<FrozenProjection> {
-    let out = block_sgd::project_cells(
-        &block_sgd::Phase2Input {
+/// (θ, b_feat) pair, and `b_feat` is frozen at predict time — re-centring θ alone
+/// would break its correspondence with the dictionary it is scored against.
+pub struct FrozenProjector<'a> {
+    feat: &'a [f32],
+    b_feat: &'a [f32],
+    h: usize,
+    lambda: f64,
+    dev: &'a Device,
+    dict: block_sgd::PassDict,
+}
+
+impl<'a> FrozenProjector<'a> {
+    /// Build the projection design for a frozen dictionary. Does the whole
+    /// per-dictionary setup once; [`Self::project`] then costs only what its own
+    /// nodes cost.
+    pub fn new(args: &FrozenProjectionArgs<'a>) -> anyhow::Result<Self> {
+        let n_features = args.b_feat.len();
+        anyhow::ensure!(
+            args.feat.len() == n_features * args.h,
+            "frozen projection: the dictionary has {} entries, expected {n_features} × {}",
+            args.feat.len(),
+            args.h
+        );
+        // The exact normalizer: every feature of the frozen side is in the partition.
+        let rows: Vec<u32> = (0..n_features as u32).collect();
+        let dict = block_sgd::PassDict::build(
+            &block_sgd::DictSpec {
+                feat: args.feat,
+                b_feat: args.b_feat,
+                h: args.h,
+                lambda: args.lambda,
+                dev: args.dev,
+                label: "Projection",
+                pass: "nodes",
+            },
+            rows,
+        )?;
+        Ok(Self {
             feat: args.feat,
             b_feat: args.b_feat,
             h: args.h,
-            n_cells: n_nodes,
             lambda: args.lambda,
             dev: args.dev,
-            label: "Projection",
-            gauge_fix: false,
-            joint: false,
-        },
-        nodes,
-        None,
-        None,
-    )?;
-    Ok(FrozenProjection {
-        theta: out.theta,
-        b_node: out.b_cell,
-    })
+            dict,
+        })
+    }
+
+    /// Nodes to hand one [`Self::project`] call.
+    ///
+    /// A whole number of solver blocks, derived from the activation budget this
+    /// crate owns — so a streaming caller that cuts its groups here fills every
+    /// block exactly instead of guessing a size in a currency the engine never
+    /// sees. It bounds host memory too: a node carries at most `F` nonzeros, and
+    /// `block_cells × F` is what the activation budget caps, so a group's nonzero
+    /// count does not grow with the feature axis.
+    pub fn group_nodes(&self) -> usize {
+        self.dict.group_nodes()
+    }
+
+    /// Project one group of nodes, advancing `bar` by one tick per node as the
+    /// blocks step.
+    ///
+    /// `nodes` is `(group-local id, feature ids, counts)` and `n_nodes` bounds that
+    /// local axis; ids are positions in the returned `[n_nodes × h]` θ, so a caller
+    /// streaming groups re-bases them per group and stitches the results itself.
+    ///
+    /// The bar is the **caller's**, not one per call: a streaming caller already has
+    /// a bar over the whole query, and a second one underneath it would either nest
+    /// or fight it for the terminal.
+    pub fn project(
+        &self,
+        nodes: &[(u32, &[u32], &[f32])],
+        n_nodes: usize,
+        bar: &indicatif::ProgressBar,
+    ) -> anyhow::Result<FrozenProjection> {
+        let out = block_sgd::project_prepared(
+            &block_sgd::Phase2Input {
+                feat: self.feat,
+                b_feat: self.b_feat,
+                h: self.h,
+                n_cells: n_nodes,
+                lambda: self.lambda,
+                dev: self.dev,
+                label: "Projection",
+                gauge_fix: false,
+                joint: false,
+            },
+            &self.dict,
+            nodes,
+            bar,
+        )?;
+        Ok(FrozenProjection {
+            theta: out.theta,
+            b_node: out.b_cell,
+        })
+    }
 }

--- a/graph-embedding-util/src/fit/projection/block_sgd/block_sgd_tests.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/block_sgd_tests.rs
@@ -406,3 +406,119 @@ fn joint_recovers_theta_and_delta() {
         );
     }
 }
+
+/// The streaming entry point must agree with the one-shot one **exactly**, not
+/// approximately. `project_prepared` skips `project_cells`'s partition/edge setup in
+/// favour of a `PassDict` the caller already holds, so this is the test that the
+/// dictionary carries the same feature partition, the edge remap still lands on the
+/// same live ids, and the scatter still writes the same rows.
+#[test]
+fn streaming_entry_matches_the_one_shot_one() {
+    let (h, n_feat) = (6, 240);
+    let (e, b) = dictionary(n_feat, h, 0.4);
+    let planted = [
+        [0.7f32, -0.5, 0.4, 0.2, -0.3, 0.1],
+        [-0.3f32, 0.6, -0.2, 0.5, 0.1, -0.4],
+        [0.2f32, 0.1, 0.5, -0.3, 0.4, 0.2],
+    ];
+    let per_cell: Vec<_> = planted
+        .iter()
+        .enumerate()
+        .map(|(i, t)| rates(&e, &b, h, t, 0.2 + 0.1 * i as f32))
+        .collect();
+    let feats: Vec<Vec<u32>> = per_cell
+        .iter()
+        .map(|c| c.iter().map(|&(f, _)| f).collect())
+        .collect();
+    let counts: Vec<Vec<f32>> = per_cell
+        .iter()
+        .map(|c| c.iter().map(|&(_, n)| n).collect())
+        .collect();
+    let nodes: Vec<(u32, &[u32], &[f32])> = (0..3)
+        .map(|i| (i as u32, feats[i].as_slice(), counts[i].as_slice()))
+        .collect();
+
+    // `gauge_fix: false` — the frozen projection never re-centres (`b_feat` is frozen,
+    // so re-gauging θ alone would break its correspondence with the dictionary).
+    let input = Phase2Input {
+        feat: &e,
+        b_feat: &b,
+        h,
+        n_cells: 3,
+        lambda: 1e-3,
+        dev: &Device::Cpu,
+        label: "Projection",
+        gauge_fix: false,
+        joint: false,
+    };
+
+    let one_shot = project_cells(&input, &nodes, None, None).expect("one-shot");
+
+    let dict = PassDict::build(
+        &DictSpec {
+            feat: &e,
+            b_feat: &b,
+            h,
+            lambda: 1e-3,
+            dev: &Device::Cpu,
+            label: "Projection",
+            pass: "nodes",
+        },
+        (0..n_feat as u32).collect(),
+    )
+    .expect("dict");
+    let streamed = project_prepared(&input, &dict, &nodes, &indicatif::ProgressBar::hidden())
+        .expect("streamed");
+
+    assert_eq!(
+        one_shot.theta, streamed.theta,
+        "θ differs between entry points"
+    );
+    assert_eq!(
+        one_shot.b_cell, streamed.b_cell,
+        "b_node differs between entry points"
+    );
+}
+
+/// The group size a streaming caller is handed must be a whole number of blocks.
+///
+/// That is the whole reason it is the engine's number and not the caller's: blocks
+/// are cut at multiples of `Bc` from the start of each group, so a group cut here
+/// reproduces the block partition of a single call over the whole query — and
+/// therefore its numbers exactly. A group size that is *not* a multiple leaves a
+/// short block at the end of every group, which both wastes steps and moves the
+/// answer.
+#[test]
+fn the_offered_group_size_is_a_whole_number_of_blocks() {
+    for f in [1usize, 100, 5_000, 58_651] {
+        let (h, n_feat) = (4, f.min(400));
+        let (e, b) = dictionary(n_feat, h, 0.4);
+        // The dict's own partition is what sizes its blocks, so vary that rather than
+        // building an enormous dictionary just to move `Bc`.
+        let rows: Vec<u32> = (0..n_feat as u32).collect();
+        let dict = PassDict::build(
+            &DictSpec {
+                feat: &e,
+                b_feat: &b,
+                h,
+                lambda: 1.0,
+                dev: &Device::Cpu,
+                label: "Projection",
+                pass: "nodes",
+            },
+            rows,
+        )
+        .unwrap();
+        let bc = block_cells(n_feat);
+        let g = dict.group_nodes();
+        assert!(
+            g >= bc,
+            "F={n_feat}: group of {g} is under one block of {bc}"
+        );
+        assert_eq!(
+            g % bc,
+            0,
+            "F={n_feat}: group of {g} is not whole blocks of {bc}"
+        );
+    }
+}

--- a/graph-embedding-util/src/fit/projection/block_sgd/edges.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/edges.rs
@@ -2,6 +2,10 @@
 //! counts restricted to one pass's feature partition, flattened once, plus the `Bc`
 //! that keeps a block's `[Bc, F]` activations inside the budget. Both are pure host
 //! bookkeeping the device loop reads but never rebuilds.
+//!
+//! The two have different lifetimes, which is why they are separate calls: `Bc`
+//! belongs to the frozen dictionary and is held by [`super::PassDict`], while the
+//! edge table belongs to the nodes and is rebuilt for every group of them.
 
 use super::{BLOCK_ACTIVATION_BYTES, LIVE_BLOCK_TENSORS, MAX_BLOCK_CELLS};
 use crate::fit::projection::{cell_edges, CellBatchDivisor};
@@ -64,27 +68,11 @@ impl EdgeTable {
     }
 }
 
-//////////////////////
-// Block partition //
-//////////////////////
+//////////////////
+// Block sizing //
+//////////////////
 
-pub(super) struct BlockPlan {
-    pub(super) block_cells_a: usize,
-    pub(super) block_cells_b: usize,
-    pub(super) two_pass: bool,
-}
-
-/// Size `Bc` per pass so a block's `[Bc, F_pass]` activations stay inside
-/// [`BLOCK_ACTIVATION_BYTES`].
-pub(super) fn block_partition(rows_a: &[u32], rows_b: &[u32]) -> BlockPlan {
-    BlockPlan {
-        block_cells_a: block_cells(rows_a.len()),
-        block_cells_b: block_cells(rows_b.len()),
-        two_pass: !rows_b.is_empty(),
-    }
-}
-
-/// Cells per block for a pass over `f` live features.
+/// Cells per block for a pass over `f` features.
 pub(super) fn block_cells(f: usize) -> usize {
     if f == 0 {
         return 1;

--- a/graph-embedding-util/src/fit/projection/block_sgd/mod.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/mod.rs
@@ -83,10 +83,17 @@
 //! # Layout
 //!
 //! [`edges`] flattens the sampler's edges once per pass and sizes the blocks;
-//! [`pass`] drives one pass (θ, or δ with θ fixed) block by block and owns the
-//! per-block argument/result types; [`solve`] is the Adam loop for one block;
-//! [`joint`] is the alternative single-solve θ+δ path. The tuning constants, the
-//! caller-facing types and the entry point stay here.
+//! [`pass`] holds the frozen per-pass design ([`pass::PassDict`]) apart from the
+//! block loop that runs nodes against it, and owns the per-block argument/result
+//! types; [`solve`] is the Adam loop for one block; [`joint`] is the alternative
+//! single-solve θ+δ path. The tuning constants, the caller-facing types and the
+//! entry points stay here.
+//!
+//! There are two entry points, differing only in who owns the dictionary.
+//! [`project_cells`] takes a whole node set and builds the design for it;
+//! [`project_prepared`] takes a design the caller already built and one group of
+//! nodes, so a caller with more nodes than it wants resident can stream them past
+//! the same dictionary.
 
 use super::CellBatchDivisor;
 use crate::progress::new_progress_bar;
@@ -98,9 +105,11 @@ mod joint;
 mod pass;
 mod solve;
 
-use edges::{block_partition, EdgeTable};
+use edges::EdgeTable;
 use joint::run_joint_pass;
-use pass::{run_pass, PassSpec};
+use pass::{run_pass, PassOut, PassSpec};
+
+pub(crate) use pass::{DictSpec, PassDict};
 
 /////////////////////////
 // Schedule / tolerance //
@@ -160,6 +169,24 @@ const LIVE_BLOCK_TENSORS: usize = 8;
 /// per-block convergence report.
 const MAX_BLOCK_CELLS: usize = 4096;
 
+/// Blocks a streaming caller should ask for in one [`project_prepared`] call, via
+/// [`PassDict::group_nodes`].
+///
+/// Now that the pass design is built once ([`PassDict`]) rather than per call, a
+/// group buys very little: the flatten, the scatter and the result allocations
+/// either side of the solve are all O(nodes) whatever the group size, so all that
+/// is left to amortize is one log line and the block loop's own bookkeeping. A
+/// small multiple is enough, and it keeps the caller's resident edges bounded —
+/// a node carries at most `F` nonzeros and `Bc·F` is itself capped by
+/// [`BLOCK_ACTIVATION_BYTES`], so a group's nonzeros cannot grow with the feature
+/// axis.
+///
+/// What it must NOT be is a number the caller guesses. That was the previous
+/// arrangement — a caller-side byte budget, in a currency (nonzeros) the engine
+/// never sees, tuned to clear a block size it could not read — and it silently
+/// reverted to one short block per call whenever anything here moved.
+const GROUP_BLOCKS: usize = 4;
+
 /// A feature whose frozen `‖e_f‖` is at or below this contributes `exp(β_f + c)`
 /// independent of `Θ`, so it is folded into a scalar partition mass and dropped
 /// from the matmul entirely.
@@ -200,6 +227,21 @@ pub(crate) struct Phase2Input<'a> {
     /// spliced and unspliced tracks — instead of the default sequential θ-then-δ (δ with
     /// θ held fixed). Ignored without `unspliced_rows`.
     pub joint: bool,
+}
+
+impl Phase2Input<'_> {
+    /// The dictionary side of this input, for building one pass's [`PassDict`].
+    fn dict_spec(&self, pass: &'static str) -> DictSpec<'_> {
+        DictSpec {
+            feat: self.feat,
+            b_feat: self.b_feat,
+            h: self.h,
+            lambda: self.lambda,
+            dev: self.dev,
+            label: self.label,
+            pass,
+        }
+    }
 }
 
 /// Phase-2 result on the host, in global cell-id order.
@@ -310,12 +352,12 @@ pub(crate) fn project_cells(
     let edges_b =
         (!rows_b.is_empty()).then(|| EdgeTable::build(cells, &rows_b, n_features, batch_divisor));
 
-    let blocks = block_partition(&rows_a, &rows_b);
     // The bar counts **cells**, across both passes, and advances *within* a block
     // in proportion to that block's Adam steps. Counting whole blocks would tick
     // maybe 16 times for an entire phase — and the better `Bc` gets for speed, the
     // coarser that becomes. Cells stay meaningful and the bar keeps moving.
-    let bar = new_progress_bar((cells.len() * (1 + usize::from(blocks.two_pass))) as u64);
+    let two_pass = !rows_b.is_empty();
+    let bar = new_progress_bar((cells.len() * (1 + usize::from(two_pass))) as u64);
     bar.enable_steady_tick(std::time::Duration::from_millis(200));
 
     // Estimate θ (and, on the splice path, δ). Two modes:
@@ -330,39 +372,92 @@ pub(crate) fn project_cells(
         }
         _ => {
             // Pass 1 — identity θ (and the kept per-cell intercept).
+            let dict_a = PassDict::build(&input.dict_spec("identity"), rows_a)?;
             let pass_a = run_pass(
                 input,
+                &dict_a,
                 &PassSpec {
-                    label: "identity",
-                    rows: &rows_a,
                     edges: &edges_a,
                     base_theta: None,
-                    block_cells: blocks.block_cells_a,
                 },
                 cells,
                 &bar,
             )?;
             // Pass 2 — velocity increment δ, with θ held fixed.
             let pass_b = match &edges_b {
-                Some(eb) => Some(run_pass(
-                    input,
-                    &PassSpec {
-                        label: "velocity",
-                        rows: &rows_b,
-                        edges: eb,
-                        base_theta: Some(&pass_a.latent),
-                        block_cells: blocks.block_cells_b,
-                    },
-                    cells,
-                    &bar,
-                )?),
+                Some(eb) => {
+                    let dict_b = PassDict::build(&input.dict_spec("velocity"), rows_b)?;
+                    Some(run_pass(
+                        input,
+                        &dict_b,
+                        &PassSpec {
+                            edges: eb,
+                            base_theta: Some(&pass_a.latent),
+                        },
+                        cells,
+                        &bar,
+                    )?)
+                }
                 None => None,
             };
             (pass_a, pass_b)
         }
     };
     bar.finish_and_clear();
+    Ok(finish(input, cells, pass_a, pass_b))
+}
 
+/// Project one group of nodes against a dictionary the caller has **already**
+/// built — the streaming counterpart of [`project_cells`].
+///
+/// One feature partition (every row of the dictionary), no batch divisor and no
+/// splice pass, on the caller's own progress bar: the shape
+/// [`super::FrozenProjector`] needs to walk a query past a frozen side group by
+/// group.
+///
+/// # Grouping does not change the answer, provided the groups are block-aligned
+///
+/// A block is an independent problem (see the module docs) but not a *per-node*
+/// one: its cells share a convergence test and a step cap, so which cells land in
+/// a block together is observable in the result. Blocks are cut at multiples of
+/// `Bc` from the start of each group, so a caller that cuts its groups at
+/// [`PassDict::group_nodes`] — a whole number of blocks — produces exactly the
+/// block partition one single call over the whole query would, and therefore
+/// exactly its numbers — byte-identical, not merely close.
+///
+/// A caller that groups on some other rhythm still gets a correct projection; it
+/// just gets a different (and, for a ragged group, short-block-padded) partition.
+///
+/// `input.n_cells` bounds the returned axis, so node ids must be group-local.
+pub(crate) fn project_prepared(
+    input: &Phase2Input,
+    dict: &PassDict,
+    nodes: &[(u32, &[u32], &[f32])],
+    bar: &indicatif::ProgressBar,
+) -> anyhow::Result<Phase2Out> {
+    let edges = EdgeTable::build(nodes, dict.rows(), input.b_feat.len(), None);
+    let pass = run_pass(
+        input,
+        dict,
+        &PassSpec {
+            edges: &edges,
+            base_theta: None,
+        },
+        nodes,
+        bar,
+    )?;
+    Ok(finish(input, nodes, pass, None))
+}
+
+/// Re-gauge the pass results and scatter them onto the global node axis — the tail
+/// both entry points share.
+fn finish(
+    input: &Phase2Input,
+    cells: &[(u32, &[u32], &[f32])],
+    pass_a: PassOut,
+    pass_b: Option<PassOut>,
+) -> Phase2Out {
+    let h = input.h;
     // Fix the gauge (see `GaugeShift`): remove the population mean from each
     // latent. Taken over the SOLVED cells only — a cell with no edges was never
     // placed by the likelihood, and after centring the origin is the population
@@ -408,7 +503,7 @@ pub(crate) fn project_cells(
         }
     }
 
-    Ok(Phase2Out {
+    Phase2Out {
         theta,
         b_cell,
         velocity,
@@ -416,7 +511,7 @@ pub(crate) fn project_cells(
             theta_mean,
             delta_mean,
         },
-    })
+    }
 }
 
 /// Column means of a row-major `[n × h]` buffer.

--- a/graph-embedding-util/src/fit/projection/block_sgd/pass.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/pass.rs
@@ -1,27 +1,233 @@
-//! One pass over one feature partition: the frozen augmented design `Ẽ` built once,
-//! the block loop that solves every node against it, and the running stats and
-//! progress the pass reports. Also the [`BlockArgs`]/[`BlockOut`] pair that is the
-//! whole interface to [`super::solve`] — built here, filled there.
+//! One pass over one feature partition: the frozen augmented design `Ẽ`, the block
+//! loop that solves every node against it, and the running stats and progress the
+//! pass reports. Also the [`BlockArgs`]/[`BlockOut`] pair that is the whole
+//! interface to [`super::solve`] — built here, filled there.
+//!
+//! The split between [`PassDict`] and [`run_pass`] is the load-bearing one. The
+//! design matrix, the live/gate-folded split, the null normalizer, the learning
+//! rate and the block size depend **only on the frozen dictionary** — not on which
+//! nodes are being projected against it. Holding them apart is what lets a caller
+//! stream nodes past one dictionary group by group
+//! ([`crate::fit::projection::FrozenProjector`]) and size those groups for its own
+//! memory, instead of large enough to hide a per-call setup.
 
-use super::edges::EdgeTable;
+use super::edges::{block_cells, EdgeTable};
 use super::solve::solve_block;
-use super::{Phase2Input, GATE_FOLD_EPS, MAX_STEPS, TARGET_DELTA_S};
-use candle_util::candle_core::Tensor;
+use super::{Phase2Input, GATE_FOLD_EPS, GROUP_BLOCKS, MAX_STEPS, TARGET_DELTA_S};
+use candle_util::candle_core::{Device, Tensor};
 use log::info;
 
-/////////////////////
-// One phase-2 pass //
-/////////////////////
+////////////////////////////////////
+// The frozen design for one pass //
+////////////////////////////////////
 
+/// The dictionary side of a pass: what [`PassDict::build`] reads, and how the pass
+/// names itself in the log.
+pub(crate) struct DictSpec<'a> {
+    /// Frozen dictionary, row-major `[n_features × h]`.
+    pub(crate) feat: &'a [f32],
+    /// Frozen feature bias, `[n_features]`.
+    pub(crate) b_feat: &'a [f32],
+    pub(crate) h: usize,
+    /// Ridge `λ`. Reported here; *applied* per block from [`Phase2Input`], which is
+    /// where the solve reads it.
+    pub(crate) lambda: f64,
+    pub(crate) dev: &'a Device,
+    /// Log prefix — `"Phase 2"`, `"Projection"`, `"pb velocity readout"`.
+    pub(crate) label: &'static str,
+    /// This pass's own name within that: `"identity"`, `"velocity"`, `"nodes"`.
+    pub(crate) pass: &'static str,
+}
+
+/// Everything a pass needs that depends **only** on the frozen dictionary and the
+/// feature partition it runs over.
+///
+/// Every field below used to be rebuilt inside `run_pass`. That was free while the
+/// only callers projected a whole run's cells in one go, and a per-group tax the
+/// moment one started streaming: the transposed dictionary, the live-feature scan,
+/// the `Σ exp(β)` reduction, the learning-rate estimate and an info line, once per
+/// handful of cells. Built once here, a group is sized by what the *caller* can
+/// hold rather than by what it has to amortize.
+pub(crate) struct PassDict {
+    /// The pass's feature partition on the global feature axis. **Owned**: the dict
+    /// outlives the call that built it, so it cannot borrow the caller's rows.
+    rows: Vec<u32>,
+    /// Global → live-local feature id; `u32::MAX` for a gate-folded row.
+    pub(super) to_live: Vec<u32>,
+    /// Augmented dictionary `Ẽᵀ [H+1, F_live]` — the live rows transposed, with a
+    /// **row of ones** appended so the per-cell intercept rides in as the last
+    /// column of the parameter matrix rather than as a separate broadcast add. That
+    /// removes a whole `[Bc, F]` op and, more to the point, makes the intercept's
+    /// gradient fall out of the same matmul as the latent's (the ones row sums `μ`
+    /// over features, which is exactly `∂/∂c`).
+    pub(super) e_aug: Tensor,
+    /// `Ẽ [F_live, H+1]`. Both orientations are needed every step — `Θ̃·Ẽᵀ` forward
+    /// and `μ·Ẽ` for the gradient — so the transpose is materialized once here.
+    pub(super) e_aug_t: Tensor,
+    /// Frozen feature bias over the live rows, `[1, F_live]`.
+    pub(super) b_row: Tensor,
+    /// `[1, H+1]` selector with 1.0 in the intercept slot, for the terms that land
+    /// on the intercept alone.
+    pub(super) intercept_mask: Tensor,
+    /// `ln(Σ_f exp(β_f) + dead_mass)` over this pass's rows — a per-pass constant,
+    /// so it is summed here rather than over every live feature in every block.
+    pub(super) null_log_norm: f64,
+    /// Gate-folded partition mass `Σ_dead exp(β_f)`; 0 at the default
+    /// [`GATE_FOLD_EPS`], where nothing is folded.
+    pub(super) dead_mass: f64,
+    /// Auto-scaled initial learning rate — a property of the dictionary's scale (see
+    /// [`TARGET_DELTA_S`]), not of the nodes.
+    pub(super) lr0: f64,
+    /// Cells per block, from the activation budget and this pass's feature count.
+    block_cells: usize,
+    /// Carried so the block loop and any streaming caller report the same pass the
+    /// dictionary was built for.
+    label: &'static str,
+    pass: &'static str,
+}
+
+impl PassDict {
+    /// Build the frozen design for one pass over `rows`.
+    pub(crate) fn build(spec: &DictSpec, rows: Vec<u32>) -> anyhow::Result<Self> {
+        let (h, dev) = (spec.h, spec.dev);
+
+        // Split the partition into the live rows (which go into the matmul) and the
+        // gate-folded rows (whose partition mass is a constant).
+        let mut live: Vec<u32> = Vec::with_capacity(rows.len());
+        let mut dead_mass = 0f64;
+        for &g in &rows {
+            let e = &spec.feat[g as usize * h..(g as usize + 1) * h];
+            if e.iter().map(|x| x * x).sum::<f32>().sqrt() > GATE_FOLD_EPS {
+                live.push(g);
+            } else {
+                dead_mass += f64::from(spec.b_feat[g as usize]).exp();
+            }
+        }
+        anyhow::ensure!(
+            !live.is_empty(),
+            "phase-2 {}: every feature in this pass is gate-folded — the frozen \
+             dictionary carries no signal to project onto",
+            spec.pass
+        );
+
+        let f_live = live.len();
+        let d = h + 1;
+        let mut e_aug = vec![0f32; d * f_live];
+        let mut b_live = vec![0f32; f_live];
+        for (l, &g) in live.iter().enumerate() {
+            let row = &spec.feat[g as usize * h..(g as usize + 1) * h];
+            for (k, &v) in row.iter().enumerate() {
+                e_aug[k * f_live + l] = v;
+            }
+            e_aug[h * f_live + l] = 1.0; // intercept row
+            b_live[l] = spec.b_feat[g as usize];
+        }
+        let e_aug = Tensor::from_vec(e_aug, (d, f_live), dev)?;
+        let e_aug_t = e_aug.t()?.contiguous()?;
+        let b_row = Tensor::from_vec(b_live, (1, f_live), dev)?;
+
+        let null_log_norm = (f64::from(b_row.exp()?.sum_all()?.to_scalar::<f32>()?) + dead_mass)
+            .max(f64::MIN_POSITIVE)
+            .ln();
+
+        let intercept_mask = {
+            let mut v = vec![0f32; d];
+            v[h] = 1.0;
+            Tensor::from_vec(v, (1, d), dev)?
+        };
+
+        // Global → live-local feature id, for remapping the pass's edges.
+        let mut to_live = vec![u32::MAX; spec.b_feat.len()];
+        for (l, &g) in live.iter().enumerate() {
+            to_live[g as usize] = l as u32;
+        }
+
+        // Auto-scale the learning rate to the dictionary. Adam's per-coordinate step
+        // is ≈ lr, so a step moves the linear predictor by `Δs ≈ lr · H · rms(e)`;
+        // pinning `Δs` makes the schedule invariant to the `β ↔ θ` scale duality that
+        // otherwise leaves `lr` either useless or divergent.
+        // `ẽ` is the ARITHMETIC mean |e|, not the RMS. A step `Δθ` moves gene `f`'s score
+        // by `Δs_f = ⟨e_f, Δθ⟩ ≈ lr·h·E|e|`, so inverting THAT is what pins `Δs` at the
+        // target. Using `√E[e²]` instead delivers `TARGET_DELTA_S/κ` with
+        // `κ = √E[e²]/E|e| ≥ 1` — it calibrates on the loudest genes while most of a
+        // cell's likelihood rides on the median one. Measured on real fits `κ` ran
+        // 2.8–66, i.e. 2–35% of the intended step, and `cor(log κ, kNN purity) = −0.93`
+        // over 12 fits: large `κ` ⇒ blocks hit the step cap ⇒ under-converged `θ`.
+        // Both estimators are scale-free (a uniform `E → αE` cancels), so this is about
+        // the TAIL, not the magnitude.
+        let e_mean = {
+            let sa: f64 = live
+                .iter()
+                .flat_map(|&g| &spec.feat[g as usize * h..(g as usize + 1) * h])
+                .map(|x| f64::from(*x).abs())
+                .sum();
+            (sa / (f_live * h) as f64).max(1e-12)
+        };
+        let lr0 = TARGET_DELTA_S / (h as f64 * e_mean);
+
+        // Sized from the WHOLE partition, not the live subset: the gate fold shrinks
+        // the matmul but the budget it is bounding is the block's, and a dictionary
+        // whose fold is disabled must land on the same `Bc`.
+        let block_cells = block_cells(rows.len());
+
+        info!(
+            "{} [{}] — {f_live} live features (of {}; {} gate-folded), blocks of \
+             {block_cells}, lr {:.4} (auto: Δs≈{TARGET_DELTA_S}), ≤{MAX_STEPS} steps, \
+             ridge λ={}",
+            spec.label,
+            spec.pass,
+            rows.len(),
+            rows.len() - f_live,
+            lr0,
+            spec.lambda,
+        );
+
+        Ok(Self {
+            rows,
+            to_live,
+            e_aug,
+            e_aug_t,
+            b_row,
+            intercept_mask,
+            null_log_norm,
+            dead_mass,
+            lr0,
+            block_cells,
+            label: spec.label,
+            pass: spec.pass,
+        })
+    }
+
+    /// The feature partition this dictionary was built over — what an [`EdgeTable`]
+    /// must be flattened against for its local ids to line up.
+    pub(crate) fn rows(&self) -> &[u32] {
+        &self.rows
+    }
+
+    /// Nodes a streaming caller should hand one [`super::project_prepared`] call.
+    ///
+    /// A whole number of blocks, so a caller that cuts its groups here never leaves
+    /// the engine a short trailing block; [`GROUP_BLOCKS`] of them, so the per-call
+    /// host work either side of the solve is spread over a run of blocks rather than
+    /// one. Both bounds live here because both derive from `Bc`, which is derived in
+    /// turn from an activation budget only this module can see — a caller guessing
+    /// at it in its own currency is guessing against numbers it cannot read.
+    pub(crate) fn group_nodes(&self) -> usize {
+        self.block_cells * GROUP_BLOCKS
+    }
+}
+
+//////////////////////
+// One phase-2 pass //
+//////////////////////
+
+/// The per-call half of a pass: which nodes' edges, and what they are solved
+/// against. The dictionary half is [`PassDict`].
 pub(super) struct PassSpec<'a> {
-    pub(super) label: &'static str,
-    /// This pass's feature partition on the global feature axis.
-    pub(super) rows: &'a [u32],
     pub(super) edges: &'a EdgeTable,
     /// Fixed identity `θ` (host, `[n_kept × h]`) folded into the per-edge offset —
     /// `Some` only on the velocity pass.
     pub(super) base_theta: Option<&'a [f32]>,
-    pub(super) block_cells: usize,
 }
 
 /// One pass's per-cell result, indexed by position in `cells` (not by global id).
@@ -32,135 +238,32 @@ pub(super) struct PassOut {
 
 pub(super) fn run_pass(
     input: &Phase2Input,
+    dict: &PassDict,
     spec: &PassSpec,
     cells: &[(u32, &[u32], &[f32])],
     bar: &indicatif::ProgressBar,
 ) -> anyhow::Result<PassOut> {
-    let (h, dev) = (input.h, input.dev);
+    let h = input.h;
     let n_kept = cells.len();
-
-    // Split this pass's partition into the live rows (which go into the matmul)
-    // and the gate-folded rows (whose partition mass is a constant).
-    let mut live: Vec<u32> = Vec::with_capacity(spec.rows.len());
-    let mut dead_mass = 0f64;
-    for &g in spec.rows {
-        let e = &input.feat[g as usize * h..(g as usize + 1) * h];
-        if e.iter().map(|x| x * x).sum::<f32>().sqrt() > GATE_FOLD_EPS {
-            live.push(g);
-        } else {
-            dead_mass += f64::from(input.b_feat[g as usize]).exp();
-        }
-    }
-    anyhow::ensure!(
-        !live.is_empty(),
-        "phase-2 {}: every feature in this pass is gate-folded — the frozen \
-         dictionary carries no signal to project onto",
-        spec.label
-    );
-
-    // Frozen, shared by every block: the transposed live dictionary, and its bias.
-    //
-    // **Augmented with a row of ones**, `Ẽᵀ = [Eᵀ ; 1]` of shape `[H+1, F]`, so the
-    // per-cell intercept rides in as the last column of the parameter matrix rather
-    // than as a separate broadcast add. That removes a whole `[Bc, F]` op (and, more
-    // to the point, makes the intercept's gradient fall out of the same matmul as
-    // the latent's — the ones row sums `μ` over features, which is exactly `∂/∂c`).
-    let f_live = live.len();
-    let d = h + 1;
-    let mut e_aug = vec![0f32; d * f_live];
-    let mut b_live = vec![0f32; f_live];
-    for (l, &g) in live.iter().enumerate() {
-        let row = &input.feat[g as usize * h..(g as usize + 1) * h];
-        for (k, &v) in row.iter().enumerate() {
-            e_aug[k * f_live + l] = v;
-        }
-        e_aug[h * f_live + l] = 1.0; // intercept row
-        b_live[l] = input.b_feat[g as usize];
-    }
-    // Both orientations are needed every step — `Θ̃·Ẽᵀ` forward and `μ·Ẽ` for the
-    // gradient — so materialize the transpose once here rather than per step.
-    let e_aug = Tensor::from_vec(e_aug, (d, f_live), dev)?;
-    let e_aug_t = e_aug.t()?.contiguous()?;
-    let b_row = Tensor::from_vec(b_live, (1, f_live), dev)?;
-
-    // `Σ_f exp(β_f)` over the live rows: a per-PASS constant, so it is summed here
-    // rather than over every live feature in every block.
-    let null_log_norm = (f64::from(b_row.exp()?.sum_all()?.to_scalar::<f32>()?) + dead_mass)
-        .max(f64::MIN_POSITIVE)
-        .ln();
-
-    // `[1, H+1]` selector for the intercept slot.
-    let intercept_mask = {
-        let mut v = vec![0f32; d];
-        v[h] = 1.0;
-        Tensor::from_vec(v, (1, d), dev)?
-    };
-
-    // Global → live-local feature id, for remapping the pass's edges.
-    let mut to_live = vec![u32::MAX; input.b_feat.len()];
-    for (l, &g) in live.iter().enumerate() {
-        to_live[g as usize] = l as u32;
-    }
-
-    // Auto-scale the learning rate to the dictionary. Adam's per-coordinate step
-    // is ≈ lr, so a step moves the linear predictor by `Δs ≈ lr · H · rms(e)`;
-    // pinning `Δs` makes the schedule invariant to the `β ↔ θ` scale duality that
-    // otherwise leaves `lr` either useless or divergent.
-    // `ẽ` is the ARITHMETIC mean |e|, not the RMS. A step `Δθ` moves gene `f`'s score
-    // by `Δs_f = ⟨e_f, Δθ⟩ ≈ lr·h·E|e|`, so inverting THAT is what pins `Δs` at the
-    // target. Using `√E[e²]` instead delivers `TARGET_DELTA_S/κ` with
-    // `κ = √E[e²]/E|e| ≥ 1` — it calibrates on the loudest genes while most of a
-    // cell's likelihood rides on the median one. Measured on real fits `κ` ran
-    // 2.8–66, i.e. 2–35% of the intended step, and `cor(log κ, kNN purity) = −0.93`
-    // over 12 fits: large `κ` ⇒ blocks hit the step cap ⇒ under-converged `θ`.
-    // Both estimators are scale-free (a uniform `E → αE` cancels), so this is about
-    // the TAIL, not the magnitude.
-    let e_mean = {
-        let sa: f64 = live
-            .iter()
-            .flat_map(|&g| &input.feat[g as usize * h..(g as usize + 1) * h])
-            .map(|x| f64::from(*x).abs())
-            .sum();
-        (sa / (f_live * h) as f64).max(1e-12)
-    };
-    let lr0 = TARGET_DELTA_S / (h as f64 * e_mean);
-
-    info!(
-        "{} [{}] — {n_kept} node(s) × {f_live} live features (of {}; {} gate-folded), \
-         blocks of {}, lr {:.4} (auto: Δs≈{TARGET_DELTA_S}), ≤{MAX_STEPS} steps, ridge λ={}",
-        input.label,
-        spec.label,
-        spec.rows.len(),
-        spec.rows.len() - f_live,
-        spec.block_cells,
-        lr0,
-        input.lambda,
-    );
+    let bc = dict.block_cells;
 
     let mut latent = vec![0f32; n_kept * h];
     let mut intercept = vec![0f32; n_kept];
     let mut stats = PassStats::default();
-    let n_blocks = n_kept.div_ceil(spec.block_cells);
+    let n_blocks = n_kept.div_ceil(bc);
 
-    for (b, start) in (0..n_kept).step_by(spec.block_cells).enumerate() {
-        let end = (start + spec.block_cells).min(n_kept);
+    for (b, start) in (0..n_kept).step_by(bc).enumerate() {
+        let end = (start + bc).min(n_kept);
         let block = solve_block(BlockArgs {
             input,
+            dict,
             spec,
-            to_live: &to_live,
-            e_aug: &e_aug,
-            e_aug_t: &e_aug_t,
-            b_row: &b_row,
-            intercept_mask: &intercept_mask,
-            null_log_norm,
-            dead_mass,
-            lr0,
             start,
             end,
             progress: &BlockProgress {
                 bar,
                 stats: &stats,
-                label: spec.label,
+                label: dict.pass,
                 block: b + 1,
                 n_blocks,
             },
@@ -171,10 +274,10 @@ pub(super) fn run_pass(
     }
 
     info!(
-        "{} [{}] — done: ⌀{:.0} steps/block, {} of {} block(s) hit the {MAX_STEPS}-step cap, \
-         mean per-edge deviance {:.4}, {:.0}s total ({:.1} ms/step){}",
-        input.label,
-        spec.label,
+        "{} [{}] — {n_kept} node(s) done: ⌀{:.0} steps/block, {} of {} block(s) hit the \
+         {MAX_STEPS}-step cap, mean per-edge deviance {:.4}, {:.0}s total ({:.1} ms/step){}",
+        dict.label,
+        dict.pass,
         stats.mean_steps(),
         stats.at_cap,
         stats.blocks,
@@ -227,11 +330,12 @@ impl PassStats {
 
 /// The shared progress bar plus what the in-flight block needs to describe itself.
 ///
-/// The bar counts **cells** across both passes. A block advances it *as it steps*,
-/// pro-rata on its step budget, so the bar keeps moving through a block that takes
-/// hundreds of Adam steps instead of jumping once per block — with `Bc` sized for
-/// speed a whole pass is only a handful of blocks, and per-block ticks would be
-/// nearly no feedback at all.
+/// The bar counts **cells** across every pass that shares it — including, on the
+/// streaming path, the caller's own bar across every group. A block advances it *as
+/// it steps*, pro-rata on its step budget, so the bar keeps moving through a block
+/// that takes hundreds of Adam steps instead of jumping once per block — with `Bc`
+/// sized for speed a whole pass is only a handful of blocks, and per-block ticks
+/// would be nearly no feedback at all.
 pub(super) struct BlockProgress<'a> {
     pub(super) bar: &'a indicatif::ProgressBar,
     /// Stats from the blocks already finished in this pass.
@@ -273,27 +377,15 @@ impl BlockProgress<'_> {
     }
 }
 
-//////////////////
+///////////////
 // One block //
-//////////////////
+///////////////
 
 pub(super) struct BlockArgs<'a> {
     pub(super) input: &'a Phase2Input<'a>,
+    /// The frozen design every block of this pass shares.
+    pub(super) dict: &'a PassDict,
     pub(super) spec: &'a PassSpec<'a>,
-    pub(super) to_live: &'a [u32],
-    /// Augmented dictionary `Ẽᵀ [H+1, F]` (ones row last) and its transpose
-    /// `Ẽ [F, H+1]` — both built once per pass, shared by every block.
-    pub(super) e_aug: &'a Tensor,
-    pub(super) e_aug_t: &'a Tensor,
-    /// Frozen feature bias as a `[1, F]` row, shared by every block.
-    pub(super) b_row: &'a Tensor,
-    /// `[1, H+1]` selector with 1.0 in the intercept slot, for the terms that land
-    /// on the intercept alone.
-    pub(super) intercept_mask: &'a Tensor,
-    /// `ln(Σ_f exp(β_f) + dead_mass)` — a per-pass constant.
-    pub(super) null_log_norm: f64,
-    pub(super) dead_mass: f64,
-    pub(super) lr0: f64,
     pub(super) start: usize,
     pub(super) end: usize,
     pub(super) progress: &'a BlockProgress<'a>,

--- a/graph-embedding-util/src/fit/projection/block_sgd/solve.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/solve.rs
@@ -13,8 +13,9 @@ pub(super) fn solve_block(a: BlockArgs) -> anyhow::Result<BlockOut> {
     let (h, dev) = (a.input.h, a.input.dev);
     let bc = a.end - a.start;
     let d = h + 1; // [Θ | c]
-    let f_live = a.b_row.dim(1)?;
-    let (e_aug, e_aug_t, intercept_mask) = (a.e_aug, a.e_aug_t, a.intercept_mask);
+    let dict = a.dict;
+    let f_live = dict.b_row.dim(1)?;
+    let (e_aug, e_aug_t, intercept_mask) = (&dict.e_aug, &dict.e_aug_t, &dict.intercept_mask);
 
     ///////////////////////////////////////
     // Gather the block's observed edges //
@@ -35,8 +36,8 @@ pub(super) fn solve_block(a: BlockArgs) -> anyhow::Result<BlockOut> {
         let (feats, counts) = a.spec.edges.cell_slice(i);
         for (&f_pass, &n) in feats.iter().zip(counts) {
             // `edges` are indexed on the pass partition; map to the live subset.
-            let g = a.spec.rows[f_pass as usize];
-            let l = a.to_live[g as usize];
+            let g = dict.rows()[f_pass as usize];
+            let l = dict.to_live[g as usize];
             n_tot[local] += f64::from(n);
             if l == u32::MAX {
                 n_dead[local] += n;
@@ -73,9 +74,9 @@ pub(super) fn solve_block(a: BlockArgs) -> anyhow::Result<BlockOut> {
             // Only the latent rows of `Ẽᵀ` — the ones row is the intercept's, and
             // the fixed identity carries no intercept of its own.
             t.matmul(&e_aug.narrow(0, 0, h)?.contiguous()?)?
-                .broadcast_add(a.b_row)?
+                .broadcast_add(&dict.b_row)?
         }
-        None => a.b_row.clone(),
+        None => dict.b_row.clone(),
     };
 
     ///////////////////////////////
@@ -99,7 +100,7 @@ pub(super) fn solve_block(a: BlockArgs) -> anyhow::Result<BlockOut> {
             .collect(),
         // Identity pass: Θ = 0 ⇒ every row shares the same Σ_f exp(β_f), hoisted to
         // the pass rather than re-summed over every live feature in every block.
-        None => vec![a.null_log_norm; bc],
+        None => vec![dict.null_log_norm; bc],
     };
     // Θ̃ = [Θ | c] — the latent and its intercept in ONE `[Bc, H+1]` parameter, with
     // the intercept initialised at the null model and the latent at zero.
@@ -125,7 +126,7 @@ pub(super) fn solve_block(a: BlockArgs) -> anyhow::Result<BlockOut> {
     let ne = {
         let mut ne = n_t.matmul(e_aug_t)?; // [Bc, H+1]
                                            // Folded rows still owe `−n_dead·c`, which lands on the intercept column.
-        if a.dead_mass > 0.0 {
+        if dict.dead_mass > 0.0 {
             ne = (ne + n_dead_t.reshape((bc, 1))?.broadcast_mul(intercept_mask)?)?;
         }
         ne
@@ -174,7 +175,7 @@ pub(super) fn solve_block(a: BlockArgs) -> anyhow::Result<BlockOut> {
     for step in 0..MAX_STEPS {
         // Linear decay to a floor so the block settles rather than dithers.
         let frac = step as f64 / MAX_STEPS as f64;
-        let lr = a.lr0 * (1.0 - frac * (1.0 - LR_FLOOR_FRAC));
+        let lr = dict.lr0 * (1.0 - frac * (1.0 - LR_FLOOR_FRAC));
 
         // Upper bound only. `exp` overflows f32 at 88 so the ceiling is a real
         // guard; the floor is not, since `exp(−large)` underflowing to 0 is the
@@ -192,8 +193,8 @@ pub(super) fn solve_block(a: BlockArgs) -> anyhow::Result<BlockOut> {
         // intercept column comes out of the same matmul via `Ẽ`'s ones row, and
         // picks up the gate-folded partition mass `exp(c)·Σ_dead exp(β_f)`.
         let mut g = ((mu.matmul(e_aug_t)? - &ne)? + theta.broadcast_mul(&lam_row)?)?;
-        if a.dead_mass > 0.0 {
-            let dead = theta.narrow(1, h, 1)?.exp()?.affine(a.dead_mass, 0.0)?;
+        if dict.dead_mass > 0.0 {
+            let dead = theta.narrow(1, h, 1)?.exp()?.affine(dict.dead_mass, 0.0)?;
             g = (g + dead.broadcast_mul(intercept_mask)?)?;
         }
 

--- a/senna/Cargo.toml
+++ b/senna/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.11.0"
+version = "0.11.1"
 
 [lib]
 name = "senna"

--- a/senna/src/bge/score.rs
+++ b/senna/src/bge/score.rs
@@ -12,7 +12,7 @@
 //! [`crate::run_manifest::resolve_feature_loading_for`] exists because three consumers each
 //! probed for ρ independently and each broke differently. Go through it. Note it returns
 //! `(ρ_path, bias_path)` and `deconvolve` discards the second — a probe needs both, since
-//! `(ρ, b_feat)` is exactly the frozen side that `project_onto_frozen` and
+//! `(ρ, b_feat)` is exactly the frozen side that [`FrozenProjector`] and
 //! [`graph_embedding_util::posterior::multinomial_ll`] consume.
 //!
 //! `--skip-etm` is **not** required. It used to be, before `feature_loading.parquet` always
@@ -24,7 +24,7 @@ use crate::topic::eval::{build_gene_remap_with, QueryNameOpts};
 use anyhow::Context;
 use auxiliary_data::data_loading::{read_data_on_shared_rows, ReadSharedRowsArgs};
 use data_beans::sparse_io_vector::SparseIoVec;
-use graph_embedding_util::fit::{project_onto_frozen, FrozenProjectionArgs, PROJECTION_RIDGE_SGD};
+use graph_embedding_util::fit::{FrozenProjectionArgs, FrozenProjector, PROJECTION_RIDGE_SGD};
 // `multinomial_ll` is not in `posterior`'s re-export list (only `poisson_ll` is), so it comes
 // from the module directly. It is the one we want — see `BgeModel::score`.
 use crate::embed_common::Mat;
@@ -37,23 +37,6 @@ use matrix_util::traits::IoOps;
 use nalgebra::DMatrix;
 use rayon::prelude::*;
 use std::path::Path;
-
-/// Host memory a projection group may hold in its remapped edges before it is handed to
-/// the SGD. Not a device bound — the engine does its own activation-budget blocking
-/// underneath — but a bound on what this side keeps resident.
-///
-/// Generous on purpose: it has to clear the engine's own block size by a wide margin, or
-/// there is only ever one block per call and the setup cost is paid per handful of cells.
-///
-/// Not [`matrix_util::utils::byte_budget_intervals`], which cuts the same kind of block
-/// from a budget but needs every column's nnz up front — `SparseIoVec` exposes only a
-/// total, so the count is only known here as the columns are read.
-const PROJECTION_GROUP_BYTES: usize = 512 << 20;
-
-/// Bytes a single nonzero costs while a group is in flight: 8 in [`EdgeGroup`]'s split
-/// `feat` / `count`, and 8 again in the `EdgeTable` the SGD builds from them, which is
-/// live at the same time.
-const GROUP_BYTES_PER_NNZ: usize = 16;
 
 /// An opened `senna bge` model: the frozen feature side, and the gene axis it lives on.
 pub struct BgeEmbedding {
@@ -203,33 +186,47 @@ impl BgeEmbedding {
             h: self.h,
         };
 
+        // The whole per-dictionary setup — the transposed design, the live-feature scan,
+        // the null normalizer, the learning rate — happens once, here, instead of on
+        // every projection call.
+        let projector = FrozenProjector::new(&FrozenProjectionArgs {
+            feat: &self.rho,
+            b_feat: &self.b_feat,
+            h: self.h,
+            lambda: f64::from(PROJECTION_RIDGE_SGD),
+            dev,
+        })?;
+
         let ntot = data_vec.num_columns();
         let mut llik = Vec::with_capacity(ntot);
         let mut total = Vec::with_capacity(ntot);
         let mut latent = Mat::zeros(ntot, self.h);
+        // ONE bar for the query. The projector advances it as its blocks step, so this
+        // side never increments it: nesting a second bar under it (one per projection
+        // call) is what the group loop used to do.
         let bar = new_progress_bar(ntot as u64).with_message("scoring");
 
         // Columns are READ in `block`-sized slabs — that bound is the reader's — but they
-        // are PROJECTED in groups accumulated up to [`PROJECTION_GROUP_BYTES`].
+        // are PROJECTED in groups the engine sizes.
         //
-        // The two sizes are not the same thing and used to be conflated. `block` is
-        // `--minibatch-size`, default 500; the projection engine sizes its own internal
-        // blocks from its activation budget and takes thousands of cells at a time. Handing
-        // it 500 gave it exactly one under-sized block per call, so its per-step matmul ran
-        // on a short `M` and every call re-paid the whole per-pass setup: the transposed
-        // dictionary, the live-feature scan, a progress bar and a log line, ~70 times over
-        // for a query of a few tens of thousands of cells.
-        let nnz_budget = PROJECTION_GROUP_BYTES / GROUP_BYTES_PER_NNZ;
+        // The two are not the same thing and used to be conflated. `block` is
+        // `--minibatch-size`, default 500; the projection engine sizes its internal blocks
+        // from an activation budget of its own and takes thousands of cells at a time.
+        // Handing it 500 gave it exactly one under-sized block per call, so its per-step
+        // matmul ran on a short `M`. The fix used to be a byte budget guessed here, in
+        // nonzeros — a currency the engine never sees, aimed at a block size this crate
+        // cannot read. [`FrozenProjector::group_nodes`] is that number in the engine's own
+        // terms, and cutting the group EXACTLY there is what keeps every block full.
+        let group_nodes = projector.group_nodes();
         let mut group = EdgeGroup::default();
 
         let mut lb = 0usize;
         while lb < ntot {
             let group_lb = lb;
-            // Accumulate slabs until the group is worth projecting. The inner loop's
-            // exit condition IS the flush condition, so a part-group at the end needs
-            // no special case.
-            while lb < ntot && group.nnz() < nnz_budget {
-                let ub = (lb + block).min(ntot);
+            // Accumulate slabs until the group is full. The inner loop's exit condition
+            // IS the flush condition, so a part-group at the end needs no special case.
+            while lb < ntot && group.len() < group_nodes {
+                let ub = (lb + block).min(group_lb + group_nodes).min(ntot);
                 let csc = data_vec.read_columns_csc(lb..ub)?;
                 // One walk per cell yields both the remapped entries and the cell's
                 // total; the total used to be a third pass over the same nonzeros.
@@ -257,7 +254,7 @@ impl BgeEmbedding {
             }
 
             let n_group = group.len();
-            let e_cell = self.project_group(&group, dev)?;
+            let e_cell = project_group(&projector, &group, &bar)?;
             // `multinomial_ll` walks the whole gene axis twice per cell for the
             // normalizer, which makes it the dominant cost here — and it sat serial
             // directly below `project_cells`, which is already rayon-parallel. Everything
@@ -279,7 +276,6 @@ impl BgeEmbedding {
                     latent[(group_lb + c, j)] = e_cell[c * self.h + j];
                 }
             }
-            bar.inc(n_group as u64);
             group.clear();
         }
         bar.finish_and_clear();
@@ -291,33 +287,26 @@ impl BgeEmbedding {
             latent,
         })
     }
+}
 
-    /// Project one group of cells onto the frozen side, returning `θ` row-major `[n, H]`.
-    ///
-    /// The SAME block SGD the training run used for its own phase 2. The Newton/IRLS
-    /// alternative fits a cell's observed features only and lets a ridge stand in for the
-    /// log-partition, so it lands in a different space — and a train/test comparison whose
-    /// two halves were projected differently measures the estimator gap as much as the model.
-    fn project_group(&self, group: &EdgeGroup, dev: &Device) -> anyhow::Result<Vec<f32>> {
-        let nodes: Vec<(u32, &[u32], &[f32])> = (0..group.len())
-            .map(|j| {
-                let (feat, count) = group.cell(j);
-                (j as u32, feat, count)
-            })
-            .collect();
-        let fit = project_onto_frozen(
-            &FrozenProjectionArgs {
-                feat: &self.rho,
-                b_feat: &self.b_feat,
-                h: self.h,
-                lambda: f64::from(PROJECTION_RIDGE_SGD),
-                dev,
-            },
-            &nodes,
-            group.len(),
-        )?;
-        Ok(fit.theta)
-    }
+/// Project one group of cells onto the frozen side, returning `θ` row-major `[n, H]`.
+///
+/// The SAME block SGD the training run used for its own phase 2. The Newton/IRLS
+/// alternative fits a cell's observed features only and lets a ridge stand in for the
+/// log-partition, so it lands in a different space — and a train/test comparison whose
+/// two halves were projected differently measures the estimator gap as much as the model.
+fn project_group(
+    projector: &FrozenProjector,
+    group: &EdgeGroup,
+    bar: &indicatif::ProgressBar,
+) -> anyhow::Result<Vec<f32>> {
+    let nodes: Vec<(u32, &[u32], &[f32])> = (0..group.len())
+        .map(|j| {
+            let (feat, count) = group.cell(j);
+            (j as u32, feat, count)
+        })
+        .collect();
+    Ok(projector.project(&nodes, group.len(), bar)?.theta)
 }
 
 /// One projection group's remapped edges, flat and split.
@@ -337,10 +326,6 @@ struct EdgeGroup {
 impl EdgeGroup {
     fn len(&self) -> usize {
         self.offsets.len().saturating_sub(1)
-    }
-
-    fn nnz(&self) -> usize {
-        self.feat.len()
     }
 
     fn cell(&self, i: usize) -> (&[u32], &[f32]) {


### PR DESCRIPTION
`senna predict` sized its projection groups from two local constants aimed at four private ones inside the block SGD. Wrong crate, wrong currency: the engine budgets `Bc × F_live` activations, senna budgeted nonzeros, and the map between them depends on query density neither side can see. Nothing linked the two, so any move in the engine's numbers would have silently restored one under-sized block per call — the bug the constants were added to fix.

The group only had to be large because the per-call setup was large. Split the pass in two: `PassDict` holds everything derived from the frozen dictionary — the augmented design in both orientations, the live-feature scan and gate fold, the null normalizer, the auto-scaled lr, the block size — and `run_pass` holds the block loop over whichever nodes arrive. `FrozenProjector` builds the first once and exposes `project` plus `group_nodes`, so the caller asks for a size derived from the activation budget instead of guessing against it. Both constants are gone from senna, and its own progress bar is now the only one.

`group_nodes` is a whole number of blocks, which is what makes grouping unobservable: blocks are cut at multiples of `Bc` from each group's start, so a caller cutting there reproduces the block partition of a single call over the whole query. That matters because a block's cells share a convergence test and a step cap, so a ragged group would move the answer, not just waste steps.

Verified byte-identical on CPU and CUDA, single-group and multi-group; the CUDA path also gains from uploading the design once per model rather than per call. New tests cover the two-entry-point equality and the block alignment.

Patch bumps: graph-embedding-util 0.3.19 (public API: `project_onto_frozen` is replaced by `FrozenProjector`), senna 0.11.1.