### PR TITLE
Gene modules, unseen-gene initialization, and a batch-free collapse frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graph-embedding-util"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "anyhow",
  "auxiliary-data",
@@ -4274,7 +4274,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -4994,7 +4994,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "senna"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "auxiliary-data"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "data-beans-alg"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graph-embedding-util"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "anyhow",
  "auxiliary-data",
@@ -4274,7 +4274,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinto"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -4994,7 +4994,7 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "senna"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "data-beans"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "approx",

--- a/auxiliary-data/Cargo.toml
+++ b/auxiliary-data/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Auxiliary data types: cell annotations, batch metadata, and pseudobulk routines"
 
-version = "0.1.13"
+version = "0.1.14"
 
 [dependencies]
 data-beans = { workspace = true }

--- a/auxiliary-data/src/frozen_features.rs
+++ b/auxiliary-data/src/frozen_features.rs
@@ -41,6 +41,11 @@ pub struct FrozenFeatureHost {
     /// `keep_target_indices` — what a caller needs to look up any other table
     /// keyed on the dictionary's rows (a module membership, say).
     pub keep_src_indices: Vec<usize>,
+    /// The whole source table `[n_src, H]` and its row names, as read — so a
+    /// caller that needs the unmatched rows too (to place a gene by its
+    /// neighbours' rows) does not decode the file a second time.
+    pub src_e_feat: DMatrix<f32>,
+    pub src_names: Vec<Box<str>>,
     /// Rows in the dictionary file, i.e. how many features the MODEL has.
     ///
     /// The only field that survives the intersection unfiltered, and the reason
@@ -187,6 +192,8 @@ pub fn load_frozen_feature_host(args: FrozenLoadArgs) -> anyhow::Result<FrozenFe
         b_feat,
         keep_target_indices,
         keep_src_indices,
+        src_e_feat: dict.mat,
+        src_names: dict.rows,
         n_src,
         h,
     })

--- a/auxiliary-data/src/frozen_features.rs
+++ b/auxiliary-data/src/frozen_features.rs
@@ -37,6 +37,10 @@ pub struct FrozenFeatureHost {
     /// Indices into the *target* feature axis that matched a source row.
     /// Length equals `e_feat.nrows()`.
     pub keep_target_indices: Vec<usize>,
+    /// The *source* (dictionary) row each kept target row came from, parallel to
+    /// `keep_target_indices` — what a caller needs to look up any other table
+    /// keyed on the dictionary's rows (a module membership, say).
+    pub keep_src_indices: Vec<usize>,
     /// Rows in the dictionary file, i.e. how many features the MODEL has.
     ///
     /// The only field that survives the intersection unfiltered, and the reason
@@ -182,6 +186,7 @@ pub fn load_frozen_feature_host(args: FrozenLoadArgs) -> anyhow::Result<FrozenFe
         e_feat,
         b_feat,
         keep_target_indices,
+        keep_src_indices,
         n_src,
         h,
     })

--- a/data-beans-alg/Cargo.toml
+++ b/data-beans-alg/Cargo.toml
@@ -3,7 +3,7 @@ name = "data-beans-alg"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
-version = "0.4.1"
+version = "0.4.2"
 description = "random projection and collapsing routines"
 
 [features]

--- a/data-beans-alg/src/collapse_data/mod.rs
+++ b/data-beans-alg/src/collapse_data/mod.rs
@@ -489,6 +489,8 @@ impl CollapsingOps for SparseIoVec {
         reference_indices: Option<&[usize]>,
         stat: &mut CollapsedStat,
     ) -> anyhow::Result<()> {
+        // The reference batches source the counterfactual and pin δ.
+        stat.anchor_batches = reference_indices.map(<[usize]>::to_vec).unwrap_or_default();
         self.visit_columns_by_group(
             &collect_matched_stat_visitor,
             &KnnParams {

--- a/data-beans-alg/src/collapse_data/pb_samples.rs
+++ b/data-beans-alg/src/collapse_data/pb_samples.rs
@@ -459,7 +459,7 @@ pub(super) fn per_batch_sc_neighbors(
 }
 
 /// Match pb-samples across batches and accumulate counterfactual
-/// statistics into `stat.imputed_sum_ds` and `stat.residual_sum_ds`.
+/// statistics into `stat.imputed_sum_ds` and `stat.matched_bs`.
 ///
 /// `pbsamp_to_group` is the per-pb-sample group assignment to use when writing
 /// into stat columns; callers pass `&layout.pb_sample_to_group` for the

--- a/data-beans-alg/src/collapse_data/stats.rs
+++ b/data-beans-alg/src/collapse_data/stats.rs
@@ -16,6 +16,7 @@
 //! (`merge_stat`).
 
 use super::*;
+use nalgebra::DVector;
 
 pub(super) struct KnnParams<'a> {
     pub(super) knn_batches: usize,
@@ -52,8 +53,6 @@ pub(super) fn collect_matched_stat_visitor(
         }
     };
 
-    let mut y1 = data_vec.read_columns_csc(cells.iter().cloned())?;
-
     let y1_pos: HashMap<_, _> = cells
         .iter()
         .cloned()
@@ -78,29 +77,28 @@ pub(super) fn collect_matched_stat_visitor(
     // weight vector
     let ww = CscMat::from_nonzero_triplets(
         y0_matched.ncols(),
-        y1.ncols(),
+        cells.len(),
         neg_distance_triplets.as_ref(),
     )?
     .normalize_exp_logits_columns();
 
-    let y1_hat = &y0_matched * ww;
-    y1.adjust_by_division_inplace(&y1_hat);
+    let y1_hat = &y0_matched * &ww;
+    let source_batches = data_vec.get_batch_membership(source_columns.iter().cloned());
 
     let mut stat = arc_stat.lock().expect("lock stat");
+
+    // Source mass per batch: each cell's weights sum to 1 over its matches.
+    for w_j in ww.col_iter() {
+        for (&k, &w) in w_j.row_indices().iter().zip(w_j.values().iter()) {
+            stat.matched_bs[(source_batches[k], sample)] += w;
+        }
+    }
 
     for y_j in y1_hat.col_iter() {
         let rows = y_j.row_indices();
         let vals = y_j.values();
         for (&gene, &y) in rows.iter().zip(vals.iter()) {
             stat.imputed_sum_ds[(gene, sample)] += y;
-        }
-    }
-
-    for y_j in y1.col_iter() {
-        let rows = y_j.row_indices();
-        let vals = y_j.values();
-        for (&gene, &y) in rows.iter().zip(vals.iter()) {
-            stat.residual_sum_ds[(gene, sample)] += y;
         }
     }
 
@@ -187,20 +185,44 @@ fn add_effective_size(denom_ds: &mut nalgebra::DMatrix<f32>, stat: &CollapsedSta
     }
 }
 
-/// `denom *= effective size`, elementwise — same dispatch as
-/// [`add_effective_size`].
-fn scale_by_effective_size(denom_ds: &mut nalgebra::DMatrix<f32>, stat: &CollapsedStat) {
-    match stat.size_ds.as_ref() {
-        Some(size_ds) => {
-            debug_assert_eq!(denom_ds.shape(), size_ds.shape());
-            denom_ds.component_mul_assign(size_ds);
+/// Rescale δ's Gamma denominators so that, per gene, the frame batches'
+/// weighted geometric mean of the posterior mean `(a0 + num) / (b0 + den)` is
+/// exactly 1. A batch masked out for a gene (`obs_mask_db == 0`) sits on the
+/// prior and does not vote. Returns the adjusted denominators.
+fn pin_delta_scale(
+    num_db: &DMatrix<f32>,
+    den_db: &DMatrix<f32>,
+    (a0, b0): (f32, f32),
+    frame_w: &DVector<f32>,
+    mask_db: Option<&DMatrix<f32>>,
+) -> DMatrix<f32> {
+    let (ng, nb) = num_db.shape();
+    let mut out = den_db.clone();
+    for g in 0..ng {
+        let (mut lsum, mut wsum) = (0f64, 0f64);
+        for b in 0..nb {
+            let w = f64::from(frame_w[b]) * mask_db.map_or(1.0, |m| f64::from(m[(g, b)]));
+            if w > 0.0 {
+                let m = f64::from(a0 + num_db[(g, b)]) / f64::from(b0 + den_db[(g, b)]);
+                lsum += w * m.max(f64::MIN_POSITIVE).ln();
+                wsum += w;
+            }
         }
-        None => {
-            for s in 0..denom_ds.ncols() {
-                denom_ds.column_mut(s).scale_mut(stat.size_s[s]);
+        if wsum > 0.0 {
+            let gm = (lsum / wsum).exp() as f32;
+            for b in 0..nb {
+                // A masked entry carries no evidence and stays on the prior.
+                if mask_db.is_some_and(|m| m[(g, b)] == 0.0) {
+                    continue;
+                }
+                // (a0 + num) / (b0 + den') = mean / gm  ⇔  den' = (b0 + den)·gm − b0.
+                // The clamp only binds when gm < 1 on an entry with less than a
+                // cell's worth of evidence, where the prior dominates anyway.
+                out[(g, b)] = ((b0 + den_db[(g, b)]) * gm - b0).max(0.0);
             }
         }
     }
+    out
 }
 
 fn optimize_block(
@@ -217,117 +239,149 @@ fn optimize_block(
     let mut mu_param = GammaMatrix::new((num_genes, num_samples), a0, b0);
 
     if num_batches > 1 {
-        // temporary denominator
-        let mut denom_ds = nalgebra::DMatrix::<f32>::zeros(num_genes, num_samples);
+        //////////////////////////////////////////////////////////////////
+        // One frame for every batch                                    //
+        //                                                              //
+        //   E[observed_gs] = μ_gs · Σ_b δ_gb · n_bs        (own cells) //
+        //   E[imputed_gs]  = μ_gs · Σ_b δ_gb · w_bs   (counterfactual) //
+        //                                                              //
+        // μ is the batch-free rate, δ_gb the per-batch fold, n_bs the  //
+        // own mass and w_bs the counterfactual's source mass. Both     //
+        // sides of a pseudobulk are Poisson at the SAME μ, so μ cannot //
+        // slide into another batch's frame; δ is identified by the     //
+        // counterfactual side and pinned per gene to geometric mean 1  //
+        // over the frame batches (all of them, or the anchors).        //
+        //////////////////////////////////////////////////////////////////
+        let n_bs = &stat.n_bs;
+        let w_bs = &stat.matched_bs;
+        let own_plus_src = n_bs + w_bs; // [b × s]
+        let obs_plus_imp = &stat.observed_sum_ds + &stat.imputed_sum_ds;
+        // Fraction of each (gene, sample)'s mass whose source measures the gene;
+        // `None` = fully observed.
+        let obs_frac: Option<DMatrix<f32>> = stat.size_ds.as_ref().map(|size_ds| {
+            DMatrix::from_fn(num_genes, num_samples, |g, s| {
+                let n = stat.size_s[s];
+                if n > 0.0 {
+                    size_ds[(g, s)] / n
+                } else {
+                    0.0
+                }
+            })
+        });
+        let frame_w = stat.frame_weights();
+        let own_plus_src_t = own_plus_src.transpose(); // [s × b]
+        let w_bs_t = w_bs.transpose();
 
-        // parameters
         let mut mu_adj_param = GammaMatrix::new((num_genes, num_samples), a0, b0);
-        let mut mu_resid_param = GammaMatrix::new((num_genes, num_samples), a0, b0);
-        let mut gamma_param = GammaMatrix::new((num_genes, num_samples), a0, b0);
         let mut delta_param = GammaMatrix::new((num_genes, num_batches), a0, b0);
+        let mut delta_gb = DMatrix::<f32>::from_element(num_genes, num_batches, 1.0);
 
-        //////////////////////////////
-        // E[y_resid] = E[μ_resid]  //
-        // E[y] = E[μ_resid] * E[μ] //
-        // E[y_hat] = E[γ] * E[μ]   //
-        // E[y_bat] = E[δ] * E[μ]   //
-        //////////////////////////////
-
-        //            residual_sum_ds
-        // μ_resid = -----------------
-        //            1_d * size_s'
-
-        {
-            add_effective_size(&mut denom_ds, stat);
-            mu_resid_param.update_stat(&stat.residual_sum_ds, &denom_ds);
-            // mu_resid is fixed across the loop (read via posterior_mean);
-            // calibrate to the output target now so it carries sd/log only
-            // when the caller actually needs them.
-            mu_resid_param.calibrate_with(out_target);
+        // μ given δ: (obs + imp) / (frac · Σ_b δ_gb (n_bs + w_bs))
+        let update_mu = |mu_adj_param: &mut GammaMatrix, delta_gb: &DMatrix<f32>| {
+            let mut denom_ds = delta_gb * &own_plus_src;
+            if let Some(f) = obs_frac.as_ref() {
+                denom_ds.component_mul_assign(f);
+            }
+            mu_adj_param.update_stat(&obs_plus_imp, &denom_ds);
+            mu_adj_param.calibrate_with(CalibrateTarget::MeanOnly);
         };
 
+        // Scratch planes, allocated once: every [g × s] temporary below is
+        // rewritten in place each iteration rather than reallocated.
+        let mut imp_share = DMatrix::<f32>::zeros(num_genes, num_samples);
+        let mut mu_frac = DMatrix::<f32>::zeros(num_genes, num_samples);
         for _opt_iter in 0..num_iter {
             #[cfg(debug_assertions)]
             {
                 debug!("iteration: {}", &_opt_iter);
             }
 
-            let resid_ds = mu_resid_param.posterior_mean();
-            let gamma_ds = gamma_param.posterior_mean();
-
-            //      observed_ds + imputed_sum_ds
-            // μ = ---------------------------------
-            //      (μ_resid + γ) .* (1_d * size_s')
-
-            denom_ds.copy_from(&(resid_ds + gamma_ds));
-
-            scale_by_effective_size(&mut denom_ds, stat);
-
-            mu_adj_param.update_stat(&(&stat.observed_sum_ds + &stat.imputed_sum_ds), &denom_ds);
-            mu_adj_param.calibrate_with(CalibrateTarget::MeanOnly);
-
+            update_mu(&mut mu_adj_param, &delta_gb);
             let mu_ds = mu_adj_param.posterior_mean();
 
-            //      imputed_sum_ds
-            // γ = ---------------------
-            //      μ .* (1_d * size_s')
+            // δ given μ (one EM step): the observed side is exact per batch
+            // (`observed_sum_db`); the counterfactual side splits each
+            // sample's imputed sum over its source batches in proportion to
+            // δ_gb · w_bs.
+            //   num_gb = obs_db + Σ_s imp_gs · δ_gb w_bs / Σ_b' δ_gb' w_b's
+            //   den_gb = Σ_s μ_gs · frac_gs · (n_bs + w_bs)
+            imp_share.gemm(1.0, &delta_gb, w_bs, 0.0); // Σ_b δ_gb w_bs
+            imp_share.zip_apply(&stat.imputed_sum_ds, |z, x| {
+                *z = if *z > 0.0 { x / *z } else { 0.0 };
+            });
+            let mut num_db =
+                &stat.observed_sum_db + (&imp_share * &w_bs_t).component_mul(&delta_gb);
+            let mu_frac_ref: &DMatrix<f32> = match obs_frac.as_ref() {
+                Some(f) => {
+                    mu_frac.copy_from(mu_ds);
+                    mu_frac.component_mul_assign(f);
+                    &mu_frac
+                }
+                None => mu_ds,
+            };
+            let mut den_db = mu_frac_ref * &own_plus_src_t; // [g × b]
+            if let Some(mask) = stat.obs_mask_db.as_ref() {
+                // Zeroing a (gene, batch) entry means "this batch carries no δ
+                // evidence for this gene"; masking BOTH sides lands the
+                // posterior on the prior exactly (≈ 1, "no adjustment").
+                num_db.component_mul_assign(mask);
+                den_db.component_mul_assign(mask);
+            }
+            // Pin the per-gene scale: the frame batches' weighted geometric
+            // mean of δ is 1. Folded into the denominators so the Gamma
+            // posterior itself carries the normalised value.
+            let den_db = pin_delta_scale(
+                &num_db,
+                &den_db,
+                (a0, b0),
+                &frame_w,
+                stat.obs_mask_db.as_ref(),
+            );
+            delta_param.update_stat(&num_db, &den_db);
+            delta_param.calibrate_with(CalibrateTarget::MeanOnly);
+            delta_gb.copy_from(delta_param.posterior_mean());
 
-            denom_ds.copy_from(mu_ds);
-            scale_by_effective_size(&mut denom_ds, stat);
-            gamma_param.update_stat(&stat.imputed_sum_ds, &denom_ds);
-            gamma_param.calibrate_with(CalibrateTarget::MeanOnly);
-
-            // Tick per descent iteration so the bar keeps moving inside a
-            // block; `inc` is atomic, so concurrent blocks share one bar.
             if let Some(p) = prog {
                 p.inc(1);
             }
         }
-
-        // Output calibration after loop. `out_target` decides whether the
-        // sd / log_mean / log_sd planes are materialized (only when the
-        // caller writes them) or left empty (e.g. bge, which reads means).
+        // μ consistent with the final δ.
+        update_mu(&mut mu_adj_param, &delta_gb);
         mu_adj_param.calibrate_with(out_target);
+        delta_param.calibrate_with(out_target);
+
+        // Per-pseudobulk readouts against the batch-free μ, on the documented
+        // scale: E[y] = μ_resid · μ (own fold) and E[ŷ] = γ · μ (source fold).
+        // Each denominator is μ times a per-sample mass (own cells, or the
+        // counterfactual's matched cells), scaled by the observed fraction when
+        // a panel gap makes it less than full.
+        let mu_ds = mu_adj_param.posterior_mean();
+        let mass_times_mu = |per_sample: &dyn Fn(usize) -> f32| {
+            let mut m = mu_ds.clone();
+            for s in 0..num_samples {
+                m.column_mut(s).scale_mut(per_sample(s));
+            }
+            if let Some(f) = obs_frac.as_ref() {
+                m.component_mul_assign(f);
+            }
+            m
+        };
+        let resid_denom = mass_times_mu(&|s| stat.size_s[s]);
+        let mut mu_resid_param = GammaMatrix::new((num_genes, num_samples), a0, b0);
+        mu_resid_param.update_stat(&stat.observed_sum_ds, &resid_denom);
+        mu_resid_param.calibrate_with(out_target);
+
+        let src_mass_s: Vec<f32> = (0..num_samples).map(|s| w_bs.column(s).sum()).collect();
+        let gamma_denom = mass_times_mu(&|s| src_mass_s[s]);
+        let mut gamma_param = GammaMatrix::new((num_genes, num_samples), a0, b0);
+        gamma_param.update_stat(&stat.imputed_sum_ds, &gamma_denom);
         gamma_param.calibrate_with(out_target);
 
-        //      observed_db
-        // δ = ---------------------
-        //      μ * size_bs'
+        // Take the observed mean over the own mass.
         {
-            let mu_ds = mu_adj_param.posterior_mean();
-            let mut denom_db = mu_ds * &stat.n_bs.transpose();
-            match stat.obs_mask_db.as_ref() {
-                // Zeroing a (gene, batch) entry of `obs_mask_db` means "this
-                // batch carries no δ evidence for this gene", and the mask
-                // applies to BOTH sides of the ratio so the posterior lands
-                // on the prior exactly. Masking the denominator alone would
-                // leave `a0 + observed` over `b0` — an exploding mean, not
-                // "no adjustment".
-                //
-                // Two callers set it, and the numerator term is why they can
-                // share one mechanism. Structural absence (`attach_
-                // observability`): nothing was measured, so the numerator is
-                // already zero and masking it is a no-op — this arm stays
-                // bitwise identical to before it masked the numerator. Bulk
-                // batches (`mark_unmatched_bulk`): plenty was observed, so
-                // masking the numerator is exactly what keeps composition out
-                // of δ.
-                Some(mask) => {
-                    denom_db.component_mul_assign(mask);
-                    let mut num_db = stat.observed_sum_db.clone();
-                    num_db.component_mul_assign(mask);
-                    delta_param.update_stat(&num_db, &denom_db);
-                }
-                None => delta_param.update_stat(&stat.observed_sum_db, &denom_db),
-            }
-            delta_param.calibrate_with(out_target);
-        }
-
-        // Take the observed mean
-        {
-            let mut denom_ds = DMatrix::<f32>::zeros(num_genes, num_samples);
-            add_effective_size(&mut denom_ds, stat);
-            mu_param.update_stat(&stat.observed_sum_ds, &denom_ds);
+            let mut own_mass = DMatrix::<f32>::zeros(num_genes, num_samples);
+            add_effective_size(&mut own_mass, stat);
+            mu_param.update_stat(&stat.observed_sum_ds, &own_mass);
             mu_param.calibrate_with(out_target);
         };
 
@@ -337,9 +391,9 @@ fn optimize_block(
         // across all training epochs). `All` consumers keep the dense mean.
         if matches!(out_target, CalibrateTarget::MeanOnly) {
             mu_param.sparsify_mean_to_support(&stat.observed_sum_ds);
-            mu_adj_param.sparsify_mean_to_support(&(&stat.observed_sum_ds + &stat.imputed_sum_ds));
+            mu_adj_param.sparsify_mean_to_support(&obs_plus_imp);
             gamma_param.sparsify_mean_to_support(&stat.imputed_sum_ds);
-            mu_resid_param.sparsify_mean_to_support(&stat.residual_sum_ds);
+            mu_resid_param.sparsify_mean_to_support(&stat.observed_sum_ds);
         }
 
         Ok(CollapsedOut {
@@ -546,10 +600,18 @@ impl CollapsedOut {
 pub struct CollapsedStat {
     pub observed_sum_ds: nalgebra::DMatrix<f32>, // observed sum within each sample
     pub imputed_sum_ds: nalgebra::DMatrix<f32>,  // counterfactual sum within each sample
-    pub residual_sum_ds: nalgebra::DMatrix<f32>, // residual sum within each sample
     pub size_s: nalgebra::DVector<f32>,          // sample s size
     pub observed_sum_db: nalgebra::DMatrix<f32>, // divergence numerator
     pub n_bs: nalgebra::DMatrix<f32>,            // batch-specific sample size
+    /// Counterfactual SOURCE mass per (batch, sample): how much of sample `s`'s
+    /// imputed profile was drawn from batch `b`'s cells (each matched cell's
+    /// weights sum to 1, so a column sums to the matched cell count). With
+    /// `n_bs` this is what identifies `δ`: `E[imputed_gs] = μ_gs Σ_b δ_gb w_bs`
+    /// against `E[observed_gs] = μ_gs Σ_b δ_gb n_bs`.
+    pub matched_bs: nalgebra::DMatrix<f32>,
+    /// Batches whose frame IS the frame: `δ` is normalised so their per-gene
+    /// geometric mean is 1. Empty = pooled, where every batch's mass weighs in.
+    pub anchor_batches: Vec<usize>,
     /// Per-(gene, sample) effective size: the mass of sample `s` whose SOURCE
     /// actually measures gene `g`. `None` means fully observed — every gene
     /// sees `size_s[s]`, and `optimize` takes the exact historical code path.
@@ -572,10 +634,11 @@ impl CollapsedStat {
         Self {
             observed_sum_ds: nalgebra::DMatrix::<f32>::zeros(ngene, nsample),
             imputed_sum_ds: nalgebra::DMatrix::<f32>::zeros(ngene, nsample),
-            residual_sum_ds: nalgebra::DMatrix::<f32>::zeros(ngene, nsample),
             size_s: nalgebra::DVector::<f32>::zeros(nsample),
             observed_sum_db: nalgebra::DMatrix::<f32>::zeros(ngene, nbatch),
             n_bs: nalgebra::DMatrix::<f32>::zeros(nbatch, nsample),
+            matched_bs: nalgebra::DMatrix::<f32>::zeros(nbatch, nsample),
+            anchor_batches: Vec::new(),
             size_ds: None,
             obs_mask_db: None,
         }
@@ -593,13 +656,30 @@ impl CollapsedStat {
         self.observed_sum_db.ncols()
     }
 
+    /// Per-batch weights that define the frame `δ` is pinned to: the anchors
+    /// when there are any (each weighted 1), else every batch by its own cell
+    /// mass.
+    pub fn frame_weights(&self) -> DVector<f32> {
+        let nb = self.num_batches();
+        if self.anchor_batches.is_empty() {
+            DVector::from_fn(nb, |b, _| self.n_bs.row(b).sum())
+        } else {
+            let mut w = DVector::<f32>::zeros(nb);
+            for &b in &self.anchor_batches {
+                w[b] = 1.0;
+            }
+            w
+        }
+    }
+
     pub fn clear(&mut self) {
         self.observed_sum_ds.fill(0_f32);
         self.imputed_sum_ds.fill(0_f32);
-        self.residual_sum_ds.fill(0_f32);
         self.observed_sum_db.fill(0_f32);
         self.size_s.fill(0_f32);
         self.n_bs.fill(0_f32);
+        self.matched_bs.fill(0_f32);
+        self.anchor_batches.clear();
         self.size_ds = None;
         self.obs_mask_db = None;
     }
@@ -617,12 +697,10 @@ impl CollapsedStat {
             out.imputed_sum_ds
                 .column_mut(new_col)
                 .copy_from(&self.imputed_sum_ds.column(old_col));
-            out.residual_sum_ds
-                .column_mut(new_col)
-                .copy_from(&self.residual_sum_ds.column(old_col));
             out.size_s[new_col] = self.size_s[old_col];
             for b in 0..nb {
                 out.n_bs[(b, new_col)] = self.n_bs[(b, old_col)];
+                out.matched_bs[(b, new_col)] = self.matched_bs[(b, old_col)];
             }
         }
         if let Some(size_ds) = self.size_ds.as_ref() {
@@ -632,21 +710,23 @@ impl CollapsedStat {
         }
         out.obs_mask_db = self.obs_mask_db.clone();
         out.observed_sum_db.copy_from(&self.observed_sum_db);
+        out.anchor_batches = self.anchor_batches.clone();
         out
     }
 
     /// Select a contiguous block of feature rows (`r0..r0+nrows`). Per-gene
-    /// stats (`observed`/`imputed`/`residual`/`observed_db`) are sliced;
-    /// the per-sample `size_s` and per-batch `n_bs` are shared, so they're
-    /// copied whole. Used by the gene-blocked `optimize`.
+    /// stats (`observed`/`imputed`/`observed_db`) are sliced; the per-sample
+    /// `size_s` and per-batch `n_bs`/`matched_bs` are shared, so they're copied
+    /// whole. Used by the gene-blocked `optimize`.
     pub fn select_rows(&self, r0: usize, nrows: usize) -> Self {
         Self {
             observed_sum_ds: self.observed_sum_ds.rows(r0, nrows).into_owned(),
             imputed_sum_ds: self.imputed_sum_ds.rows(r0, nrows).into_owned(),
-            residual_sum_ds: self.residual_sum_ds.rows(r0, nrows).into_owned(),
             size_s: self.size_s.clone(),
             observed_sum_db: self.observed_sum_db.rows(r0, nrows).into_owned(),
             n_bs: self.n_bs.clone(),
+            matched_bs: self.matched_bs.clone(),
+            anchor_batches: self.anchor_batches.clone(),
             size_ds: self
                 .size_ds
                 .as_ref()
@@ -694,7 +774,8 @@ pub(super) const DEFAULT_COARSEST_SORT_DIM: usize = 7;
 /// Cross-batch matched-stat accumulation on top of the pb-sample
 /// layout. For each fine-group, fetches `knn` matched cells from each
 /// non-own batch via `batch_knn_lookup`, dedupes them through their
-/// pb-samples, and emits the matched gene sums into `stat.matched_dn`.
+/// pb-samples, and emits the counterfactual gene sums into
+/// `stat.imputed_sum_ds` and the per-batch source mass into `stat.matched_bs`.
 pub(super) fn collect_matched_stat_coarse(
     layout: &PbSampleLayout,
     gene_sums: &[Vec<(usize, f32)>],
@@ -707,6 +788,9 @@ pub(super) fn collect_matched_stat_coarse(
     let num_pb = layout.cell_counts.len();
     debug_assert_eq!(pbsamp_to_group.len(), num_pb);
 
+    // The batches that source the counterfactual are the batches that pin δ:
+    // recorded here, where that mass is written, so no caller can forget.
+    stat.anchor_batches = anchor_batches.map(<[usize]>::to_vec).unwrap_or_default();
     let neighbors_per_sc = per_batch_sc_neighbors(layout, batch_knn_lookup, knn, anchor_batches)?;
 
     use indicatif::ParallelProgressIterator;
@@ -765,17 +849,14 @@ pub(super) fn collect_matched_stat_coarse(
                 stat.imputed_sum_ds[(gene, pbsamp_group)] += sc_count * y;
             }
 
-            // Accumulate residual_sum_ds[g, s] += y_obs[g] / y_hat[g]
-            // where y_obs[g] = gene_sums[pbsamp][g] / cell_counts[pbsamp]
-            // -> residual_sum_ds[g, s] += gene_sums[pbsamp][g] / (cell_counts[pbsamp] * y_hat[g])
-            //    then × cell_counts[pbsamp] to match original scaling
-            // = gene_sums[pbsamp][g] / y_hat[g]
-            for &(gene, val) in &gene_sums[pbsamp_idx] {
-                if let Some(&y_h) = y_hat.get(&gene) {
-                    if y_h > 0.0 {
-                        stat.residual_sum_ds[(gene, pbsamp_group)] += val / y_h;
-                    }
+            // Source mass per batch: this pb-sample's `sc_count` cells split their
+            // unit weight over the matched pb-samples' batches.
+            for ((matched_sc, _), &w) in filtered.iter().zip(weights.iter()) {
+                if layout.cell_counts[*matched_sc] < 1.0 {
+                    continue;
                 }
+                stat.matched_bs[(layout.pb_sample_to_batch[*matched_sc], pbsamp_group)] +=
+                    sc_count * w;
             }
         });
 
@@ -805,13 +886,10 @@ pub(super) fn merge_stat(
             .imputed_sum_ds
             .column_mut(coarse_g)
             .add_assign(&fine_stat.imputed_sum_ds.column(fine_g));
-        coarse
-            .residual_sum_ds
-            .column_mut(coarse_g)
-            .add_assign(&fine_stat.residual_sum_ds.column(fine_g));
         coarse.size_s[coarse_g] += fine_stat.size_s[fine_g];
         for b in 0..num_batches {
             coarse.n_bs[(b, coarse_g)] += fine_stat.n_bs[(b, fine_g)];
+            coarse.matched_bs[(b, coarse_g)] += fine_stat.matched_bs[(b, fine_g)];
         }
     }
 
@@ -827,6 +905,7 @@ pub(super) fn merge_stat(
         coarse.size_ds = Some(size_ds);
     }
     coarse.obs_mask_db = fine_stat.obs_mask_db.clone();
+    coarse.anchor_batches = fine_stat.anchor_batches.clone();
 
     coarse.observed_sum_db.copy_from(&fine_stat.observed_sum_db);
     coarse

--- a/data-beans-alg/src/collapse_data/stats_tests.rs
+++ b/data-beans-alg/src/collapse_data/stats_tests.rs
@@ -10,11 +10,157 @@ fn toy_stat(num_genes: usize, num_samples: usize, num_batches: usize) -> Collaps
     let f = |a: usize, b: usize| -> f32 { 1.0 + ((a * 7 + b * 13) % 11) as f32 };
     s.observed_sum_ds = DMatrix::from_fn(num_genes, num_samples, &f);
     s.imputed_sum_ds = DMatrix::from_fn(num_genes, num_samples, |g, c| 0.5 * f(g + 1, c + 2));
-    s.residual_sum_ds = DMatrix::from_fn(num_genes, num_samples, |g, c| 0.3 * f(g + 2, c + 1));
     s.size_s = DVector::from_fn(num_samples, |c, _| 2.0 + (c % 3) as f32);
     s.observed_sum_db = DMatrix::from_fn(num_genes, num_batches, |g, b| f(g, b) + 0.7);
     s.n_bs = DMatrix::from_fn(num_batches, num_samples, |b, c| 1.0 + ((b + c) % 4) as f32);
+    s.matched_bs = DMatrix::from_fn(num_batches, num_samples, |b, c| {
+        0.5 + ((b + 2 * c) % 3) as f32
+    });
     s
+}
+
+/// Two batch-pure pseudobulks of ONE cell type: pb 0 in batch 0 (frame `a`),
+/// pb 1 in batch 1 (frame `b`), each matched to the other. `n` cells each, so the
+/// unit priors are negligible.
+fn two_pure_pbs(a: &[f32], b: &[f32], n: f32) -> CollapsedStat {
+    let g = a.len();
+    let mut s = CollapsedStat::new(g, 2, 2);
+    for i in 0..g {
+        s.observed_sum_ds[(i, 0)] = a[i] * n;
+        s.imputed_sum_ds[(i, 0)] = b[i] * n;
+        s.observed_sum_ds[(i, 1)] = b[i] * n;
+        s.imputed_sum_ds[(i, 1)] = a[i] * n;
+        s.observed_sum_db[(i, 0)] = a[i] * n;
+        s.observed_sum_db[(i, 1)] = b[i] * n;
+    }
+    s.size_s = DVector::from_element(2, n);
+    s.n_bs = DMatrix::from_row_slice(2, 2, &[n, 0.0, 0.0, n]);
+    // pb 0's counterfactual comes from batch 1 and vice versa
+    s.matched_bs = DMatrix::from_row_slice(2, 2, &[0.0, n, n, 0.0]);
+    s
+}
+
+fn assert_rel(got: f32, want: f32, tol: f32, tag: &str) {
+    assert!(
+        (got / want - 1.0).abs() < tol,
+        "{tag}: got {got}, want {want} (rel tol {tol})"
+    );
+}
+
+/// Pooled adjustment: both pseudobulks land in ONE frame — the per-gene
+/// geometric mean of the two batch frames — with `δ` carrying the whole
+/// batch ratio, normalised to geometric mean 1 across batches. The per-pb
+/// outputs keep their documented meaning: `mu_residual` is the own-batch fold
+/// `E[y]/E[μ]`, `gamma` the counterfactual's `E[ŷ]/E[μ]`.
+#[test]
+#[allow(clippy::needless_range_loop)] // `g` indexes four parallel tables
+fn pooled_two_pure_batches_share_one_frame() {
+    let a = [8.0f32, 2.0, 12.0, 1.0];
+    let b = [2.0f32, 8.0, 3.0, 4.0];
+    let stat = two_pure_pbs(&a, &b, 2000.0);
+    let out = optimize_block(&stat, (1.0, 1.0), 60, CalibrateTarget::All, None).unwrap();
+    let mu = out.mu_adjusted.as_ref().unwrap().posterior_mean();
+    let delta = out.delta.as_ref().unwrap().posterior_mean();
+    let resid = out.mu_residual.as_ref().unwrap().posterior_mean();
+    let gamma = out.gamma.as_ref().unwrap().posterior_mean();
+    for g in 0..a.len() {
+        let common = (a[g] * b[g]).sqrt();
+        assert_rel(mu[(g, 0)], common, 0.02, &format!("gene {g} mu pb0"));
+        assert_rel(mu[(g, 1)], common, 0.02, &format!("gene {g} mu pb1"));
+        assert_rel(
+            delta[(g, 0)] / delta[(g, 1)],
+            a[g] / b[g],
+            0.02,
+            &format!("gene {g} delta ratio"),
+        );
+        assert_rel(
+            delta[(g, 0)] * delta[(g, 1)],
+            1.0,
+            0.02,
+            &format!("gene {g} delta geometric mean"),
+        );
+        assert_rel(
+            resid[(g, 0)],
+            delta[(g, 0)],
+            0.02,
+            &format!("gene {g} mu_residual pb0 = own delta"),
+        );
+        assert_rel(
+            resid[(g, 1)],
+            delta[(g, 1)],
+            0.02,
+            &format!("gene {g} mu_residual pb1 = own delta"),
+        );
+        assert_rel(
+            gamma[(g, 0)],
+            delta[(g, 1)],
+            0.02,
+            &format!("gene {g} gamma pb0 = source delta"),
+        );
+    }
+}
+
+/// Anchored: the anchor batch's frame is the frame. Its pseudobulk self-matches
+/// (counterfactual = its own profile), the other batch is matched to it. Then
+/// `δ_anchor = 1`, both `μ` equal the anchor profile, and the new batch's `δ` is
+/// its fold relative to the anchor.
+#[test]
+fn anchored_frame_is_the_anchor_batch() {
+    let a = [8.0f32, 2.0, 12.0, 1.0];
+    let b = [2.0f32, 8.0, 3.0, 4.0];
+    let n = 2000.0;
+    let mut stat = two_pure_pbs(&a, &b, n);
+    // pb 1 (batch 1) is the anchor: it self-matches.
+    for (g, &bg) in b.iter().enumerate() {
+        stat.imputed_sum_ds[(g, 1)] = bg * n;
+    }
+    stat.matched_bs = DMatrix::from_row_slice(2, 2, &[0.0, 0.0, n, n]);
+    stat.anchor_batches = vec![1];
+    let out = optimize_block(&stat, (1.0, 1.0), 60, CalibrateTarget::All, None).unwrap();
+    let mu = out.mu_adjusted.as_ref().unwrap().posterior_mean();
+    let delta = out.delta.as_ref().unwrap().posterior_mean();
+    for g in 0..a.len() {
+        assert_rel(delta[(g, 1)], 1.0, 0.02, &format!("gene {g} anchor delta"));
+        assert_rel(
+            delta[(g, 0)],
+            a[g] / b[g],
+            0.03,
+            &format!("gene {g} new-batch delta"),
+        );
+        assert_rel(
+            mu[(g, 0)],
+            b[g],
+            0.03,
+            &format!("gene {g} mu pb0 in the anchor frame"),
+        );
+        assert_rel(mu[(g, 1)], b[g], 0.02, &format!("gene {g} mu pb1"));
+    }
+}
+
+/// Coarsening adds the counterfactual source mass like every other per-sample
+/// statistic, and carries the anchor set.
+#[test]
+fn merge_stat_sums_matched_mass_and_keeps_anchors() {
+    let mut fine = toy_stat(3, 4, 2);
+    fine.anchor_batches = vec![0];
+    let coarse = merge_stat(&fine, &[0, 1, 0, 1], 2);
+    for b in 0..2 {
+        assert_eq!(
+            coarse.matched_bs[(b, 0)],
+            fine.matched_bs[(b, 0)] + fine.matched_bs[(b, 2)]
+        );
+        assert_eq!(
+            coarse.matched_bs[(b, 1)],
+            fine.matched_bs[(b, 1)] + fine.matched_bs[(b, 3)]
+        );
+    }
+    assert_eq!(coarse.anchor_batches, vec![0]);
+    let sub = fine.select_rows(1, 2);
+    assert_eq!(sub.matched_bs, fine.matched_bs);
+    assert_eq!(sub.anchor_batches, vec![0]);
+    let cols = fine.select_columns(&[3, 1]);
+    assert_eq!(cols.matched_bs.column(0), fine.matched_bs.column(3));
+    assert_eq!(cols.anchor_batches, vec![0]);
 }
 
 fn assert_mat_close(a: &DMatrix<f32>, b: &DMatrix<f32>, tag: &str) {

--- a/data-beans-alg/tests/anchored_batches.rs
+++ b/data-beans-alg/tests/anchored_batches.rs
@@ -158,8 +158,10 @@ fn the_anchor_batch_keeps_delta_at_one() {
     let d0 = mean_abs_log_delta(&out, 0);
     let d1 = mean_abs_log_delta(&out, 1);
     let (anchor_dev, new_dev) = if d0 < d1 { (d0, d1) } else { (d1, d0) };
+    // Exactly 1 up to the Gamma prior: the anchor set pins δ's per-gene scale,
+    // which the matched-stat collector records from the anchors it was handed.
     assert!(
-        anchor_dev < 0.15,
+        anchor_dev < 0.02,
         "anchor batch was re-adjusted: mean|log delta| = {anchor_dev}"
     );
     assert!(

--- a/data-beans-alg/tests/pooled_frame.rs
+++ b/data-beans-alg/tests/pooled_frame.rs
@@ -1,0 +1,221 @@
+//! Pooled (un-anchored) batch adjustment must land every batch's pseudobulks in
+//! ONE common frame: the same cell type from two batches should have the same
+//! `mu_adjusted` profile, up to matching noise. That is what every downstream
+//! consumer assumes when it trains on `mu_adjusted` and later corrects cells with
+//! `delta` (or `mu_residual`) relative to it.
+//!
+//! Planted: two batches over the same 2-type biology, batch "shifted" carrying a
+//! per-gene platform factor (2× on the first half of the genes, 0.5× on the
+//! second), batch "clean" carrying none.
+
+use data_beans::sparse_io::create_sparse_from_triplets;
+use data_beans::sparse_io_vector::SparseIoVec;
+use data_beans_alg::collapse_data::{collapse_columns_multilevel_with_hierarchy, MultilevelParams};
+use data_beans_alg::random_projection::RandProjOps;
+use matrix_param::traits::Inference;
+
+const D: usize = 8;
+const PER_BATCH: usize = 120;
+
+fn type_profile(i: usize) -> Vec<f32> {
+    if i.is_multiple_of(2) {
+        (0..D).map(|g| 10.0 + 3.0 * (g % 2) as f32).collect()
+    } else {
+        (0..D).map(|g| 4.0 + 2.0 * ((g + 1) % 2) as f32).collect()
+    }
+}
+
+fn platform(g: usize) -> f32 {
+    if g < D / 2 {
+        2.0
+    } else {
+        0.5
+    }
+}
+
+/// Columns `0..PER_BATCH` are the shifted batch, the next `PER_BATCH` the clean
+/// one; types alternate by column parity in both.
+fn cohort() -> (SparseIoVec, Vec<&'static str>) {
+    let mut cols: Vec<Vec<f32>> = Vec::new();
+    let mut batches: Vec<&'static str> = Vec::new();
+    for i in 0..PER_BATCH {
+        let wiggle = 1.0 + 0.05 * ((i % 5) as f32 - 2.0);
+        cols.push(
+            type_profile(i)
+                .into_iter()
+                .enumerate()
+                .map(|(g, v)| v * platform(g) * wiggle)
+                .collect(),
+        );
+        batches.push("shifted");
+    }
+    for i in 0..PER_BATCH {
+        let wiggle = 1.0 + 0.05 * ((i % 5) as f32 - 2.0);
+        cols.push(type_profile(i).into_iter().map(|v| v * wiggle).collect());
+        batches.push("clean");
+    }
+    let dir = std::env::temp_dir().join(format!("dba_pooled_frame_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join("frame.zarr");
+    let _ = std::fs::remove_dir_all(&path);
+    let mut triplets: Vec<(u64, u64, f32)> = Vec::new();
+    for (j, col) in cols.iter().enumerate() {
+        for (g, &v) in col.iter().enumerate() {
+            triplets.push((g as u64, j as u64, v));
+        }
+    }
+    let shape = (D, cols.len(), triplets.len());
+    let mut b = create_sparse_from_triplets(
+        &triplets,
+        shape,
+        Some(path.to_str().expect("utf8")),
+        Some(&data_beans::sparse_io::SparseIoBackend::Zarr),
+    )
+    .expect("create backend");
+    b.register_row_names_vec(
+        &(0..D)
+            .map(|g| format!("g{g}").into_boxed_str())
+            .collect::<Vec<_>>(),
+    );
+    b.register_column_names_vec(
+        &(0..cols.len())
+            .map(|c| format!("c{c}").into_boxed_str())
+            .collect::<Vec<_>>(),
+    );
+    let mut v = SparseIoVec::new();
+    v.push(std::sync::Arc::from(b), None).expect("push");
+    (v, batches)
+}
+
+/// Per-gene ratio `mu_adjusted(shifted-batch pbs) / mu_adjusted(clean-batch pbs)`
+/// for one planted type, averaged over batch-pure pseudobulks.
+/// Run the pooled collapse once; returns the finest level and the collapse's
+/// batch names in δ-column order.
+fn run_pooled() -> (
+    data_beans_alg::collapse_data::MultilevelCollapseOut,
+    Vec<Box<str>>,
+) {
+    let (mut v, batches) = cohort();
+    let corrected = v
+        .project_columns_with_batch_correction(4, None, Some(&batches))
+        .expect("proj")
+        .proj;
+    // Real batches rarely hash together (most finest groups are batch-pure on
+    // multi-study data); a batch indicator as the first sketch dimension keeps
+    // that property here so each batch has its own pseudobulks to compare.
+    // Cross-batch matching itself runs within each batch's own index, which this
+    // constant-per-batch row does not disturb.
+    let mut proj = nalgebra::DMatrix::<f32>::zeros(corrected.nrows() + 1, corrected.ncols());
+    for c in 0..corrected.ncols() {
+        proj[(0, c)] = if c < PER_BATCH { 10.0 } else { -10.0 };
+    }
+    proj.rows_mut(1, corrected.nrows()).copy_from(&corrected);
+    let params = MultilevelParams {
+        knn_pb_samples: 3,
+        num_levels: 1,
+        sort_dim: 4,
+        num_opt_iter: 30,
+        // No refinement sweeps: the hashed partition stands, so the batch
+        // indicator above keeps every pseudobulk batch-pure.
+        refine: Some(data_beans_alg::refine_multilevel::RefineParams {
+            num_gibbs: 0,
+            num_greedy: 0,
+            ..Default::default()
+        }),
+        output_calibration: matrix_param::traits::CalibrateTarget::All,
+        anchor_batches: None,
+        bulk_batches: None,
+        observe_panels: true,
+        keep_finest_stats: false,
+    };
+    let out = collapse_columns_multilevel_with_hierarchy(&mut v, &proj, &batches, &params)
+        .expect("collapse");
+    let names = v.batch_names().expect("batch names");
+    (out, names)
+}
+
+fn ratio_from(out: &data_beans_alg::collapse_data::MultilevelCollapseOut, ty: usize) -> Vec<f32> {
+    let level = &out.levels[0];
+    let cell_to_pb = &out.cell_to_pb_per_level[0];
+    let adj = level
+        .mu_adjusted
+        .as_ref()
+        .expect("two batches ⇒ mu_adjusted")
+        .posterior_mean();
+    let n_pb = adj.ncols();
+
+    // Which (batch, type) each pb holds; keep only pure pbs.
+    let mut count = vec![[[0usize; 2]; 2]; n_pb]; // [pb][batch][type]
+    for (c, &p) in cell_to_pb.iter().enumerate() {
+        let b = usize::from(c >= PER_BATCH);
+        let t = (c % PER_BATCH) % 2;
+        count[p][b][t] += 1;
+    }
+    let mut mean = [vec![0f32; D], vec![0f32; D]];
+    let mut n = [0usize; 2];
+    for (p, cnt) in count.iter().enumerate() {
+        let tot: usize = cnt.iter().flatten().sum();
+        for b in 0..2 {
+            if cnt[b][ty] == tot && tot > 0 {
+                for g in 0..D {
+                    mean[b][g] += adj[(g, p)];
+                }
+                n[b] += 1;
+            }
+        }
+    }
+    assert!(
+        n[0] >= 1 && n[1] >= 1,
+        "need batch-pure pseudobulks of type {ty} in both batches, got {n:?}"
+    );
+    (0..D)
+        .map(|g| (mean[0][g] / n[0] as f32) / (mean[1][g] / n[1] as f32))
+        .collect()
+}
+
+/// The invariant every consumer of `mu_adjusted` relies on: after pooled
+/// adjustment the two batches' pseudobulks of the same type coincide. If the
+/// adjustment instead moved each batch into the OTHER batch's frame, the ratio
+/// would be the inverse platform factor (0.5 on the first half, 2 on the second).
+#[test]
+fn pooled_adjustment_lands_both_batches_in_one_frame() {
+    let (out, _) = run_pooled();
+    for ty in 0..2 {
+        let ratio = ratio_from(&out, ty);
+        let worst = ratio.iter().map(|r| r.ln().abs()).fold(0f32, f32::max);
+        let swapped: Vec<f32> = (0..D).map(|g| 1.0 / platform(g)).collect();
+        assert!(
+            worst < 0.3f32.ln().abs().min(0.3),
+            "type {ty}: mu_adjusted(shifted)/mu_adjusted(clean) per gene = {ratio:?} — \
+             not a common frame (|log ratio| up to {worst:.2}); the inverse platform \
+             factor would be {swapped:?}"
+        );
+    }
+}
+
+/// `δ` carries the whole platform factor between the batches and is pinned to
+/// geometric mean 1 per gene, so neither batch is "the" reference.
+#[test]
+fn delta_carries_the_platform_factor_symmetrically() {
+    let (out, names) = run_pooled();
+    let delta = out.levels[0]
+        .delta
+        .as_ref()
+        .expect("two batches ⇒ delta")
+        .posterior_mean();
+    let shifted = names.iter().position(|n| n.as_ref() == "shifted").unwrap();
+    let clean = names.iter().position(|n| n.as_ref() == "clean").unwrap();
+    for g in 0..D {
+        let ratio = delta[(g, shifted)] / delta[(g, clean)];
+        assert!(
+            (ratio / platform(g)).ln().abs() < 0.3f32.ln().abs().min(0.3),
+            "gene {g}: delta ratio {ratio:.3} vs planted platform {}",
+            platform(g)
+        );
+        let gm = (delta[(g, shifted)] * delta[(g, clean)]).sqrt();
+        assert!(
+            (gm - 1.0).abs() < 0.1,
+            "gene {g}: geometric mean of delta = {gm:.3}, want 1"
+        );
+    }
+}

--- a/data-beans/Cargo.toml
+++ b/data-beans/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 edition.workspace = true
 # Own version (decoupled from workspace.version): data-beans evolves its CLI /
 # QC API independently of the shared utility crates.
-version = "0.6.0"
+version = "0.6.1"
 
 [[bin]]
 name = "data-beans"

--- a/data-beans/src/handlers/transformation.rs
+++ b/data-beans/src/handlers/transformation.rs
@@ -47,6 +47,14 @@ pub struct SubsetColumnsArgs {
     #[arg(long, default_value_t = true)]
     pub allow_prefix: bool,
 
+    /// Match names exactly (plus the delimiter base key): no prefix matching.
+    /// `--allow-prefix` defaults to on and, being a bare flag, cannot be turned
+    /// off from the command line; this is the off switch. Numeric or short gene
+    /// names are prefixes of many others, so a name list can otherwise keep far
+    /// more rows than it names.
+    #[arg(long, default_value_t = false)]
+    pub exact_names: bool,
+
     /// squeeze
     #[arg(long, default_value_t = false)]
     pub do_squeeze: bool,
@@ -84,6 +92,14 @@ pub struct SubsetRowsArgs {
     /// enable prefix matching (stored name is prefix of query or vice versa)
     #[arg(long, default_value_t = true)]
     pub allow_prefix: bool,
+
+    /// Match names exactly (plus the delimiter base key): no prefix matching.
+    /// `--allow-prefix` defaults to on and, being a bare flag, cannot be turned
+    /// off from the command line; this is the off switch. Numeric or short gene
+    /// names are prefixes of many others, so a name list can otherwise keep far
+    /// more rows than it names.
+    #[arg(long, default_value_t = false)]
+    pub exact_names: bool,
 
     /// squeeze
     #[arg(long, default_value_t = false)]

--- a/data-beans/src/handlers/transformation/subset.rs
+++ b/data-beans/src/handlers/transformation/subset.rs
@@ -89,7 +89,7 @@ pub fn subset_columns(args: &SubsetColumnsArgs) -> anyhow::Result<()> {
                 .iter()
                 .enumerate()
                 .map(|(i, name)| (name.clone(), i.to_string().into_boxed_str())),
-            args.allow_prefix,
+            args.allow_prefix && !args.exact_names,
         )
         .with_delimiter(args.delimiter);
 
@@ -179,7 +179,7 @@ pub fn subset_rows(args: &SubsetRowsArgs) -> anyhow::Result<()> {
                 .iter()
                 .enumerate()
                 .map(|(i, name)| (name.clone(), i.to_string().into_boxed_str())),
-            args.allow_prefix,
+            args.allow_prefix && !args.exact_names,
         )
         .with_delimiter(args.delimiter);
 

--- a/graph-embedding-util/Cargo.toml
+++ b/graph-embedding-util/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.3.19"
+version = "0.3.20"
 
 [lib]
 name = "graph_embedding_util"

--- a/graph-embedding-util/Cargo.toml
+++ b/graph-embedding-util/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.3.20"
+version = "0.3.21"
 
 [lib]
 name = "graph_embedding_util"

--- a/graph-embedding-util/src/eval.rs
+++ b/graph-embedding-util/src/eval.rs
@@ -149,7 +149,6 @@ pub fn save_outputs_named(
         save_embedding(&vsel_path, &velocity_sel, ctx.feature_names, "feature")?;
         info!("Per-gene velocity inclusion probability σ(s_δ) → {vsel_path}");
     }
-    write_module_tables(out_prefix, model, ctx.feature_names)?;
     Ok(())
 }
 
@@ -163,41 +162,45 @@ pub fn save_outputs_named(
 /// * `{out}.module_bias.parquet` — the per-module bias of the exact term.
 ///
 /// The feature dictionary itself keeps holding the composed `ρ = π μ + r`, so
-/// nothing that reads it has to know modules exist.
+/// nothing that reads it has to know modules exist. Called by each driver after
+/// its own outputs, not from [`save_outputs_named`].
 pub fn write_module_tables(
     out_prefix: &str,
     model: &JointEmbedModel,
     feature_names: &[Box<str>],
 ) -> anyhow::Result<()> {
-    let Some(pi) = model.module_membership()? else {
+    use crate::transfer::{
+        MODULE_BIAS_SUFFIX, MODULE_DICTIONARY_SUFFIX, MODULE_MEMBERSHIP_SUFFIX,
+        MODULE_RESIDUAL_SUFFIX,
+    };
+    let Some(modules) = &model.modules else {
         return Ok(());
     };
-    let modules = model
-        .modules
-        .as_ref()
-        .expect("module_membership implies modules");
+    let pi = model
+        .module_membership()?
+        .expect("a module model has a membership");
     let m = modules.n_modules;
     let module_names: Vec<Box<str>> = (0..m).map(|i| format!("m{i}").into_boxed_str()).collect();
-    let pi_path = format!("{out_prefix}.module_membership.parquet");
+    let pi_path = format!("{out_prefix}.{MODULE_MEMBERSHIP_SUFFIX}");
     pi.to_parquet_with_names(
         &pi_path,
         (Some(feature_names), Some("feature")),
         Some(&module_names),
     )?;
     save_embedding(
-        &format!("{out_prefix}.module_dictionary.parquet"),
+        &format!("{out_prefix}.{MODULE_DICTIONARY_SUFFIX}"),
         &modules.mu.detach(),
         &module_names,
         "module",
     )?;
     save_embedding(
-        &format!("{out_prefix}.module_residual.parquet"),
+        &format!("{out_prefix}.{MODULE_RESIDUAL_SUFFIX}"),
         &modules.residual.detach(),
         feature_names,
         "feature",
     )?;
     save_bias(
-        &format!("{out_prefix}.module_bias.parquet"),
+        &format!("{out_prefix}.{MODULE_BIAS_SUFFIX}"),
         &modules.b_module.detach(),
         &module_names,
         "module",

--- a/graph-embedding-util/src/eval.rs
+++ b/graph-embedding-util/src/eval.rs
@@ -149,6 +149,60 @@ pub fn save_outputs_named(
         save_embedding(&vsel_path, &velocity_sel, ctx.feature_names, "feature")?;
         info!("Per-gene velocity inclusion probability σ(s_δ) → {vsel_path}");
     }
+    write_module_tables(out_prefix, model, ctx.feature_names)?;
+    Ok(())
+}
+
+/// Write the learned-module tables of a module-parameterized model; a no-op for
+/// every other parameterization.
+///
+/// * `{out}.module_membership.parquet` — `π [D × M]`, rows on the simplex with
+///   exact zeros, columns `m0..`; keyed on the feature names.
+/// * `{out}.module_dictionary.parquet` — `μ [M × H]`, rows `m0..`, columns `h0..`.
+/// * `{out}.module_residual.parquet` — `r [D × H]`, the per-feature remainder.
+/// * `{out}.module_bias.parquet` — the per-module bias of the exact term.
+///
+/// The feature dictionary itself keeps holding the composed `ρ = π μ + r`, so
+/// nothing that reads it has to know modules exist.
+pub fn write_module_tables(
+    out_prefix: &str,
+    model: &JointEmbedModel,
+    feature_names: &[Box<str>],
+) -> anyhow::Result<()> {
+    let Some(pi) = model.module_membership()? else {
+        return Ok(());
+    };
+    let modules = model
+        .modules
+        .as_ref()
+        .expect("module_membership implies modules");
+    let m = modules.n_modules;
+    let module_names: Vec<Box<str>> = (0..m).map(|i| format!("m{i}").into_boxed_str()).collect();
+    let pi_path = format!("{out_prefix}.module_membership.parquet");
+    pi.to_parquet_with_names(
+        &pi_path,
+        (Some(feature_names), Some("feature")),
+        Some(&module_names),
+    )?;
+    save_embedding(
+        &format!("{out_prefix}.module_dictionary.parquet"),
+        &modules.mu.detach(),
+        &module_names,
+        "module",
+    )?;
+    save_embedding(
+        &format!("{out_prefix}.module_residual.parquet"),
+        &modules.residual.detach(),
+        feature_names,
+        "feature",
+    )?;
+    save_bias(
+        &format!("{out_prefix}.module_bias.parquet"),
+        &modules.b_module.detach(),
+        &module_names,
+        "module",
+    )?;
+    info!("Learned gene modules ({m}) → {pi_path} (+ module_dictionary / module_residual / module_bias)");
     Ok(())
 }
 

--- a/graph-embedding-util/src/fit/batch_fold.rs
+++ b/graph-embedding-util/src/fit/batch_fold.rs
@@ -1,0 +1,116 @@
+//! Per-batch gene fold for the phase-2 projection.
+//!
+//! The collapse estimates, per gene and batch, the fold `δ_gb` by which that
+//! batch's observed counts depart from the batch-free pseudobulk rate `μ`
+//! (`E[y_gb] = δ_gb · μ_g`). Phase 1 trains the dictionary on those batch-free
+//! pseudobulks, so phase 2 puts each cell in the same frame by **dividing its
+//! counts by its batch's fold** before the Poisson-MAP solve.
+//!
+//! Why divide rather than offset the rate: a low-rank log-linear dictionary
+//! cannot reproduce a whole gene profile exactly, and at the optimum the Poisson
+//! fit matches the count-weighted centroid in dictionary space. With `log δ` as a
+//! rate offset that centroid is weighted by each batch's own `δ`, so two batches
+//! solve two different weighted problems and land apart even when `δ` is right.
+//! Dividing the counts first hands every batch the same estimating equation, so
+//! the solution is batch-invariant regardless of misfit — measured at pseudobulk
+//! resolution, where sparsity plays no part, the divide agreed across studies
+//! markedly better than the offset.
+//!
+//! This module turns the collapse's `δ` into that fold on the unified axes:
+//! batches matched **by name** (the count backend numbers batches by sorted name,
+//! the unified data by first appearance), rows gathered onto the unified feature
+//! axis, floored so a gene a batch never measured divides by a small positive
+//! number rather than zero.
+
+use super::projection::CellBatchFold;
+use anyhow::Context;
+use nalgebra::DMatrix;
+use rustc_hash::FxHashMap;
+
+/// Floor on a posterior-mean `δ`, so a gene a batch never measured stays a finite
+/// positive divisor.
+pub const DELTA_FLOOR: f32 = 1e-6;
+
+/// `δ_gb` on the unified feature axis, one row per **unified** batch id.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BatchGeneFold {
+    /// `[n_batches × n_features]` row-major, linear scale, floored.
+    pub delta: Vec<f32>,
+    pub n_features: usize,
+    /// Unified batch names, in row order.
+    pub batch_names: Vec<Box<str>>,
+}
+
+impl BatchGeneFold {
+    pub fn n_batches(&self) -> usize {
+        self.batch_names.len()
+    }
+
+    /// The fold row for unified batch `b`.
+    pub fn row(&self, b: usize) -> &[f32] {
+        &self.delta[b * self.n_features..(b + 1) * self.n_features]
+    }
+
+    /// The per-cell view phase 2 divides by: this table plus each cell's batch.
+    pub(crate) fn cell_fold<'a>(&'a self, cell_to_batch: &'a [u32]) -> CellBatchFold<'a> {
+        CellBatchFold {
+            fold: self,
+            cell_to_batch,
+        }
+    }
+}
+
+/// What [`batch_gene_fold`] reads.
+pub(crate) struct FoldSource<'a> {
+    /// The collapse's `δ` posterior mean, `[backend_rows × collapse_batches]`.
+    pub delta: &'a DMatrix<f32>,
+    /// The collapse's batch names, in `delta`'s column order.
+    pub collapse_batch_names: &'a [Box<str>],
+    /// Unified batch names, in unified batch-id order.
+    pub unified_batch_names: &'a [Box<str>],
+    pub n_features: usize,
+    /// Unified feature → backend row.
+    pub feature_to_backend: &'a [usize],
+}
+
+/// Build the per-batch fold table, or `None` when there is a single unified
+/// batch (nothing to correct against).
+pub(crate) fn batch_gene_fold(src: FoldSource) -> anyhow::Result<Option<BatchGeneFold>> {
+    let n_batches = src.unified_batch_names.len();
+    if n_batches < 2 {
+        return Ok(None);
+    }
+    anyhow::ensure!(
+        src.delta.ncols() == src.collapse_batch_names.len(),
+        "collapse δ has {} columns but {} batch names",
+        src.delta.ncols(),
+        src.collapse_batch_names.len()
+    );
+    let col_of: FxHashMap<&str, usize> = src
+        .collapse_batch_names
+        .iter()
+        .enumerate()
+        .map(|(c, name)| (name.as_ref(), c))
+        .collect();
+    let delta =
+        super::setup::gather_to_unified_axis(src.delta, src.n_features, src.feature_to_backend);
+    let n_features = src.n_features;
+    let mut fold = Vec::with_capacity(n_batches * n_features);
+    for name in src.unified_batch_names {
+        let &c = col_of.get(name.as_ref()).with_context(|| {
+            format!(
+                "batch {name:?} has no δ column in the collapse (collapse batches: {})",
+                src.collapse_batch_names.join(", ")
+            )
+        })?;
+        fold.extend((0..n_features).map(|f| delta[(f, c)].max(DELTA_FLOOR)));
+    }
+    Ok(Some(BatchGeneFold {
+        delta: fold,
+        n_features,
+        batch_names: src.unified_batch_names.to_vec(),
+    }))
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/fit/batch_fold/tests.rs
+++ b/graph-embedding-util/src/fit/batch_fold/tests.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+fn names(v: &[&str]) -> Vec<Box<str>> {
+    v.iter().map(|s| (*s).into()).collect()
+}
+
+fn assert_close(got: &[f32], want: &[f32]) {
+    assert_eq!(got.len(), want.len());
+    for (i, (g, w)) in got.iter().zip(want).enumerate() {
+        assert!((g - w).abs() < 1e-6, "entry {i}: got {g}, want {w}");
+    }
+}
+
+/// The count backend numbers batches by sorted name, the unified data by first
+/// appearance. The fold rows must follow the UNIFIED ids, matched by name.
+#[test]
+fn maps_collapse_batches_by_name_not_by_column() {
+    // rows = genes, columns = collapse batches ["early", "late"] (sorted order)
+    let delta = DMatrix::from_row_slice(3, 2, &[1.0, 0.5, 2.0, 1.0, 4.0, 8.0]);
+    let off = batch_gene_fold(FoldSource {
+        delta: &delta,
+        collapse_batch_names: &names(&["early", "late"]),
+        unified_batch_names: &names(&["late", "early"]),
+        n_features: 3,
+        feature_to_backend: &[0, 1, 2],
+    })
+    .unwrap()
+    .expect("two batches ⇒ a fold");
+    assert_eq!(off.n_batches(), 2);
+    assert_eq!(off.batch_names, names(&["late", "early"]));
+    assert_close(off.row(0), &[0.5, 1.0, 8.0]);
+    assert_close(off.row(1), &[1.0, 2.0, 4.0]);
+}
+
+/// Backend rows are gathered onto the unified feature axis through
+/// `feature_to_backend`, like every other collapse table.
+#[test]
+fn gathers_rows_onto_the_unified_feature_axis() {
+    let delta = DMatrix::from_row_slice(4, 2, &[1.0, 1.0, 2.0, 3.0, 1.0, 1.0, 4.0, 5.0]);
+    let off = batch_gene_fold(FoldSource {
+        delta: &delta,
+        collapse_batch_names: &names(&["a", "b"]),
+        unified_batch_names: &names(&["a", "b"]),
+        n_features: 2,
+        feature_to_backend: &[3, 1],
+    })
+    .unwrap()
+    .unwrap();
+    assert_eq!(off.n_features, 2);
+    assert_close(off.row(0), &[4.0, 2.0]);
+    assert_close(off.row(1), &[5.0, 3.0]);
+}
+
+#[test]
+fn one_batch_yields_no_fold() {
+    let delta = DMatrix::from_row_slice(2, 1, &[3.0, 0.2]);
+    let off = batch_gene_fold(FoldSource {
+        delta: &delta,
+        collapse_batch_names: &names(&["only"]),
+        unified_batch_names: &names(&["only"]),
+        n_features: 2,
+        feature_to_backend: &[0, 1],
+    })
+    .unwrap();
+    assert!(off.is_none());
+}
+
+#[test]
+fn unified_batch_missing_from_the_collapse_is_an_error() {
+    let delta = DMatrix::from_row_slice(2, 2, &[1.0, 1.0, 1.0, 1.0]);
+    let err = batch_gene_fold(FoldSource {
+        delta: &delta,
+        collapse_batch_names: &names(&["a", "b"]),
+        unified_batch_names: &names(&["a", "c"]),
+        n_features: 2,
+        feature_to_backend: &[0, 1],
+    })
+    .expect_err("unknown batch must fail");
+    assert!(err.to_string().contains('c'), "{err}");
+}
+
+#[test]
+fn nonpositive_delta_is_floored() {
+    let delta = DMatrix::from_row_slice(2, 2, &[0.0, 1.0, -1.0, 2.0]);
+    let off = batch_gene_fold(FoldSource {
+        delta: &delta,
+        collapse_batch_names: &names(&["a", "b"]),
+        unified_batch_names: &names(&["a", "b"]),
+        n_features: 2,
+        feature_to_backend: &[0, 1],
+    })
+    .unwrap()
+    .unwrap();
+    assert_close(off.row(0), &[DELTA_FLOOR, DELTA_FLOOR]);
+    assert_close(off.row(1), &[1.0, 2.0]);
+}

--- a/graph-embedding-util/src/fit/config.rs
+++ b/graph-embedding-util/src/fit/config.rs
@@ -219,8 +219,6 @@ pub struct GeneModuleConfig {
     pub lambda_module: f32,
     /// Weight of the load-balance prior `KL(π̄ ‖ Uniform)`.
     pub lambda_balance: f32,
-    /// Weight of the row-entropy penalty on the membership (`0` = off).
-    pub lambda_entropy: f32,
     /// Ridge on the per-feature residual `r_g` — the module model's only per-row
     /// table, so this replaces `feature_embedding_l2`.
     pub residual_l2: f32,
@@ -236,8 +234,8 @@ pub struct GeneModuleConfig {
     pub parent: Option<ParentModulesOwned>,
 }
 
-/// Owned form of [`crate::fit::module_warm::ParentModules`], carried on the
-/// config because the fit outlives the caller's borrows.
+/// A parent run's module tables, carried on the config for the warm start
+/// (`senna update`).
 #[derive(Clone, Debug)]
 pub struct ParentModulesOwned {
     /// Parent composed rows `[D_parent × H]`.
@@ -248,25 +246,19 @@ pub struct ParentModulesOwned {
     pub mu: nalgebra::DMatrix<f32>,
     /// For each feature of this fit's axis, the parent row it matched.
     pub row_to_parent: Vec<Option<usize>>,
-    /// Neighbours / floor for the unmatched features' initialization.
-    pub k: usize,
-    pub similarity_floor: f32,
+    /// Neighbourhood for the unmatched features' initialization.
+    pub knobs: crate::transfer::AlignKnobs,
 }
 
-impl Default for GeneModuleConfig {
-    fn default() -> Self {
-        Self {
-            n_modules: 128,
-            warmup_epochs: None,
-            gene_dropout: 0.2,
-            lambda_module: 1.0,
-            lambda_balance: 1.0,
-            lambda_entropy: 0.0,
-            residual_l2: 0.1,
-            units_per_step: 64,
-            init_own_mass: 0.9,
-            parent: None,
-        }
+impl GeneModuleConfig {
+    /// Epochs the warm-start membership is held: the explicit count, else a
+    /// quarter of the epochs, at least one and at most all of them. The one
+    /// definition every trainer with a module model uses.
+    #[must_use]
+    pub fn warmup_epochs_for(&self, epochs: usize) -> usize {
+        self.warmup_epochs
+            .unwrap_or_else(|| ((epochs as f64) * MODULE_WARMUP_FRAC).ceil() as usize)
+            .clamp(usize::from(epochs > 0), epochs)
     }
 }
 
@@ -354,15 +346,11 @@ pub(crate) fn stage_params(config: &FitConfig) -> TrainingParams {
         max_grad_norm: config.max_grad_norm,
         delta_l2: config.delta_l2,
         module: config.gene_modules.as_ref().map(|g| ModuleTrainParams {
-            warmup_epochs: g
-                .warmup_epochs
-                .unwrap_or_else(|| ((config.epochs as f64) * MODULE_WARMUP_FRAC).ceil() as usize)
-                .clamp(usize::from(config.epochs > 0), config.epochs),
+            warmup_epochs: g.warmup_epochs_for(config.epochs),
             gene_dropout: g.gene_dropout,
             units_per_step: g.units_per_step,
             lambda_module: g.lambda_module,
             lambda_balance: g.lambda_balance,
-            lambda_entropy: g.lambda_entropy,
             residual_l2: g.residual_l2,
         }),
     }

--- a/graph-embedding-util/src/fit/config.rs
+++ b/graph-embedding-util/src/fit/config.rs
@@ -332,6 +332,9 @@ pub struct FitOutput {
     /// each with its pseudobulks' batches — the geometry the feature side was
     /// trained against, for batch diagnostics.
     pub pb_embeddings: Vec<super::pb_readout::PbLevelEmbedding>,
+    /// Per-batch gene fold `log δ_gb` phase 2 divided each batch's cell counts by;
+    /// `None` on single-batch data.
+    pub batch_gene_fold: Option<super::batch_fold::BatchGeneFold>,
 }
 
 pub(crate) fn stage_params(config: &FitConfig) -> TrainingParams {

--- a/graph-embedding-util/src/fit/config.rs
+++ b/graph-embedding-util/src/fit/config.rs
@@ -1,7 +1,7 @@
 use super::lift::{CellLineage, LineageQc};
 use super::projection::PbLevelVelocity;
 use crate::model::JointEmbedModel;
-use crate::training::TrainingParams;
+use crate::training::{ModuleTrainParams, TrainingParams};
 use candle_util::candle_core::Device;
 use candle_util::candle_nn::VarMap;
 use data_beans_alg::refine_multilevel::RefineParams;
@@ -32,6 +32,10 @@ pub(crate) const DEFAULT_STRATIFY_ALPHA_CELL: f32 = 0.5;
 /// orient the DAG — that is exactly what this fraction trades. Off the lineage
 /// path phase 1 keeps the whole budget and the run is byte-identical.
 pub(crate) const LINEAGE_WARMUP_FRAC: f64 = 0.5;
+
+/// Fraction of `epochs` the module membership is held at its warm start when
+/// [`GeneModuleConfig::warmup_epochs`] is not given.
+pub(crate) const MODULE_WARMUP_FRAC: f64 = 0.25;
 
 /// Hyperparameter / configuration bundle for [`fit`]. Constructed by
 /// each caller from its own CLI arguments — this crate doesn't import
@@ -191,6 +195,55 @@ pub struct FitConfig {
     /// `posterior::dim_block` samples as a PIP. See [`FeatureGateConfig`] and
     /// [`crate::model::FeatureGateSpec`].
     pub feature_gate: Option<FeatureGateConfig>,
+    /// Learned gene modules in front of the feature embedding
+    /// ([`crate::model::FeatModules`]): `ρ_g = Σ_m π_gm μ_m + r_g` with a learned
+    /// mixed membership, an exact cell–module softmax term, within-module NCE
+    /// negatives and gene dropout at pooling time. `None` (default) = the free
+    /// embedding, byte-identical to a build before this existed. Mutually
+    /// exclusive with `feat_factor` and `pb_posterior`.
+    pub gene_modules: Option<GeneModuleConfig>,
+}
+
+/// Caller-facing configuration of the learned gene modules.
+#[derive(Clone, Debug)]
+pub struct GeneModuleConfig {
+    /// Number of modules `M`.
+    pub n_modules: usize,
+    /// Epochs the warm-start membership is held before it trains. `None` = a
+    /// quarter of the epochs, at least one.
+    pub warmup_epochs: Option<usize>,
+    /// Per-step probability that a feature is hidden when the module counts are
+    /// pooled (`0` = off).
+    pub gene_dropout: f32,
+    /// Weight of the exact cell–module term relative to the NCE.
+    pub lambda_module: f32,
+    /// Weight of the load-balance prior `KL(π̄ ‖ Uniform)`.
+    pub lambda_balance: f32,
+    /// Weight of the row-entropy penalty on the membership (`0` = off).
+    pub lambda_entropy: f32,
+    /// Ridge on the per-feature residual `r_g` — the module model's only per-row
+    /// table, so this replaces `feature_embedding_l2`.
+    pub residual_l2: f32,
+    /// Units (cells or pseudobulks) pooled for the exact term per step per axis.
+    pub units_per_step: usize,
+    /// Share of a feature's warm-start membership on its k-means module.
+    pub init_own_mass: f32,
+}
+
+impl Default for GeneModuleConfig {
+    fn default() -> Self {
+        Self {
+            n_modules: 128,
+            warmup_epochs: None,
+            gene_dropout: 0.2,
+            lambda_module: 1.0,
+            lambda_balance: 1.0,
+            lambda_entropy: 0.0,
+            residual_l2: 0.1,
+            units_per_step: 64,
+            init_own_mass: 0.9,
+        }
+    }
 }
 
 /// Caller-provided spec for the per-gene β-sharing feature factorization. Lengths
@@ -276,5 +329,17 @@ pub(crate) fn stage_params(config: &FitConfig) -> TrainingParams {
         feature_embedding_l2: config.feature_embedding_l2,
         max_grad_norm: config.max_grad_norm,
         delta_l2: config.delta_l2,
+        module: config.gene_modules.as_ref().map(|g| ModuleTrainParams {
+            warmup_epochs: g
+                .warmup_epochs
+                .unwrap_or_else(|| ((config.epochs as f64) * MODULE_WARMUP_FRAC).ceil() as usize)
+                .clamp(usize::from(config.epochs > 0), config.epochs),
+            gene_dropout: g.gene_dropout,
+            units_per_step: g.units_per_step,
+            lambda_module: g.lambda_module,
+            lambda_balance: g.lambda_balance,
+            lambda_entropy: g.lambda_entropy,
+            residual_l2: g.residual_l2,
+        }),
     }
 }

--- a/graph-embedding-util/src/fit/config.rs
+++ b/graph-embedding-util/src/fit/config.rs
@@ -328,6 +328,10 @@ pub struct FitOutput {
     /// Both gates' posteriors on the β-sharing (splice) model. `Some` in place of
     /// [`Self::pb_posterior`] when `feat_factor` was set.
     pub splice_posterior: Option<crate::posterior::pb_gibbs::SpliceGibbsResult>,
+    /// The phase-1 pseudobulk embeddings per collapse level (coarsest → finest),
+    /// each with its pseudobulks' batches — the geometry the feature side was
+    /// trained against, for batch diagnostics.
+    pub pb_embeddings: Vec<super::pb_readout::PbLevelEmbedding>,
 }
 
 pub(crate) fn stage_params(config: &FitConfig) -> TrainingParams {

--- a/graph-embedding-util/src/fit/config.rs
+++ b/graph-embedding-util/src/fit/config.rs
@@ -228,6 +228,29 @@ pub struct GeneModuleConfig {
     pub units_per_step: usize,
     /// Share of a feature's warm-start membership on its k-means module.
     pub init_own_mass: f32,
+    /// A parent run's module tables to warm-start from (`senna update`): matched
+    /// features carry the parent's membership, unmatched ones are initialized
+    /// through the parent's modules from their profile neighbours, and `μ` starts
+    /// at the parent's. Overrides `n_modules` with the parent's `M`. `None` = the
+    /// k-means warm start from this fit's own pseudobulks.
+    pub parent: Option<ParentModulesOwned>,
+}
+
+/// Owned form of [`crate::fit::module_warm::ParentModules`], carried on the
+/// config because the fit outlives the caller's borrows.
+#[derive(Clone, Debug)]
+pub struct ParentModulesOwned {
+    /// Parent composed rows `[D_parent × H]`.
+    pub rho: nalgebra::DMatrix<f32>,
+    /// Parent membership `[D_parent × M]`.
+    pub pi: nalgebra::DMatrix<f32>,
+    /// Parent module dictionary `[M × H]`.
+    pub mu: nalgebra::DMatrix<f32>,
+    /// For each feature of this fit's axis, the parent row it matched.
+    pub row_to_parent: Vec<Option<usize>>,
+    /// Neighbours / floor for the unmatched features' initialization.
+    pub k: usize,
+    pub similarity_floor: f32,
 }
 
 impl Default for GeneModuleConfig {
@@ -242,6 +265,7 @@ impl Default for GeneModuleConfig {
             residual_l2: 0.1,
             units_per_step: 64,
             init_own_mass: 0.9,
+            parent: None,
         }
     }
 }

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -3,6 +3,7 @@
 //! [`UnifiedData`] (so this crate stays free of file/path concerns).
 
 mod axes;
+pub mod batch_fold;
 mod config;
 pub mod lift;
 pub mod lineage;
@@ -17,6 +18,7 @@ mod selection;
 mod setup;
 pub(crate) mod stacked_pb;
 
+pub use batch_fold::BatchGeneFold;
 pub use config::{
     FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput, GeneModuleConfig, ParentModulesOwned,
 };
@@ -36,7 +38,8 @@ use matrix_param::traits::Inference;
 use nalgebra::DMatrix;
 
 use config::{stage_params, LINEAGE_WARMUP_FRAC};
-use projection::{project_cells_phase2, project_pbs_phase2, CellBatchDivisor, PHASE2_RIDGE};
+use matrix_util::traits::ConvertMatOps;
+use projection::{project_cells_phase2, project_pbs_phase2, CellBatchFold, PHASE2_RIDGE};
 pub use projection::{
     FrozenProjection, FrozenProjectionArgs, FrozenProjector, PHASE2_RIDGE as PROJECTION_RIDGE_SGD,
 };
@@ -80,6 +83,26 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
         cell_to_pb_per_level,
         blobs: pb_blobs,
     } = pb;
+    // Per-batch gene fold for phase 2, from the finest collapse's `δ`. The count
+    // backend numbers batches by sorted name; the unified data by first appearance
+    // — matched by name inside.
+    let batch_gene_fold: Option<BatchGeneFold> =
+        match collapsed_levels.last().and_then(|c| c.delta.as_ref()) {
+            Some(delta) => {
+                let collapse_batch_names =
+                    unified.count_backend().batch_names().ok_or_else(|| {
+                        anyhow::anyhow!("collapse fit a δ but the backend has no batch names")
+                    })?;
+                batch_fold::batch_gene_fold(batch_fold::FoldSource {
+                    delta: delta.posterior_mean(),
+                    collapse_batch_names: &collapse_batch_names,
+                    unified_batch_names: &unified.batch_names,
+                    n_features,
+                    feature_to_backend: &feature_to_backend,
+                })?
+            }
+            None => None,
+        };
     // Levels run coarsest..finest here, so the finest is `.last()`. Cloned
     // rather than moved: the level list feeds training below. The clone is
     // cheap relative to the fit and only happens when a reference is emitted.
@@ -271,10 +294,10 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
         .zip(&cell_to_pb_per_level)
         .map(
             |(m, c2pb)| -> anyhow::Result<pb_readout::PbLevelEmbedding> {
-                let n_pb = m.e_cell.dim(0)?;
-                let flat: Vec<f32> = m.e_cell.detach().flatten_all()?.to_vec1()?;
+                let e_pb = DMatrix::<f32>::from_tensor(&m.e_cell)?;
+                let n_pb = e_pb.nrows();
                 Ok(pb_readout::PbLevelEmbedding {
-                    e_pb: DMatrix::from_row_slice(n_pb, h, &flat),
+                    e_pb,
                     batch: pb_readout::majority_batch_per_pb(c2pb, &unified.batch_membership, n_pb),
                 })
             },
@@ -434,26 +457,13 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
     // `projection::project_cells_phase2`. The per-cell intercept `b_cell` is fitted
     // and kept.
     let phase2 = {
-        // Phase-2 batch correction (mirrors senna svd/topic): divide each cell's
-        // counts by its finest-pb μ_residual fold-factor. μ_residual is gathered
-        // onto the unified feature axis so a feature id indexes a row directly;
-        // built only when the collapse fit one (>1 batch).
-        let phase2_mu_residual: Option<DMatrix<f32>> = collapsed_levels
-            .last()
-            .and_then(|c| c.mu_residual.as_ref())
-            .map(|mr| {
-                setup::gather_to_unified_axis(mr.posterior_mean(), n_features, &feature_to_backend)
-            });
-        let batch_divisor = phase2_mu_residual.as_ref().map(|mu| CellBatchDivisor {
-            mu_residual: mu,
-            // `.last()` is always `Some` here: the divisor only exists when the
-            // collapse produced a μ_residual, i.e. ≥1 level (num_levels.max(1)),
-            // and `cell_to_pb_per_level` has the same length.
-            cell_to_pb: cell_to_pb_per_level
-                .last()
-                .map(Vec::as_slice)
-                .expect("collapse always produces ≥1 level"),
-        });
+        // Phase-2 batch correction: divide each cell's counts by its batch's
+        // per-gene fold `δ` from the finest collapse (see `batch_fold`), so the
+        // solve runs in the batch-free frame the dictionary was trained in. `None`
+        // on single-batch data.
+        let batch_fold: Option<CellBatchFold> = batch_gene_fold
+            .as_ref()
+            .map(|f| f.cell_fold(&unified.batch_membership));
 
         // β-sharing (gem): identity is resolved by the SPLICED edges (stored raw),
         // and a second pass emits the raw velocity increment δ on the cell axis.
@@ -470,7 +480,7 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
             n_cells,
             f64::from(PHASE2_RIDGE),
             &config.device,
-            batch_divisor,
+            batch_fold,
             unspliced,
             config.joint_velocity,
         )?
@@ -543,6 +553,7 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
     };
 
     Ok(FitOutput {
+        batch_gene_fold,
         model: cell_model,
         finest_collapse,
         varmap,

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod stacked_pb;
 
 pub use config::{FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput, GeneModuleConfig};
 pub use lift::{CellLineage, LineageQc};
-pub use module_args::GeneModuleArgs;
+pub use module_args::{GeneModuleArgs, DEFAULT_GENE_MODULES};
 pub use module_warm::warm_start_module_labels;
 pub use projection::PbLevelVelocity;
 pub use resolve_embedding::{train_rest, RestConfig, RestTrainInputs, TrainedRest};

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -20,8 +20,8 @@ pub use config::{
     FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput, GeneModuleConfig, ParentModulesOwned,
 };
 pub use lift::{CellLineage, LineageQc};
-pub use module_args::{GeneModuleArgs, DEFAULT_GENE_MODULES};
-pub use module_warm::{parent_module_logits, warm_start_module_labels, ParentModules};
+pub use module_args::GeneModuleArgs;
+pub use module_warm::{parent_module_logits, warm_start_module_labels};
 pub use projection::PbLevelVelocity;
 pub use resolve_embedding::{train_rest, RestConfig, RestTrainInputs, TrainedRest};
 
@@ -109,17 +109,7 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
         let profile = setup::gather_to_unified_axis(pb_full, n_features, &feature_to_backend);
         match &g.parent {
             Some(parent) => models::ModuleWarm::Parent {
-                logits: module_warm::parent_module_logits(
-                    &module_warm::ParentModules {
-                        rho: &parent.rho,
-                        pi: &parent.pi,
-                        mu: &parent.mu,
-                        row_to_parent: &parent.row_to_parent,
-                    },
-                    &profile,
-                    parent.k,
-                    parent.similarity_floor,
-                ),
+                logits: module_warm::parent_module_logits(parent, &profile),
                 mu: parent.mu.clone(),
             },
             None => models::ModuleWarm::Labels(module_warm::warm_start_module_labels(

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -9,6 +9,7 @@ pub mod lineage;
 mod models;
 pub mod module_args;
 pub mod module_warm;
+pub mod pb_readout;
 pub mod projection;
 pub mod resolve_embedding;
 mod samplers;
@@ -22,6 +23,7 @@ pub use config::{
 pub use lift::{CellLineage, LineageQc};
 pub use module_args::GeneModuleArgs;
 pub use module_warm::{parent_module_logits, warm_start_module_labels};
+pub use pb_readout::{majority_batch_per_pb, PbLevelEmbedding};
 pub use projection::PbLevelVelocity;
 pub use resolve_embedding::{train_rest, RestConfig, RestTrainInputs, TrainedRest};
 

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -7,6 +7,8 @@ mod config;
 pub mod lift;
 pub mod lineage;
 mod models;
+pub mod module_args;
+pub mod module_warm;
 pub mod projection;
 pub mod resolve_embedding;
 mod samplers;
@@ -14,8 +16,10 @@ mod selection;
 mod setup;
 pub(crate) mod stacked_pb;
 
-pub use config::{FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput};
+pub use config::{FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput, GeneModuleConfig};
 pub use lift::{CellLineage, LineageQc};
+pub use module_args::GeneModuleArgs;
+pub use module_warm::warm_start_module_labels;
 pub use projection::PbLevelVelocity;
 pub use resolve_embedding::{train_rest, RestConfig, RestTrainInputs, TrainedRest};
 
@@ -89,10 +93,21 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
     // VarMap and embedding heads //
     ////////////////////////////////
     let varmap = VarMap::new();
+    // Module warm start: k-means over the feature profiles at the finest collapse
+    // level, on the same batch-corrected pseudobulk counts phase 1 trains on.
+    let module_warm: Option<Vec<u32>> = config.gene_modules.as_ref().map(|g| {
+        let finest = collapsed_levels.last().expect("at least one level");
+        let pb_full = match &finest.mu_adjusted {
+            Some(adj) => adj.posterior_mean(),
+            None => finest.mu_observed.posterior_mean(),
+        };
+        let profile = setup::gather_to_unified_axis(pb_full, n_features, &feature_to_backend);
+        module_warm::warm_start_module_labels(&profile, g.n_modules, config.seed)
+    });
     let models::Heads {
         mut cell_model,
         mut level_models,
-    } = models::build_heads(unified, &pb_blobs, &config, &varmap)?;
+    } = models::build_heads(unified, &pb_blobs, &config, module_warm.as_deref(), &varmap)?;
 
     ////////////////////////////////
     // Composite axes and trainer //

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -264,6 +264,23 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
     // `cell_axis` / `pb_axes` borrows of `cell_model` / `cell_samplers` end
     // here, freeing them for the phase-2 `&mut` projection below.
 
+    // The trained pseudobulk tables, read before phase 2 takes `&mut cell_model`:
+    // one `[n_pb × H]` per level with each pseudobulk's batch.
+    let pb_embeddings: Vec<pb_readout::PbLevelEmbedding> = level_models
+        .iter()
+        .zip(&cell_to_pb_per_level)
+        .map(
+            |(m, c2pb)| -> anyhow::Result<pb_readout::PbLevelEmbedding> {
+                let n_pb = m.e_cell.dim(0)?;
+                let flat: Vec<f32> = m.e_cell.detach().flatten_all()?.to_vec1()?;
+                Ok(pb_readout::PbLevelEmbedding {
+                    e_pb: DMatrix::from_row_slice(n_pb, h, &flat),
+                    batch: pb_readout::majority_batch_per_pb(c2pb, &unified.batch_membership, n_pb),
+                })
+            },
+        )
+        .collect::<anyhow::Result<_>>()?;
+
     // Back to the mean for everything downstream: training averaged over draws, so
     // `E[z ⊙ β] = pip ⊙ β` is the dictionary the fit actually implies. Leaving a draw
     // installed would ship ONE random sub-model as if it were the answer. No-op when
@@ -536,6 +553,7 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
         lineage_qc,
         pb_posterior,
         splice_posterior,
+        pb_embeddings,
     })
 }
 

--- a/graph-embedding-util/src/fit/mod.rs
+++ b/graph-embedding-util/src/fit/mod.rs
@@ -16,10 +16,12 @@ mod selection;
 mod setup;
 pub(crate) mod stacked_pb;
 
-pub use config::{FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput, GeneModuleConfig};
+pub use config::{
+    FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput, GeneModuleConfig, ParentModulesOwned,
+};
 pub use lift::{CellLineage, LineageQc};
 pub use module_args::{GeneModuleArgs, DEFAULT_GENE_MODULES};
-pub use module_warm::warm_start_module_labels;
+pub use module_warm::{parent_module_logits, warm_start_module_labels, ParentModules};
 pub use projection::PbLevelVelocity;
 pub use resolve_embedding::{train_rest, RestConfig, RestTrainInputs, TrainedRest};
 
@@ -95,19 +97,42 @@ pub fn fit(unified: &mut UnifiedData, config: FitConfig) -> anyhow::Result<FitOu
     let varmap = VarMap::new();
     // Module warm start: k-means over the feature profiles at the finest collapse
     // level, on the same batch-corrected pseudobulk counts phase 1 trains on.
-    let module_warm: Option<Vec<u32>> = config.gene_modules.as_ref().map(|g| {
+    // Either the k-means labels over this fit's own profiles, or — under a parent
+    // (`senna update`) — explicit logits carrying the parent's membership for the
+    // matched features and initializing the rest through the parent's modules.
+    let module_warm: Option<models::ModuleWarm> = config.gene_modules.as_ref().map(|g| {
         let finest = collapsed_levels.last().expect("at least one level");
         let pb_full = match &finest.mu_adjusted {
             Some(adj) => adj.posterior_mean(),
             None => finest.mu_observed.posterior_mean(),
         };
         let profile = setup::gather_to_unified_axis(pb_full, n_features, &feature_to_backend);
-        module_warm::warm_start_module_labels(&profile, g.n_modules, config.seed)
+        match &g.parent {
+            Some(parent) => models::ModuleWarm::Parent {
+                logits: module_warm::parent_module_logits(
+                    &module_warm::ParentModules {
+                        rho: &parent.rho,
+                        pi: &parent.pi,
+                        mu: &parent.mu,
+                        row_to_parent: &parent.row_to_parent,
+                    },
+                    &profile,
+                    parent.k,
+                    parent.similarity_floor,
+                ),
+                mu: parent.mu.clone(),
+            },
+            None => models::ModuleWarm::Labels(module_warm::warm_start_module_labels(
+                &profile,
+                g.n_modules,
+                config.seed,
+            )),
+        }
     });
     let models::Heads {
         mut cell_model,
         mut level_models,
-    } = models::build_heads(unified, &pb_blobs, &config, module_warm.as_deref(), &varmap)?;
+    } = models::build_heads(unified, &pb_blobs, &config, module_warm.as_ref(), &varmap)?;
 
     ////////////////////////////////
     // Composite axes and trainer //

--- a/graph-embedding-util/src/fit/models.rs
+++ b/graph-embedding-util/src/fit/models.rs
@@ -11,7 +11,8 @@
 use super::config::FitConfig;
 use crate::data::UnifiedData;
 use crate::model::{
-    FactoredInit, JointEmbedModel, ModelArgs, ModelInit, ModuleInit, ShareFeaturesArgs,
+    FactoredInit, JointEmbedModel, ModelArgs, ModelInit, ModuleInit, ModuleWarmStart,
+    ShareFeaturesArgs,
 };
 use candle_util::candle_nn::{VarBuilder, VarMap};
 use log::info;
@@ -79,8 +80,14 @@ pub(super) fn build_heads(
                     gm.residual_l2
                 );
             }
-            let (init_labels, init_logits, init_mu, n_modules) = match module_warm {
-                Some(ModuleWarm::Labels(l)) => (Some(l.as_slice()), None, None, gm.n_modules),
+            let (warm, n_modules) = match module_warm {
+                Some(ModuleWarm::Labels(l)) => (
+                    ModuleWarmStart::Labels {
+                        labels: l,
+                        own_mass: gm.init_own_mass,
+                    },
+                    gm.n_modules,
+                ),
                 Some(ModuleWarm::Parent { logits, mu }) => {
                     anyhow::ensure!(
                         mu.ncols() == h,
@@ -88,16 +95,23 @@ pub(super) fn build_heads(
                          set --embedding-dim to match the parent",
                         mu.ncols()
                     );
-                    (None, Some(logits), Some(mu), mu.nrows())
+                    (
+                        ModuleWarmStart::Explicit {
+                            logits,
+                            mu: Some(mu),
+                        },
+                        mu.nrows(),
+                    )
                 }
-                None => (None, None, None, gm.n_modules),
+                None => (ModuleWarmStart::Uniform, gm.n_modules),
             };
+            let from_parent = matches!(warm, ModuleWarmStart::Explicit { .. });
             info!(
                 "learned gene modules: {} features → {} modules (mixed membership{}), \
                  gene dropout {}, exact module term λ={}, balance λ={}",
                 n_features,
                 n_modules,
-                if init_mu.is_some() {
+                if from_parent {
                     ", warm-started from the parent"
                 } else {
                     ""
@@ -112,10 +126,7 @@ pub(super) fn build_heads(
                     n_cells,
                     embedding_dim: h,
                     n_modules,
-                    init_labels,
-                    init_own_mass: gm.init_own_mass,
-                    init_logits,
-                    init_mu,
+                    warm,
                     b_feat: &zeros_features,
                     b_cell: &zeros_cells,
                     seed: config.seed,

--- a/graph-embedding-util/src/fit/models.rs
+++ b/graph-embedding-util/src/fit/models.rs
@@ -10,7 +10,9 @@
 
 use super::config::FitConfig;
 use crate::data::UnifiedData;
-use crate::model::{FactoredInit, JointEmbedModel, ModelArgs, ModelInit, ShareFeaturesArgs};
+use crate::model::{
+    FactoredInit, JointEmbedModel, ModelArgs, ModelInit, ModuleInit, ShareFeaturesArgs,
+};
 use candle_util::candle_nn::{VarBuilder, VarMap};
 use log::info;
 
@@ -31,6 +33,7 @@ pub(super) fn build_heads(
     unified: &UnifiedData,
     pb_blobs: &[UnifiedData],
     config: &FitConfig,
+    module_warm: Option<&[u32]>,
     varmap: &VarMap,
 ) -> anyhow::Result<Heads> {
     let (n_features, n_cells, h) = (
@@ -42,8 +45,50 @@ pub(super) fn build_heads(
     let zeros_features = vec![0f32; n_features];
     let zeros_cells = vec![0f32; n_cells];
 
-    let mut cell_model = match &config.feat_factor {
-        Some(spec) => {
+    let mut cell_model = match (&config.gene_modules, &config.feat_factor) {
+        (Some(gm), factor) => {
+            // Hard errors, not silent no-ops: the module model's `e_feat` is a
+            // composed snapshot, and both of these write or read it as the trained
+            // table.
+            anyhow::ensure!(
+                factor.is_none(),
+                "gene modules are not supported with feat_factor (β-sharing) in this version"
+            );
+            anyhow::ensure!(
+                config.pb_posterior.is_none(),
+                "gene modules cannot combine with the phase-1 posterior sampler: the \
+                 selection pass writes per-feature loadings into a table the module \
+                 model composes rather than trains"
+            );
+            if config.feature_embedding_l2 > 0.0 {
+                info!(
+                    "gene modules: feature_embedding_l2 is ignored; the residual ridge \
+                     ({}) is the module model's per-row shrinkage",
+                    gm.residual_l2
+                );
+            }
+            info!(
+                "learned gene modules: {} features → {} modules (mixed membership), \
+                 gene dropout {}, exact module term λ={}, balance λ={}",
+                n_features, gm.n_modules, gm.gene_dropout, gm.lambda_module, gm.lambda_balance
+            );
+            JointEmbedModel::new_with_modules(
+                ModuleInit {
+                    n_features,
+                    n_cells,
+                    embedding_dim: h,
+                    n_modules: gm.n_modules,
+                    init_labels: module_warm,
+                    init_own_mass: gm.init_own_mass,
+                    b_feat: &zeros_features,
+                    b_cell: &zeros_cells,
+                    seed: config.seed,
+                },
+                varmap,
+                &config.device,
+            )?
+        }
+        (None, Some(spec)) => {
             // β-sharing is incompatible with the free-E_feat L2, which assumes a single
             // free feature table per row.
             anyhow::ensure!(
@@ -98,7 +143,7 @@ pub(super) fn build_heads(
                 &config.device,
             )?
         }
-        None => JointEmbedModel::new_with_init(
+        (None, None) => JointEmbedModel::new_with_init(
             ModelArgs {
                 n_features,
                 n_cells,
@@ -156,6 +201,7 @@ pub(super) fn build_heads(
                     shared_e_feat_logstd: cell_model.e_feat_logstd.clone(),
                     shared_gate_ibp_bias: cell_model.gate_ibp_bias.clone(),
                     gate: cell_model.gate,
+                    shared_modules: cell_model.modules.clone(),
                 },
                 varmap,
                 &config.device,

--- a/graph-embedding-util/src/fit/models.rs
+++ b/graph-embedding-util/src/fit/models.rs
@@ -16,6 +16,18 @@ use crate::model::{
 use candle_util::candle_nn::{VarBuilder, VarMap};
 use log::info;
 
+/// How the module membership starts: k-means labels over this fit's own
+/// profiles, or a parent's tables (`senna update`).
+pub(super) enum ModuleWarm {
+    Labels(Vec<u32>),
+    Parent {
+        /// `[D × M]` membership logits (simplex rows; sparsemax reproduces them).
+        logits: nalgebra::DMatrix<f32>,
+        /// `[M × H]` parent module dictionary.
+        mu: nalgebra::DMatrix<f32>,
+    },
+}
+
 /// The primary (per-cell) head and one head per pseudobulk level, coarsest → finest.
 pub(super) struct Heads {
     pub cell_model: JointEmbedModel,
@@ -33,7 +45,7 @@ pub(super) fn build_heads(
     unified: &UnifiedData,
     pb_blobs: &[UnifiedData],
     config: &FitConfig,
-    module_warm: Option<&[u32]>,
+    module_warm: Option<&ModuleWarm>,
     varmap: &VarMap,
 ) -> anyhow::Result<Heads> {
     let (n_features, n_cells, h) = (
@@ -67,21 +79,43 @@ pub(super) fn build_heads(
                     gm.residual_l2
                 );
             }
+            let (init_labels, init_logits, init_mu, n_modules) = match module_warm {
+                Some(ModuleWarm::Labels(l)) => (Some(l.as_slice()), None, None, gm.n_modules),
+                Some(ModuleWarm::Parent { logits, mu }) => {
+                    anyhow::ensure!(
+                        mu.ncols() == h,
+                        "parent modules are {}-dimensional but this fit uses H={h}; \
+                         set --embedding-dim to match the parent",
+                        mu.ncols()
+                    );
+                    (None, Some(logits), Some(mu), mu.nrows())
+                }
+                None => (None, None, None, gm.n_modules),
+            };
             info!(
-                "learned gene modules: {} features → {} modules (mixed membership), \
+                "learned gene modules: {} features → {} modules (mixed membership{}), \
                  gene dropout {}, exact module term λ={}, balance λ={}",
-                n_features, gm.n_modules, gm.gene_dropout, gm.lambda_module, gm.lambda_balance
+                n_features,
+                n_modules,
+                if init_mu.is_some() {
+                    ", warm-started from the parent"
+                } else {
+                    ""
+                },
+                gm.gene_dropout,
+                gm.lambda_module,
+                gm.lambda_balance
             );
             JointEmbedModel::new_with_modules(
                 ModuleInit {
                     n_features,
                     n_cells,
                     embedding_dim: h,
-                    n_modules: gm.n_modules,
-                    init_labels: module_warm,
+                    n_modules,
+                    init_labels,
                     init_own_mass: gm.init_own_mass,
-                    init_logits: None,
-                    init_mu: None,
+                    init_logits,
+                    init_mu,
                     b_feat: &zeros_features,
                     b_cell: &zeros_cells,
                     seed: config.seed,

--- a/graph-embedding-util/src/fit/models.rs
+++ b/graph-embedding-util/src/fit/models.rs
@@ -80,6 +80,8 @@ pub(super) fn build_heads(
                     n_modules: gm.n_modules,
                     init_labels: module_warm,
                     init_own_mass: gm.init_own_mass,
+                    init_logits: None,
+                    init_mu: None,
                     b_feat: &zeros_features,
                     b_cell: &zeros_cells,
                     seed: config.seed,

--- a/graph-embedding-util/src/fit/module_args.rs
+++ b/graph-embedding-util/src/fit/module_args.rs
@@ -6,23 +6,18 @@
 
 use super::config::GeneModuleConfig;
 
-/// Module count a CLI that turns modules on by default uses when `--gene-modules`
-/// is not given. `senna bge` passes it to [`GeneModuleArgs::resolve`]; `pinto cage`
-/// passes `None` (its default sampled gate is exclusive with modules).
-pub const DEFAULT_GENE_MODULES: usize = 128;
-
 #[derive(clap::Args, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default = "matrix_util::clap_defaults::clap_defaults")]
 pub struct GeneModuleArgs {
     #[arg(
         long = "gene-modules",
         value_name = "M",
-        help = "Learn M gene modules and embed genes THROUGH them (senna bge: on by default, M=128)",
+        help = "Learn M gene modules and embed genes THROUGH them",
         long_help = "Put a learned mixed-membership module layer in front of the feature embedding.\n\
                      Each gene's row becomes a sparse mixture of M shared module vectors,\n\
                      plus a small ridge-shrunk residual of its own.\n\
-                     senna bge turns this on by default with M=128; --no-gene-modules turns it off.\n\
-                     pinto cage leaves it off unless M is given.\n\
+                     Whether it is on without this flag is the command's own choice — see its\n\
+                     help; --no-gene-modules turns it off either way.\n\
                      \n\
                      WHY. A free row receives gradient only on the steps that draw its gene.\n\
                      A rare gene, or one absent from a later dataset, has nothing standing in for it.\n\
@@ -104,15 +99,6 @@ pub struct GeneModuleArgs {
     pub module_weight: f32,
 
     #[arg(
-        long = "module-entropy",
-        value_name = "LAMBDA",
-        default_value_t = 0.0,
-        help = "Row-entropy penalty on the membership (0 = off)",
-        hide = true
-    )]
-    pub module_entropy: f32,
-
-    #[arg(
         long = "module-residual-l2",
         value_name = "LAMBDA",
         default_value_t = 0.1,
@@ -168,7 +154,6 @@ impl GeneModuleArgs {
             gene_dropout: self.gene_dropout,
             lambda_module: self.module_weight,
             lambda_balance: self.module_balance,
-            lambda_entropy: self.module_entropy,
             residual_l2: self.module_residual_l2,
             units_per_step: self.module_units_per_step,
             init_own_mass: self.module_init_mass,

--- a/graph-embedding-util/src/fit/module_args.rs
+++ b/graph-embedding-util/src/fit/module_args.rs
@@ -1,0 +1,158 @@
+//! The `--gene-modules` flag group, flattened by the CLIs that expose the
+//! learned-module parameterization. Same pattern as
+//! [`crate::posterior::PosteriorArgs`]: one `clap::Args` so every caller shows one
+//! help text and resolves one way, and `serde` with `clap_defaults` so a manifest
+//! written before a flag existed still deserializes.
+
+use super::config::GeneModuleConfig;
+
+#[derive(clap::Args, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default = "matrix_util::clap_defaults::clap_defaults")]
+pub struct GeneModuleArgs {
+    #[arg(
+        long = "gene-modules",
+        value_name = "M",
+        help = "Learn M gene modules and embed genes THROUGH them (off by default)",
+        long_help = "Put a learned mixed-membership module layer in front of the feature embedding.\n\
+                     Each gene's row becomes a sparse mixture of M shared module vectors,\n\
+                     plus a small ridge-shrunk residual of its own.\n\
+                     \n\
+                     WHY. A free row receives gradient only on the steps that draw its gene.\n\
+                     A rare gene, or one absent from a later dataset, has nothing standing in for it.\n\
+                     Through a module, every edge on any member trains the shared vector,\n\
+                     so a gene that is never drawn still inherits a trained row from its siblings.\n\
+                     \n\
+                     HOW. Membership is sparsemax over learned logits: a gene sits on a few modules\n\
+                     with exact zeros elsewhere, never on a uniform average of all of them.\n\
+                     Two terms train it. An EXACT softmax over all M modules scores each unit's\n\
+                     module-pooled counts, so every module gets gradient on every step.\n\
+                     The usual NCE then draws its negatives from the positive gene's own module,\n\
+                     so it resolves genes WITHIN a module and leaves the rest to the exact term.\n\
+                     \n\
+                     The membership starts from a k-means over the pseudobulk gene profiles\n\
+                     and is held there for the first epochs (--module-warmup-epochs).\n\
+                     A load-balance prior (--module-balance) keeps the modules from merging.\n\
+                     Every epoch logs occupancy, dead modules, row entropy and support,\n\
+                     which is where a collapse shows first.\n\
+                     \n\
+                     OUTPUTS. {out}.module_membership.parquet (gene x M), \n\
+                     {out}.module_dictionary.parquet (M x H), {out}.module_residual.parquet,\n\
+                     {out}.module_bias.parquet. The feature dictionary keeps holding the composed\n\
+                     row, so nothing that reads it has to know modules exist.\n\
+                     \n\
+                     Cannot combine with --posterior."
+    )]
+    pub gene_modules: Option<usize>,
+
+    #[arg(
+        long = "module-warmup-epochs",
+        value_name = "N",
+        help = "Epochs the warm-start membership is held before it trains (default: a quarter)",
+        long_help = "Epochs the k-means membership is held fixed while the module vectors and\n\
+                     residuals train. A membership released too early is rich-get-richer:\n\
+                     the exact term rewards putting every gene in the module\n\
+                     that already scores well. Default: a quarter of the epochs, at least one."
+    )]
+    pub module_warmup_epochs: Option<usize>,
+
+    #[arg(
+        long = "gene-dropout",
+        value_name = "P",
+        default_value_t = 0.2,
+        help = "Per-step probability a gene is hidden when module counts are pooled",
+        long_help = "Gene dropout at pooling time. Each step hides a random subset of genes\n\
+                     when the module counts are formed, and rescales the survivors of each\n\
+                     module so its expected count is unchanged.\n\
+                     This is exactly the situation a later dataset with a different gene panel\n\
+                     presents, so the module vectors are fit under that perturbation. 0 turns it off."
+    )]
+    pub gene_dropout: f32,
+
+    #[arg(
+        long = "module-balance",
+        value_name = "LAMBDA",
+        default_value_t = 1.0,
+        help = "Weight of the load-balance prior on module occupancy",
+        long_help = "Weight of KL(occupancy || uniform), where occupancy is the mean membership\n\
+                     each module carries across genes. Zero when every module holds an equal share,\n\
+                     largest when one module holds them all. A uniform target on purpose:\n\
+                     for modules, a decaying prior is the collapse direction."
+    )]
+    pub module_balance: f32,
+
+    #[arg(
+        long = "module-weight",
+        value_name = "LAMBDA",
+        default_value_t = 1.0,
+        help = "Weight of the exact cell-module term relative to the NCE",
+        hide = true
+    )]
+    pub module_weight: f32,
+
+    #[arg(
+        long = "module-entropy",
+        value_name = "LAMBDA",
+        default_value_t = 0.0,
+        help = "Row-entropy penalty on the membership (0 = off)",
+        hide = true
+    )]
+    pub module_entropy: f32,
+
+    #[arg(
+        long = "module-residual-l2",
+        value_name = "LAMBDA",
+        default_value_t = 0.1,
+        help = "Ridge on the per-gene residual (the module model's only per-row table)",
+        hide = true
+    )]
+    pub module_residual_l2: f32,
+
+    #[arg(
+        long = "module-units-per-step",
+        value_name = "U",
+        default_value_t = 64,
+        help = "Units pooled per step per axis for the exact module term",
+        hide = true
+    )]
+    pub module_units_per_step: usize,
+
+    #[arg(
+        long = "module-init-mass",
+        value_name = "P",
+        default_value_t = 0.9,
+        help = "Share of a gene's warm-start membership on its k-means module",
+        hide = true
+    )]
+    pub module_init_mass: f32,
+}
+
+impl GeneModuleArgs {
+    /// `None` when `--gene-modules` was not given; otherwise the validated config.
+    pub fn to_config(&self) -> anyhow::Result<Option<GeneModuleConfig>> {
+        let Some(m) = self.gene_modules else {
+            return Ok(None);
+        };
+        anyhow::ensure!(m >= 2, "--gene-modules needs at least 2 modules, got {m}");
+        anyhow::ensure!(
+            (0.0..1.0).contains(&self.gene_dropout),
+            "--gene-dropout must be in [0, 1), got {}",
+            self.gene_dropout
+        );
+        anyhow::ensure!(
+            self.module_init_mass > 0.0 && self.module_init_mass <= 1.0,
+            "--module-init-mass must be in (0, 1], got {}",
+            self.module_init_mass
+        );
+        Ok(Some(GeneModuleConfig {
+            n_modules: m,
+            warmup_epochs: self.module_warmup_epochs,
+            gene_dropout: self.gene_dropout,
+            lambda_module: self.module_weight,
+            lambda_balance: self.module_balance,
+            lambda_entropy: self.module_entropy,
+            residual_l2: self.module_residual_l2,
+            units_per_step: self.module_units_per_step,
+            init_own_mass: self.module_init_mass,
+        }))
+    }
+}

--- a/graph-embedding-util/src/fit/module_args.rs
+++ b/graph-embedding-util/src/fit/module_args.rs
@@ -6,16 +6,23 @@
 
 use super::config::GeneModuleConfig;
 
+/// Module count a CLI that turns modules on by default uses when `--gene-modules`
+/// is not given. `senna bge` passes it to [`GeneModuleArgs::resolve`]; `pinto cage`
+/// passes `None` (its default sampled gate is exclusive with modules).
+pub const DEFAULT_GENE_MODULES: usize = 128;
+
 #[derive(clap::Args, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default = "matrix_util::clap_defaults::clap_defaults")]
 pub struct GeneModuleArgs {
     #[arg(
         long = "gene-modules",
         value_name = "M",
-        help = "Learn M gene modules and embed genes THROUGH them (off by default)",
+        help = "Learn M gene modules and embed genes THROUGH them (senna bge: on by default, M=128)",
         long_help = "Put a learned mixed-membership module layer in front of the feature embedding.\n\
                      Each gene's row becomes a sparse mixture of M shared module vectors,\n\
                      plus a small ridge-shrunk residual of its own.\n\
+                     senna bge turns this on by default with M=128; --no-gene-modules turns it off.\n\
+                     pinto cage leaves it off unless M is given.\n\
                      \n\
                      WHY. A free row receives gradient only on the steps that draw its gene.\n\
                      A rare gene, or one absent from a later dataset, has nothing standing in for it.\n\
@@ -45,6 +52,13 @@ pub struct GeneModuleArgs {
     pub gene_modules: Option<usize>,
 
     #[arg(
+        long = "no-gene-modules",
+        conflicts_with = "gene_modules",
+        help = "Train the plain free feature embedding instead of the module layer"
+    )]
+    pub no_gene_modules: bool,
+
+    #[arg(
         long = "module-warmup-epochs",
         value_name = "N",
         help = "Epochs the warm-start membership is held before it trains (default: a quarter)",
@@ -58,7 +72,7 @@ pub struct GeneModuleArgs {
     #[arg(
         long = "gene-dropout",
         value_name = "P",
-        default_value_t = 0.2,
+        default_value_t = 0.3,
         help = "Per-step probability a gene is hidden when module counts are pooled",
         long_help = "Gene dropout at pooling time. Each step hides a random subset of genes\n\
                      when the module counts are formed, and rescales the survivors of each\n\
@@ -127,9 +141,14 @@ pub struct GeneModuleArgs {
 }
 
 impl GeneModuleArgs {
-    /// `None` when `--gene-modules` was not given; otherwise the validated config.
-    pub fn to_config(&self) -> anyhow::Result<Option<GeneModuleConfig>> {
-        let Some(m) = self.gene_modules else {
+    /// Resolve the group against the CLI's own default: `--no-gene-modules` wins,
+    /// then an explicit `--gene-modules M`, then `default_on` (`Some(M)` for a CLI
+    /// that trains modules unless told otherwise, `None` for an opt-in CLI).
+    pub fn resolve(&self, default_on: Option<usize>) -> anyhow::Result<Option<GeneModuleConfig>> {
+        if self.no_gene_modules {
+            return Ok(None);
+        }
+        let Some(m) = self.gene_modules.or(default_on) else {
             return Ok(None);
         };
         anyhow::ensure!(m >= 2, "--gene-modules needs at least 2 modules, got {m}");
@@ -156,3 +175,6 @@ impl GeneModuleArgs {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/fit/module_args.rs
+++ b/graph-embedding-util/src/fit/module_args.rs
@@ -172,6 +172,7 @@ impl GeneModuleArgs {
             residual_l2: self.module_residual_l2,
             units_per_step: self.module_units_per_step,
             init_own_mass: self.module_init_mass,
+            parent: None,
         }))
     }
 }

--- a/graph-embedding-util/src/fit/module_args/tests.rs
+++ b/graph-embedding-util/src/fit/module_args/tests.rs
@@ -13,17 +13,14 @@ fn parse(args: &[&str]) -> GeneModuleArgs {
 
 #[test]
 fn default_on_cli_trains_modules_unless_told_otherwise() {
-    let cfg = parse(&[])
-        .resolve(Some(DEFAULT_GENE_MODULES))
-        .unwrap()
-        .unwrap();
-    assert_eq!(cfg.n_modules, DEFAULT_GENE_MODULES);
+    let cfg = parse(&[]).resolve(Some(128)).unwrap().unwrap();
+    assert_eq!(cfg.n_modules, 128);
     assert!(parse(&["--no-gene-modules"])
-        .resolve(Some(DEFAULT_GENE_MODULES))
+        .resolve(Some(128))
         .unwrap()
         .is_none());
     let cfg = parse(&["--gene-modules", "32"])
-        .resolve(Some(DEFAULT_GENE_MODULES))
+        .resolve(Some(128))
         .unwrap()
         .unwrap();
     assert_eq!(cfg.n_modules, 32);

--- a/graph-embedding-util/src/fit/module_args/tests.rs
+++ b/graph-embedding-util/src/fit/module_args/tests.rs
@@ -1,0 +1,56 @@
+use super::*;
+use clap::Parser;
+
+#[derive(Parser)]
+struct Cli {
+    #[command(flatten)]
+    modules: GeneModuleArgs,
+}
+
+fn parse(args: &[&str]) -> GeneModuleArgs {
+    Cli::parse_from(std::iter::once("x").chain(args.iter().copied())).modules
+}
+
+#[test]
+fn default_on_cli_trains_modules_unless_told_otherwise() {
+    let cfg = parse(&[])
+        .resolve(Some(DEFAULT_GENE_MODULES))
+        .unwrap()
+        .unwrap();
+    assert_eq!(cfg.n_modules, DEFAULT_GENE_MODULES);
+    assert!(parse(&["--no-gene-modules"])
+        .resolve(Some(DEFAULT_GENE_MODULES))
+        .unwrap()
+        .is_none());
+    let cfg = parse(&["--gene-modules", "32"])
+        .resolve(Some(DEFAULT_GENE_MODULES))
+        .unwrap()
+        .unwrap();
+    assert_eq!(cfg.n_modules, 32);
+}
+
+#[test]
+fn opt_in_cli_stays_off_without_the_flag() {
+    assert!(parse(&[]).resolve(None).unwrap().is_none());
+    assert_eq!(
+        parse(&["--gene-modules", "16"])
+            .resolve(None)
+            .unwrap()
+            .unwrap()
+            .n_modules,
+        16
+    );
+}
+
+#[test]
+fn the_two_flags_conflict() {
+    assert!(Cli::try_parse_from(["x", "--gene-modules", "8", "--no-gene-modules"]).is_err());
+}
+
+#[test]
+fn validation_rejects_bad_knobs() {
+    assert!(parse(&["--gene-modules", "1"]).resolve(None).is_err());
+    assert!(parse(&["--gene-modules", "8", "--gene-dropout", "1.0"])
+        .resolve(None)
+        .is_err());
+}

--- a/graph-embedding-util/src/fit/module_warm.rs
+++ b/graph-embedding-util/src/fit/module_warm.rs
@@ -8,12 +8,12 @@
 //! batch-corrected pseudobulk count matrix the fit already built, so this costs
 //! nothing extra.
 
+use super::config::ParentModulesOwned;
 use log::info;
 use matrix_util::principal_graph::kmeans_centroids_seeded;
 use matrix_util::rand_util::name_seed;
 use matrix_util::traits::SampleOps;
 use nalgebra::DMatrix;
-use rayon::prelude::*;
 
 /// Widest profile k-means runs on directly; a pseudobulk axis longer than this is
 /// sketched down to [`WARM_SKETCH_DIM`] with a seeded Gaussian first.
@@ -33,32 +33,8 @@ pub fn warm_start_module_labels(profile: &DMatrix<f32>, n_modules: usize, seed: 
     if d == 0 || n_modules < 2 {
         return vec![0u32; d];
     }
-    // Column depth normalization to a common scale, then log1p.
-    let col_tot: Vec<f32> = (0..s)
-        .map(|j| profile.column(j).iter().sum::<f32>().max(1e-8))
-        .collect();
-    let mean_tot = col_tot.iter().sum::<f32>() / s.max(1) as f32;
-    let mut z = DMatrix::<f32>::zeros(d, s);
-    // nalgebra is column-major: fill by column.
-    for j in 0..s {
-        let scale = mean_tot / col_tot[j];
-        for i in 0..d {
-            z[(i, j)] = (profile[(i, j)] * scale).ln_1p();
-        }
-    }
-    // Row centre + unit norm, in parallel over rows via a row-major scratch.
-    let mut rows: Vec<Vec<f32>> = (0..d).map(|i| z.row(i).iter().copied().collect()).collect();
-    rows.par_iter_mut().for_each(|r| {
-        let mean = r.iter().sum::<f32>() / s.max(1) as f32;
-        for x in r.iter_mut() {
-            *x -= mean;
-        }
-        let norm = r.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-8);
-        for x in r.iter_mut() {
-            *x /= norm;
-        }
-    });
-    let mut z = DMatrix::<f32>::from_fn(d, s, |i, j| rows[i][j]);
+    let unit = crate::transfer::unit_log_profile_rows(profile);
+    let mut z = DMatrix::<f32>::from_fn(d, s, |i, j| unit[i][j]);
     if s > WARM_PROFILE_MAX_DIM {
         let basis =
             DMatrix::<f32>::rnorm_seeded(s, WARM_SKETCH_DIM, name_seed(seed, "module_warm"));
@@ -83,77 +59,47 @@ pub fn warm_start_module_labels(profile: &DMatrix<f32>, n_modules: usize, seed: 
     labels.into_iter().map(|l| l as u32).collect()
 }
 
-/// A parent run's module tables, for a warm start that carries them.
-pub struct ParentModules<'a> {
-    /// Parent composed rows `[D_parent × H]` (needed only to place unmatched
-    /// features, through [`crate::transfer::align_gene_axis`]).
-    pub rho: &'a DMatrix<f32>,
-    /// Parent membership `[D_parent × M]`.
-    pub pi: &'a DMatrix<f32>,
-    /// Parent module dictionary `[M × H]`.
-    pub mu: &'a DMatrix<f32>,
-    /// For each feature of THIS fit's axis, the parent row it matched, or `None`.
-    pub row_to_parent: &'a [Option<usize>],
-}
-
 /// Membership logits `[D × M]` for a fit warm-started from a parent: a matched
 /// feature takes the parent's membership row verbatim (a simplex point, which
 /// sparsemax reproduces exactly), an unmatched one is initialized through the
-/// parent's modules from its `k` nearest matched neighbours by profile, or the
+/// parent's modules from its nearest matched neighbours by profile, or the
 /// parent's module-average membership below the similarity floor.
 #[must_use]
-pub fn parent_module_logits(
-    parent: &ParentModules,
-    profiles: &DMatrix<f32>,
-    k: usize,
-    similarity_floor: f32,
-) -> DMatrix<f32> {
-    use crate::transfer::{align_gene_axis, AlignInputs, GeneStatus, ModuleTables};
+pub fn parent_module_logits(parent: &ParentModulesOwned, profiles: &DMatrix<f32>) -> DMatrix<f32> {
+    use crate::transfer::{align_gene_axis, AlignInputs, ModuleTables};
     let d = parent.row_to_parent.len();
     let m = parent.pi.ncols();
-    let zeros = vec![0f32; parent.rho.nrows()];
     let al = align_gene_axis(&AlignInputs {
-        rho: parent.rho,
-        b_feat: &zeros,
+        rho: &parent.rho,
+        b_feat: None,
         modules: Some(ModuleTables {
-            pi: parent.pi,
-            mu: parent.mu,
+            pi: &parent.pi,
+            mu: &parent.mu,
         }),
-        new_to_train: parent.row_to_parent,
+        new_to_train: &parent.row_to_parent,
         profiles_new: Some(profiles),
-        k,
-        similarity_floor,
+        knobs: parent.knobs,
     });
     let membership = al
         .membership
         .as_ref()
         .expect("module tables given ⇒ membership present");
     let mut logits = DMatrix::<f32>::zeros(d, m);
-    let mut next_unmatched = parent.rho.nrows();
-    let (mut n_matched, mut n_init, mut n_diffuse) = (0usize, 0usize, 0usize);
+    let (mut n_init, mut n_diffuse) = (0usize, 0usize);
     for g in 0..d {
-        let union = match parent.row_to_parent[g] {
-            Some(t) => {
-                n_matched += 1;
-                t
-            }
-            None => {
-                let u = next_unmatched;
-                next_unmatched += 1;
-                debug_assert_eq!(al.union_to_new[u], Some(g));
-                debug_assert_eq!(al.status[u], GeneStatus::Initialized);
-                n_init += 1;
-                if al.provenance[u].as_ref().is_some_and(|p| p.diffuse) {
-                    n_diffuse += 1;
-                }
-                u
-            }
-        };
+        let union = al.new_to_union[g].expect("every feature is matched or initialized");
         logits.set_row(g, &membership.row(union));
+        if !al.is_scored(union) {
+            n_init += 1;
+            if al.provenance[union].as_ref().is_some_and(|p| p.diffuse) {
+                n_diffuse += 1;
+            }
+        }
     }
     info!(
-        "module warm start from a parent: {n_matched} features carry the parent's membership, \
-         {n_init} initialized through its modules ({n_diffuse} on the diffuse prior)"
+        "module warm start from a parent: {} features carry the parent's membership, \
+         {n_init} initialized through its modules ({n_diffuse} on the diffuse prior)",
+        d - n_init
     );
     logits
 }

--- a/graph-embedding-util/src/fit/module_warm.rs
+++ b/graph-embedding-util/src/fit/module_warm.rs
@@ -1,0 +1,87 @@
+//! Warm start for the learned gene modules: a seeded k-means over the feature
+//! profiles at the finest pseudobulk level.
+//!
+//! A membership learned from a cold start is rich-get-richer — the exact module
+//! term rewards putting every feature in the module that already scores well — so
+//! the partition starts from the data's own co-expression structure and is held
+//! there for the first epochs (`FeatModules::set_frozen`). The profile is the
+//! batch-corrected pseudobulk count matrix the fit already built, so this costs
+//! nothing extra.
+
+use log::info;
+use matrix_util::principal_graph::kmeans_centroids_seeded;
+use matrix_util::rand_util::name_seed;
+use matrix_util::traits::SampleOps;
+use nalgebra::DMatrix;
+use rayon::prelude::*;
+
+/// Widest profile k-means runs on directly; a pseudobulk axis longer than this is
+/// sketched down to [`WARM_SKETCH_DIM`] with a seeded Gaussian first.
+pub const WARM_PROFILE_MAX_DIM: usize = 1024;
+pub const WARM_SKETCH_DIM: usize = 64;
+/// Lloyd iterations for the warm-start clustering.
+const WARM_KMEANS_ITER: usize = 30;
+
+/// Cluster the rows of a `[features × pseudobulks]` count profile into `n_modules`
+/// groups. Columns are depth-normalized, `log1p`-transformed, each row centred and
+/// scaled to unit norm (so the clustering reads the SHAPE of a feature's profile,
+/// not its abundance), then k-means with a seeded kmeans++ init. Returns one
+/// module id per feature.
+#[must_use]
+pub fn warm_start_module_labels(profile: &DMatrix<f32>, n_modules: usize, seed: u64) -> Vec<u32> {
+    let (d, s) = (profile.nrows(), profile.ncols());
+    if d == 0 || n_modules < 2 {
+        return vec![0u32; d];
+    }
+    // Column depth normalization to a common scale, then log1p.
+    let col_tot: Vec<f32> = (0..s)
+        .map(|j| profile.column(j).iter().sum::<f32>().max(1e-8))
+        .collect();
+    let mean_tot = col_tot.iter().sum::<f32>() / s.max(1) as f32;
+    let mut z = DMatrix::<f32>::zeros(d, s);
+    // nalgebra is column-major: fill by column.
+    for j in 0..s {
+        let scale = mean_tot / col_tot[j];
+        for i in 0..d {
+            z[(i, j)] = (profile[(i, j)] * scale).ln_1p();
+        }
+    }
+    // Row centre + unit norm, in parallel over rows via a row-major scratch.
+    let mut rows: Vec<Vec<f32>> = (0..d).map(|i| z.row(i).iter().copied().collect()).collect();
+    rows.par_iter_mut().for_each(|r| {
+        let mean = r.iter().sum::<f32>() / s.max(1) as f32;
+        for x in r.iter_mut() {
+            *x -= mean;
+        }
+        let norm = r.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-8);
+        for x in r.iter_mut() {
+            *x /= norm;
+        }
+    });
+    let mut z = DMatrix::<f32>::from_fn(d, s, |i, j| rows[i][j]);
+    if s > WARM_PROFILE_MAX_DIM {
+        let basis =
+            DMatrix::<f32>::rnorm_seeded(s, WARM_SKETCH_DIM, name_seed(seed, "module_warm"));
+        z = (&z * basis) / (WARM_SKETCH_DIM as f32).sqrt();
+    }
+    let (_, labels) = kmeans_centroids_seeded(&z, n_modules, WARM_KMEANS_ITER, seed);
+    let mut sizes = vec![0usize; n_modules];
+    for &l in &labels {
+        sizes[l.min(n_modules - 1)] += 1;
+    }
+    info!(
+        "module warm start: k-means over {d} feature profiles × {s} pseudobulk(s) → {n_modules} \
+         modules, sizes min {} / median {} / max {}",
+        sizes.iter().min().copied().unwrap_or(0),
+        {
+            let mut v = sizes.clone();
+            v.sort_unstable();
+            v[v.len() / 2]
+        },
+        sizes.iter().max().copied().unwrap_or(0),
+    );
+    labels.into_iter().map(|l| l as u32).collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/fit/module_warm.rs
+++ b/graph-embedding-util/src/fit/module_warm.rs
@@ -83,5 +83,34 @@ pub fn warm_start_module_labels(profile: &DMatrix<f32>, n_modules: usize, seed: 
     labels.into_iter().map(|l| l as u32).collect()
 }
 
+/// A parent run's module tables, for a warm start that carries them.
+pub struct ParentModules<'a> {
+    /// Parent composed rows `[D_parent × H]` (needed only to place unmatched
+    /// features, through [`crate::transfer::align_gene_axis`]).
+    pub rho: &'a DMatrix<f32>,
+    /// Parent membership `[D_parent × M]`.
+    pub pi: &'a DMatrix<f32>,
+    /// Parent module dictionary `[M × H]`.
+    pub mu: &'a DMatrix<f32>,
+    /// For each feature of THIS fit's axis, the parent row it matched, or `None`.
+    pub row_to_parent: &'a [Option<usize>],
+}
+
+/// Membership logits `[D × M]` for a fit warm-started from a parent: a matched
+/// feature takes the parent's membership row verbatim (a simplex point, which
+/// sparsemax reproduces exactly), an unmatched one is initialized through the
+/// parent's modules from its `k` nearest matched neighbours by profile, or the
+/// parent's module-average membership below the similarity floor.
+#[must_use]
+pub fn parent_module_logits(
+    parent: &ParentModules,
+    profiles: &DMatrix<f32>,
+    k: usize,
+    similarity_floor: f32,
+) -> DMatrix<f32> {
+    let _ = (parent, profiles, k, similarity_floor);
+    todo!("parent_module_logits")
+}
+
 #[cfg(test)]
 mod tests;

--- a/graph-embedding-util/src/fit/module_warm.rs
+++ b/graph-embedding-util/src/fit/module_warm.rs
@@ -108,8 +108,54 @@ pub fn parent_module_logits(
     k: usize,
     similarity_floor: f32,
 ) -> DMatrix<f32> {
-    let _ = (parent, profiles, k, similarity_floor);
-    todo!("parent_module_logits")
+    use crate::transfer::{align_gene_axis, AlignInputs, GeneStatus, ModuleTables};
+    let d = parent.row_to_parent.len();
+    let m = parent.pi.ncols();
+    let zeros = vec![0f32; parent.rho.nrows()];
+    let al = align_gene_axis(&AlignInputs {
+        rho: parent.rho,
+        b_feat: &zeros,
+        modules: Some(ModuleTables {
+            pi: parent.pi,
+            mu: parent.mu,
+        }),
+        new_to_train: parent.row_to_parent,
+        profiles_new: Some(profiles),
+        k,
+        similarity_floor,
+    });
+    let membership = al
+        .membership
+        .as_ref()
+        .expect("module tables given ⇒ membership present");
+    let mut logits = DMatrix::<f32>::zeros(d, m);
+    let mut next_unmatched = parent.rho.nrows();
+    let (mut n_matched, mut n_init, mut n_diffuse) = (0usize, 0usize, 0usize);
+    for g in 0..d {
+        let union = match parent.row_to_parent[g] {
+            Some(t) => {
+                n_matched += 1;
+                t
+            }
+            None => {
+                let u = next_unmatched;
+                next_unmatched += 1;
+                debug_assert_eq!(al.union_to_new[u], Some(g));
+                debug_assert_eq!(al.status[u], GeneStatus::Initialized);
+                n_init += 1;
+                if al.provenance[u].as_ref().is_some_and(|p| p.diffuse) {
+                    n_diffuse += 1;
+                }
+                u
+            }
+        };
+        logits.set_row(g, &membership.row(union));
+    }
+    info!(
+        "module warm start from a parent: {n_matched} features carry the parent's membership, \
+         {n_init} initialized through its modules ({n_diffuse} on the diffuse prior)"
+    );
+    logits
 }
 
 #[cfg(test)]

--- a/graph-embedding-util/src/fit/module_warm.rs
+++ b/graph-embedding-util/src/fit/module_warm.rs
@@ -34,20 +34,42 @@ pub fn warm_start_module_labels(profile: &DMatrix<f32>, n_modules: usize, seed: 
         return vec![0u32; d];
     }
     let unit = crate::transfer::unit_log_profile_rows(profile);
-    let mut z = DMatrix::<f32>::from_fn(d, s, |i, j| unit[i][j]);
+    // A gene with no profile (never expressed in any pseudobulk) is the zero
+    // vector after normalization. Thousands of them would pile into one cluster
+    // and starve the rest with seeds, so they go to ONE explicit background
+    // module and only the expressed genes are clustered.
+    let expressed: Vec<usize> = (0..d)
+        .filter(|&i| unit[i].iter().any(|&x| x != 0.0))
+        .collect();
+    let n_zero = d - expressed.len();
+    let (k, background) = if n_zero > 0 && n_modules > 2 {
+        (n_modules - 1, Some(n_modules - 1))
+    } else {
+        (n_modules, None)
+    };
+    let mut z = DMatrix::<f32>::from_fn(expressed.len(), s, |r, j| unit[expressed[r]][j]);
     if s > WARM_PROFILE_MAX_DIM {
         let basis =
             DMatrix::<f32>::rnorm_seeded(s, WARM_SKETCH_DIM, name_seed(seed, "module_warm"));
         z = (&z * basis) / (WARM_SKETCH_DIM as f32).sqrt();
     }
-    let (_, labels) = kmeans_centroids_seeded(&z, n_modules, WARM_KMEANS_ITER, seed);
+    let (_, cluster) = kmeans_centroids_seeded(&z, k, WARM_KMEANS_ITER, seed);
+    let mut labels = vec![background.unwrap_or(0) as u32; d];
+    for (r, &i) in expressed.iter().enumerate() {
+        labels[i] = cluster[r].min(k - 1) as u32;
+    }
     let mut sizes = vec![0usize; n_modules];
     for &l in &labels {
-        sizes[l.min(n_modules - 1)] += 1;
+        sizes[l as usize] += 1;
     }
     info!(
-        "module warm start: k-means over {d} feature profiles × {s} pseudobulk(s) → {n_modules} \
-         modules, sizes min {} / median {} / max {}",
+        "module warm start: k-means over {} expressed feature profiles × {s} pseudobulk(s) → {k} \
+         modules{}, sizes min {} / median {} / max {}",
+        expressed.len(),
+        match background {
+            Some(b) => format!(" + module {b} for the {n_zero} features with no profile"),
+            None => String::new(),
+        },
         sizes.iter().min().copied().unwrap_or(0),
         {
             let mut v = sizes.clone();
@@ -56,7 +78,7 @@ pub fn warm_start_module_labels(profile: &DMatrix<f32>, n_modules: usize, seed: 
         },
         sizes.iter().max().copied().unwrap_or(0),
     );
-    labels.into_iter().map(|l| l as u32).collect()
+    labels
 }
 
 /// Membership logits `[D × M]` for a fit warm-started from a parent: a matched

--- a/graph-embedding-util/src/fit/module_warm/tests.rs
+++ b/graph-embedding-util/src/fit/module_warm/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::fit::config::ParentModulesOwned;
 
 /// Three planted co-expression blocks over 12 pseudobulks are recovered as three
 /// modules, up to label permutation.
@@ -81,15 +82,17 @@ fn parent_warm_start_carries_matched_rows_and_initializes_the_rest() {
         ],
     );
     let logits = parent_module_logits(
-        &ParentModules {
-            rho: &parent_rho,
-            pi: &parent_pi,
-            mu: &parent_mu,
-            row_to_parent: &row_to_parent,
+        &ParentModulesOwned {
+            rho: parent_rho,
+            pi: parent_pi.clone(),
+            mu: parent_mu,
+            row_to_parent,
+            knobs: crate::transfer::AlignKnobs {
+                k: 2,
+                similarity_floor: 0.5,
+            },
         },
         &profiles,
-        2,
-        0.5,
     );
     assert_eq!(logits.nrows(), 4);
     assert_eq!(logits.ncols(), 2);

--- a/graph-embedding-util/src/fit/module_warm/tests.rs
+++ b/graph-embedding-util/src/fit/module_warm/tests.rs
@@ -129,10 +129,15 @@ fn zero_profile_genes_take_the_background_module() {
     }
     let labels = warm_start_module_labels(&m, 3, 11);
     let bg = labels[20];
-    assert!(labels[20..].iter().all(|&l| l == bg), "zero rows share one module: {labels:?}");
-    assert!(labels[..20].iter().all(|&l| l != bg), "expressed genes stay out of it: {labels:?}");
+    assert!(
+        labels[20..].iter().all(|&l| l == bg),
+        "zero rows share one module: {labels:?}"
+    );
+    assert!(
+        labels[..20].iter().all(|&l| l != bg),
+        "expressed genes stay out of it: {labels:?}"
+    );
     assert!(labels[..10].iter().all(|&l| l == labels[0]));
     assert!(labels[10..20].iter().all(|&l| l == labels[10]));
     assert_ne!(labels[0], labels[10]);
 }
-

--- a/graph-embedding-util/src/fit/module_warm/tests.rs
+++ b/graph-embedding-util/src/fit/module_warm/tests.rs
@@ -57,3 +57,54 @@ fn wide_profiles_are_sketched() {
     assert!(labels[6..].iter().all(|&l| l == labels[6]));
     assert_ne!(labels[0], labels[6]);
 }
+
+/// Warm start from a PARENT: matched features take the parent's membership rows
+/// verbatim; unmatched ones are initialized through the parent's modules from
+/// their profile neighbours (identical profile ⇒ identical row).
+#[test]
+fn parent_warm_start_carries_matched_rows_and_initializes_the_rest() {
+    let parent_pi = DMatrix::<f32>::from_row_slice(3, 2, &[1.0, 0.0, 0.0, 1.0, 0.5, 0.5]);
+    let parent_mu = DMatrix::<f32>::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]);
+    let parent_rho = &parent_pi * &parent_mu;
+    // New axis: gene 0 = parent 2, gene 1 = parent 0, gene 2 = unseen with gene 1's
+    // profile, gene 3 = unseen with parent-1-like profile (parent 1 is MISSING here,
+    // so it is initialized from the matched neighbours only).
+    let row_to_parent = vec![Some(2), Some(0), None, None];
+    let profiles = DMatrix::<f32>::from_row_slice(
+        4,
+        4,
+        &[
+            5.0, 5.0, 5.0, 5.0, //
+            9.0, 1.0, 9.0, 1.0, //
+            9.0, 1.0, 9.0, 1.0, //
+            1.0, 9.0, 1.0, 9.0,
+        ],
+    );
+    let logits = parent_module_logits(
+        &ParentModules {
+            rho: &parent_rho,
+            pi: &parent_pi,
+            mu: &parent_mu,
+            row_to_parent: &row_to_parent,
+        },
+        &profiles,
+        2,
+        0.5,
+    );
+    assert_eq!(logits.nrows(), 4);
+    assert_eq!(logits.ncols(), 2);
+    assert_eq!(logits.row(0), parent_pi.row(2));
+    assert_eq!(logits.row(1), parent_pi.row(0));
+    assert_eq!(
+        logits.row(2),
+        parent_pi.row(0),
+        "same profile as gene 1 → parent 0's row"
+    );
+    // Anti-correlated with every matched gene → diffuse module average of the parent.
+    let avg: Vec<f32> = (0..2)
+        .map(|m| parent_pi.column(m).iter().sum::<f32>() / 3.0)
+        .collect();
+    for m in 0..2 {
+        assert!((logits[(3, m)] - avg[m]).abs() < 1e-6);
+    }
+}

--- a/graph-embedding-util/src/fit/module_warm/tests.rs
+++ b/graph-embedding-util/src/fit/module_warm/tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+/// Three planted co-expression blocks over 12 pseudobulks are recovered as three
+/// modules, up to label permutation.
+fn planted() -> DMatrix<f32> {
+    let (d, s) = (30usize, 12usize);
+    let mut m = DMatrix::<f32>::zeros(d, s);
+    for i in 0..d {
+        let block = i / 10;
+        for j in 0..s {
+            let on = j / 4 == block;
+            m[(i, j)] = if on { 50.0 } else { 2.0 } + ((i * 7 + j * 3) % 5) as f32;
+        }
+    }
+    m
+}
+
+#[test]
+fn warm_start_recovers_planted_blocks() {
+    let labels = warm_start_module_labels(&planted(), 3, 11);
+    assert_eq!(labels.len(), 30);
+    for block in 0..3 {
+        let first = labels[block * 10];
+        assert!(
+            labels[block * 10..(block + 1) * 10]
+                .iter()
+                .all(|&l| l == first),
+            "block {block} split: {labels:?}"
+        );
+    }
+    let mut distinct = labels.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(distinct.len(), 3);
+}
+
+#[test]
+fn warm_start_is_seed_reproducible() {
+    let a = warm_start_module_labels(&planted(), 3, 5);
+    let b = warm_start_module_labels(&planted(), 3, 5);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn wide_profiles_are_sketched() {
+    // More pseudobulks than the direct limit → the Gaussian sketch path.
+    let (d, s) = (12usize, WARM_PROFILE_MAX_DIM + 8);
+    let mut m = DMatrix::<f32>::zeros(d, s);
+    for i in 0..d {
+        for j in 0..s {
+            let on = (j % 2 == 0) == (i < 6);
+            m[(i, j)] = if on { 40.0 } else { 1.0 };
+        }
+    }
+    let labels = warm_start_module_labels(&m, 2, 3);
+    assert!(labels[..6].iter().all(|&l| l == labels[0]));
+    assert!(labels[6..].iter().all(|&l| l == labels[6]));
+    assert_ne!(labels[0], labels[6]);
+}

--- a/graph-embedding-util/src/fit/module_warm/tests.rs
+++ b/graph-embedding-util/src/fit/module_warm/tests.rs
@@ -111,3 +111,28 @@ fn parent_warm_start_carries_matched_rows_and_initializes_the_rest() {
         assert!((logits[(3, m)] - avg[m]).abs() < 1e-6);
     }
 }
+
+/// Genes with no profile at all (never expressed in any pseudobulk) do not get
+/// to seed clusters: they go to one explicit background module, and the
+/// expressed genes are clustered among the remaining modules.
+#[test]
+fn zero_profile_genes_take_the_background_module() {
+    let (d, s) = (30usize, 12usize);
+    let mut m = DMatrix::<f32>::zeros(d, s);
+    // 20 expressed genes in two planted blocks; 10 genes with all-zero profiles.
+    for i in 0..20 {
+        let block = i / 10;
+        for j in 0..s {
+            let on = j / 6 == block;
+            m[(i, j)] = if on { 50.0 } else { 2.0 } + ((i * 7 + j * 3) % 5) as f32;
+        }
+    }
+    let labels = warm_start_module_labels(&m, 3, 11);
+    let bg = labels[20];
+    assert!(labels[20..].iter().all(|&l| l == bg), "zero rows share one module: {labels:?}");
+    assert!(labels[..20].iter().all(|&l| l != bg), "expressed genes stay out of it: {labels:?}");
+    assert!(labels[..10].iter().all(|&l| l == labels[0]));
+    assert!(labels[10..20].iter().all(|&l| l == labels[10]));
+    assert_ne!(labels[0], labels[10]);
+}
+

--- a/graph-embedding-util/src/fit/pb_readout.rs
+++ b/graph-embedding-util/src/fit/pb_readout.rs
@@ -1,0 +1,28 @@
+//! The phase-1 pseudobulk embeddings as an output: one table per collapse
+//! level, with each pseudobulk's batch. Phase 1 trains the feature side against
+//! exactly these, so their geometry by batch is the first place to look when
+//! the per-cell embedding separates by batch — it says whether the collapse's
+//! adjustment already failed or phase 2 re-introduced the effect.
+
+use nalgebra::DMatrix;
+
+/// One collapse level's trained pseudobulk table and its batch labels.
+pub struct PbLevelEmbedding {
+    /// `[n_pb × H]`.
+    pub e_pb: DMatrix<f32>,
+    /// Batch index of each pseudobulk: the batch its member cells belong to
+    /// (the majority when a pseudobulk straddles batches; `u32::MAX` for an
+    /// empty pseudobulk).
+    pub batch: Vec<u32>,
+}
+
+/// The majority batch of each pseudobulk from the cell → pseudobulk map and the
+/// cells' batches. Empty pseudobulks get `u32::MAX`.
+#[must_use]
+pub fn majority_batch_per_pb(cell_to_pb: &[usize], batch_of_cell: &[u32], n_pb: usize) -> Vec<u32> {
+    let _ = (cell_to_pb, batch_of_cell, n_pb);
+    todo!("majority_batch_per_pb")
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/fit/pb_readout.rs
+++ b/graph-embedding-util/src/fit/pb_readout.rs
@@ -20,8 +20,29 @@ pub struct PbLevelEmbedding {
 /// cells' batches. Empty pseudobulks get `u32::MAX`.
 #[must_use]
 pub fn majority_batch_per_pb(cell_to_pb: &[usize], batch_of_cell: &[u32], n_pb: usize) -> Vec<u32> {
-    let _ = (cell_to_pb, batch_of_cell, n_pb);
-    todo!("majority_batch_per_pb")
+    let n_batches = batch_of_cell
+        .iter()
+        .copied()
+        .max()
+        .map_or(0, |b| b as usize + 1);
+    let mut counts = vec![vec![0usize; n_batches]; n_pb];
+    for (c, &p) in cell_to_pb.iter().enumerate() {
+        if p < n_pb {
+            counts[p][batch_of_cell[c] as usize] += 1;
+        }
+    }
+    counts
+        .iter()
+        .map(|row| {
+            let best = row.iter().copied().max().unwrap_or(0);
+            if best == 0 {
+                return u32::MAX;
+            }
+            row.iter()
+                .position(|&n| n == best)
+                .expect("max is in the row") as u32
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/graph-embedding-util/src/fit/pb_readout/tests.rs
+++ b/graph-embedding-util/src/fit/pb_readout/tests.rs
@@ -6,12 +6,18 @@ fn majority_batch_follows_the_member_cells() {
     // pb 2: empty → u32::MAX.
     let cell_to_pb = vec![0usize, 0, 0, 1, 1];
     let batch_of_cell = vec![0u32, 0, 1, 1, 1];
-    assert_eq!(majority_batch_per_pb(&cell_to_pb, &batch_of_cell, 3), vec![0, 1, u32::MAX]);
+    assert_eq!(
+        majority_batch_per_pb(&cell_to_pb, &batch_of_cell, 3),
+        vec![0, 1, u32::MAX]
+    );
 }
 
 #[test]
 fn ties_resolve_to_the_lowest_batch() {
     let cell_to_pb = vec![0usize, 0];
     let batch_of_cell = vec![2u32, 1];
-    assert_eq!(majority_batch_per_pb(&cell_to_pb, &batch_of_cell, 1), vec![1]);
+    assert_eq!(
+        majority_batch_per_pb(&cell_to_pb, &batch_of_cell, 1),
+        vec![1]
+    );
 }

--- a/graph-embedding-util/src/fit/pb_readout/tests.rs
+++ b/graph-embedding-util/src/fit/pb_readout/tests.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+#[test]
+fn majority_batch_follows_the_member_cells() {
+    // pb 0: cells 0,1,2 in batches 0,0,1 → 0; pb 1: cells 3,4 in batch 1 → 1;
+    // pb 2: empty → u32::MAX.
+    let cell_to_pb = vec![0usize, 0, 0, 1, 1];
+    let batch_of_cell = vec![0u32, 0, 1, 1, 1];
+    assert_eq!(majority_batch_per_pb(&cell_to_pb, &batch_of_cell, 3), vec![0, 1, u32::MAX]);
+}
+
+#[test]
+fn ties_resolve_to_the_lowest_batch() {
+    let cell_to_pb = vec![0usize, 0];
+    let batch_of_cell = vec![2u32, 1];
+    assert_eq!(majority_batch_per_pb(&cell_to_pb, &batch_of_cell, 1), vec![1]);
+}

--- a/graph-embedding-util/src/fit/projection.rs
+++ b/graph-embedding-util/src/fit/projection.rs
@@ -2,12 +2,11 @@
 //! Poisson-MAP SGD engine ([`block_sgd`]) is shared by two callers, split by what
 //! they project: [`cells`] (per-cell Phase 2 → `e_cell`) and [`pseudobulk`]
 //! (per-pb velocity readout → `θ_pb`/`δ_pb` landmarks). This root holds only what
-//! both share — the ridge, the batch divisor, and the per-cell edge fold the
+//! both share — the ridge, the per-batch fold, and the per-cell edge divide the
 //! engine calls back into.
 
+use super::batch_fold::BatchGeneFold;
 use candle_util::candle_core::Device;
-use matrix_util::dmatrix_util::adjust_by_poisson_ratio;
-use nalgebra::DMatrix;
 
 mod block_sgd;
 mod cells;
@@ -26,49 +25,44 @@ pub use pseudobulk::PbLevelVelocity;
 /// in for the partition.
 pub const PHASE2_RIDGE: f32 = 1.0;
 
-/// Phase-2 batch correction, mirroring `senna svd`/`topic`: divide each cell's
-/// counts by its finest-pseudobulk `μ_residual` fold-factor before the
-/// Poisson-MAP projection, so `e_cell` fits the de-batched signal. Built only
-/// when the collapse fit a `μ_residual` (>1 batch); a no-op otherwise.
+/// Phase-2 batch correction: each cell's counts are divided by its batch's
+/// per-gene fold `δ_gb` before the Poisson-MAP projection, so `θ_c` is solved in
+/// the batch-free frame the dictionary was trained in (see
+/// [`crate::fit::batch_fold`] for why a divide and not a rate offset). Built only
+/// when the collapse fit a `δ` (>1 batch); absent otherwise.
 #[derive(Clone, Copy)]
-pub(crate) struct CellBatchDivisor<'a> {
-    /// `[n_features × n_pb]` batch fold-factor on the **unified** feature axis,
-    /// so a cell's feature id indexes a row directly (no remap).
-    pub mu_residual: &'a DMatrix<f32>,
-    /// Cell id → finest-pseudobulk id (the `μ_residual` column to divide by).
-    pub cell_to_pb: &'a [usize],
+pub(crate) struct CellBatchFold<'a> {
+    /// The fold table on the unified axes.
+    pub fold: &'a BatchGeneFold,
+    /// Cell id → unified batch id (the table row to divide by).
+    pub cell_to_batch: &'a [u32],
 }
 
-/// Divide one cell's `(feature, count)` edges by its pseudobulk batch fold-factor,
-/// reusing matrix-util's [`adjust_by_poisson_ratio`] — the same self-normalizing
-/// divide (`λ = Σx/Σd`, depth preserved for `b_cell`) `senna svd`/`topic` apply via
-/// the `CscMatrix` trait, here straight on the cell's counts (no per-cell CSC).
-/// `feats` index `μ_residual` rows directly.
-fn adjust_cell_edges(
-    feats: &[u32],
-    counts: &[f32],
-    pb: usize,
-    mu_residual: &DMatrix<f32>,
-) -> Vec<(u32, f32)> {
-    let mut vals = counts.to_vec();
-    adjust_by_poisson_ratio(&mut vals, |k| mu_residual[(feats[k] as usize, pb)]);
-    feats.iter().copied().zip(vals).collect()
-}
-
-/// One node's `(feature, count)` edges, batch-divided by its pseudobulk
-/// fold-factor when correction is on, else the raw edges. Called back by the block
-/// SGD ([`block_sgd`]) as it flattens each node's edges. (The pb readout passes no
-/// divisor — its aggregates are already batch-corrected.)
-pub(crate) fn cell_edges(
-    cell: u32,
-    feats: &[u32],
-    counts: &[f32],
-    batch_divisor: Option<CellBatchDivisor>,
-) -> Vec<(u32, f32)> {
-    match batch_divisor {
-        Some(bd) => adjust_cell_edges(feats, counts, bd.cell_to_pb[cell as usize], bd.mu_residual),
-        None => feats.iter().copied().zip(counts.iter().copied()).collect(),
+impl<'a> CellBatchFold<'a> {
+    /// The fold row for `cell`'s batch. Takes `self` by value (the struct is
+    /// `Copy`) so the row borrows the table, not this handle.
+    pub(crate) fn row_for(self, cell: u32) -> &'a [f32] {
+        self.fold.row(self.cell_to_batch[cell as usize] as usize)
     }
+}
+
+/// One cell's `(feature, count)` edges, divided by its batch's fold when
+/// correction is on, else the raw edges. Plain division — no depth rescale — so
+/// a cell whose counts are exactly a batch's fold of another cell's solves to the
+/// identical latent and intercept. Called by the block SGD as it flattens each
+/// cell's edges. (The pb readout passes no fold — its aggregates are already
+/// batch-free.)
+pub(crate) fn cell_edges<'a>(
+    cell: u32,
+    feats: &'a [u32],
+    counts: &'a [f32],
+    fold: Option<CellBatchFold<'a>>,
+) -> impl Iterator<Item = (u32, f32)> + 'a {
+    let row = fold.map(|f| f.row_for(cell));
+    feats.iter().zip(counts).map(move |(&f, &c)| match row {
+        Some(d) => (f, c / d[f as usize]),
+        None => (f, c),
+    })
 }
 
 /////////////////////////////////////////

--- a/graph-embedding-util/src/fit/projection/block_sgd/block_sgd_tests.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/block_sgd_tests.rs
@@ -15,6 +15,7 @@
 
 use super::edges::block_cells;
 use super::*;
+use crate::fit::batch_fold::BatchGeneFold;
 use candle_util::candle_core::Device;
 
 fn cos(a: &[f32], b: &[f32]) -> f32 {
@@ -55,36 +56,9 @@ fn rates(e: &[f32], b: &[f32], h: usize, theta: &[f32], b_c: f32) -> Vec<(u32, f
         .collect()
 }
 
-/// Run `project_cells` over one pass (no splice split) for a set of planted cells.
+/// Run `project_cells` over one pass (no splice split, no fold) for a set of planted cells.
 fn project(e: &[f32], b: &[f32], h: usize, per_cell: &[Vec<(u32, f32)>], lambda: f64) -> Phase2Out {
-    let feats: Vec<Vec<u32>> = per_cell
-        .iter()
-        .map(|c| c.iter().map(|&(f, _)| f).collect())
-        .collect();
-    let counts: Vec<Vec<f32>> = per_cell
-        .iter()
-        .map(|c| c.iter().map(|&(_, n)| n).collect())
-        .collect();
-    let cells: Vec<(u32, &[u32], &[f32])> = (0..per_cell.len())
-        .map(|i| (i as u32, feats[i].as_slice(), counts[i].as_slice()))
-        .collect();
-    project_cells(
-        &Phase2Input {
-            feat: e,
-            b_feat: b,
-            h,
-            n_cells: per_cell.len(),
-            lambda,
-            dev: &Device::Cpu,
-            label: "Phase 2",
-            gauge_fix: true,
-            joint: false,
-        },
-        &cells,
-        None,
-        None,
-    )
-    .expect("phase-2 SGD")
+    project_with(e, b, h, per_cell, lambda, None)
 }
 
 /// Three planted latents; counts at the noiseless full-partition rate. Each cell's
@@ -521,4 +495,203 @@ fn the_offered_group_size_is_a_whole_number_of_blocks() {
             "F={n_feat}: group of {g} is not whole blocks of {bc}"
         );
     }
+}
+
+////////////////////////////
+// Per-batch gene fold     //
+////////////////////////////
+
+/// A planted per-feature batch fold on batch 1: powers of two in
+/// `{¼, ½, 1, 2, 4}`, exact in f32 so `(y·δ)/δ == y` bit for bit.
+fn planted_fold(n_feat: usize) -> Vec<f32> {
+    (0..n_feat)
+        .map(|f| 2f32.powi(((f * 3) % 5) as i32 - 2))
+        .collect()
+}
+
+/// A two-batch fold table: batch 0 unfolded, batch 1 with the planted fold.
+fn fold_table(n_feat: usize) -> BatchGeneFold {
+    let mut delta = vec![1f32; n_feat]; // batch 0: no fold
+    delta.extend(planted_fold(n_feat));
+    BatchGeneFold {
+        delta,
+        n_features: n_feat,
+        batch_names: vec!["a".into(), "b".into()],
+    }
+}
+
+/// Two batches, three planted latents each. Batch 1's counts carry a per-feature
+/// fold on top of the shared dictionary. Dividing by the matching fold must
+/// recover every planted direction in BOTH batches; solving raw must fail on
+/// batch 1 — that is what shows the fold is doing the work.
+#[test]
+fn batch_fold_recovers_a_shared_latent_across_batches() {
+    let (h, n_feat) = (8, 300);
+    let (e, b) = dictionary(n_feat, h, 0.4);
+    let fold = planted_fold(n_feat);
+    let planted = [
+        [0.8f32, -0.6, 0.4, 0.2, -0.3, 0.5, 0.1, -0.4],
+        [-0.5f32, 0.7, -0.2, 0.6, 0.1, -0.4, 0.3, 0.2],
+        [0.2f32, 0.1, -0.7, -0.3, 0.5, 0.2, -0.6, 0.4],
+    ];
+    // Cells 0..3 in batch 0, 3..6 in batch 1 (the same latents again).
+    let mut per_cell: Vec<Vec<(u32, f32)>> = Vec::new();
+    let mut cell_to_batch: Vec<u32> = Vec::new();
+    for batch in 0..2u32 {
+        for (i, t) in planted.iter().enumerate() {
+            let mut r = rates(&e, &b, h, t, 0.4 + 0.1 * i as f32);
+            if batch == 1 {
+                for (f, x) in r.iter_mut() {
+                    *x *= fold[*f as usize];
+                }
+            }
+            per_cell.push(r);
+            cell_to_batch.push(batch);
+        }
+    }
+    let table = fold_table(n_feat);
+    let cbf = CellBatchFold {
+        fold: &table,
+        cell_to_batch: &cell_to_batch,
+    };
+
+    let with = project_with(&e, &b, h, &per_cell, 1e-3, Some(cbf));
+    let without = project_with(&e, &b, h, &per_cell, 1e-3, None);
+    let cos_of = |out: &Phase2Out, i: usize| {
+        let got = ungauge(&out.theta[i * h..(i + 1) * h], &out.gauge.theta_mean);
+        cos(&got, &planted[i % 3])
+    };
+    for i in 0..6 {
+        let c = cos_of(&with, i);
+        assert!(c > 0.97, "with fold: cell {i} misaligned (cos={c:.3})");
+    }
+    let worst_without = (3..6).map(|i| cos_of(&without, i)).fold(1.0f32, f32::min);
+    assert!(
+        worst_without < 0.97,
+        "without the fold batch 1 must NOT pass the recovery bar (worst cos={worst_without:.3}), \
+         or the test has no teeth"
+    );
+}
+
+/// The contract that makes the divide batch-invariant under misfit: a cell whose
+/// counts are exactly a batch's fold of another cell's counts is the SAME problem
+/// after the divide, so it solves to the identical latent and intercept — bit for
+/// bit, misfit or not. (An offset on the rate weights each batch's misfit by its
+/// own fold and does not have this property.)
+#[test]
+fn a_folded_copy_of_a_cell_solves_to_the_identical_latent() {
+    let (h, n_feat) = (6, 120);
+    let (e, b) = dictionary(n_feat, h, 0.3);
+    let fold = planted_fold(n_feat);
+    // Counts that the dictionary cannot reproduce exactly: a planted profile plus
+    // an off-model bump on every third feature.
+    let mut base: Vec<(u32, f32)> = rates(&e, &b, h, &[0.4, -0.2, 0.5, 0.1, -0.6, 0.3], 0.3);
+    for (f, x) in base.iter_mut() {
+        if *f % 3 == 0 {
+            *x *= 3.0;
+        }
+    }
+    let folded: Vec<(u32, f32)> = base
+        .iter()
+        .map(|&(f, x)| (f, x * fold[f as usize]))
+        .collect();
+    let other = rates(&e, &b, h, &[-0.3, 0.6, -0.1, 0.4, 0.2, -0.5], 0.2);
+    let per_cell = vec![base, folded, other];
+    let cell_to_batch = vec![0u32, 1, 0];
+    let table = fold_table(n_feat);
+    let out = project_with(
+        &e,
+        &b,
+        h,
+        &per_cell,
+        1e-3,
+        Some(CellBatchFold {
+            fold: &table,
+            cell_to_batch: &cell_to_batch,
+        }),
+    );
+    assert_eq!(
+        &out.theta[..h],
+        &out.theta[h..2 * h],
+        "folded copy must solve identically"
+    );
+    assert_eq!(out.b_cell[0], out.b_cell[1], "and to the same intercept");
+    // Sanity: the third cell is a different problem.
+    assert_ne!(&out.theta[..h], &out.theta[2 * h..3 * h]);
+}
+
+/// A single batch with an all-ones fold row is the same problem as no fold at
+/// all — same block partition, same numbers, byte for byte.
+#[test]
+fn unit_fold_is_byte_identical_to_none() {
+    let (h, n_feat) = (6, 120);
+    let (e, b) = dictionary(n_feat, h, 0.3);
+    let per_cell: Vec<_> = (0..5)
+        .map(|i| {
+            let t: Vec<f32> = (0..h)
+                .map(|k| (((i * 3 + k * 5) % 7) as f32 / 7.0) - 0.5)
+                .collect();
+            rates(&e, &b, h, &t, 0.2 + 0.05 * i as f32)
+        })
+        .collect();
+    let ones = BatchGeneFold {
+        delta: vec![1f32; n_feat],
+        n_features: n_feat,
+        batch_names: vec!["only".into()],
+    };
+    let cell_to_batch = vec![0u32; 5];
+    let a = project_with(&e, &b, h, &per_cell, 1e-3, None);
+    let z = project_with(
+        &e,
+        &b,
+        h,
+        &per_cell,
+        1e-3,
+        Some(CellBatchFold {
+            fold: &ones,
+            cell_to_batch: &cell_to_batch,
+        }),
+    );
+    assert_eq!(a.theta, z.theta);
+    assert_eq!(a.b_cell, z.b_cell);
+    assert_eq!(a.gauge.theta_mean, z.gauge.theta_mean);
+}
+
+/// `project` with an optional batch fold.
+fn project_with(
+    e: &[f32],
+    b: &[f32],
+    h: usize,
+    per_cell: &[Vec<(u32, f32)>],
+    lambda: f64,
+    fold: Option<CellBatchFold>,
+) -> Phase2Out {
+    let feats: Vec<Vec<u32>> = per_cell
+        .iter()
+        .map(|c| c.iter().map(|&(f, _)| f).collect())
+        .collect();
+    let counts: Vec<Vec<f32>> = per_cell
+        .iter()
+        .map(|c| c.iter().map(|&(_, n)| n).collect())
+        .collect();
+    let cells: Vec<(u32, &[u32], &[f32])> = (0..per_cell.len())
+        .map(|i| (i as u32, feats[i].as_slice(), counts[i].as_slice()))
+        .collect();
+    project_cells(
+        &Phase2Input {
+            feat: e,
+            b_feat: b,
+            h,
+            n_cells: per_cell.len(),
+            lambda,
+            dev: &Device::Cpu,
+            label: "Phase 2",
+            gauge_fix: true,
+            joint: false,
+        },
+        &cells,
+        fold,
+        None,
+    )
+    .expect("phase-2 SGD")
 }

--- a/graph-embedding-util/src/fit/projection/block_sgd/edges.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/edges.rs
@@ -8,7 +8,7 @@
 //! edge table belongs to the nodes and is rebuilt for every group of them.
 
 use super::{BLOCK_ACTIVATION_BYTES, LIVE_BLOCK_TENSORS, MAX_BLOCK_CELLS};
-use crate::fit::projection::{cell_edges, CellBatchDivisor};
+use crate::fit::projection::{cell_edges, CellBatchFold};
 
 ////////////////////////////
 // Edge table (host, once) //
@@ -17,8 +17,8 @@ use crate::fit::projection::{cell_edges, CellBatchDivisor};
 /// Every cell's edges restricted to one pass's feature partition, remapped to that
 /// pass's local feature ids, grouped by cell position and flattened.
 ///
-/// Built once per pass. A block takes a *slice* of these — no per-block copy, and
-/// no per-cell `Vec` churn of the kind `cell_edges` does on the Newton path.
+/// Built once per pass. A block takes a *slice* of these — no per-block copy and
+/// no per-cell `Vec` churn.
 pub(super) struct EdgeTable {
     /// `offsets[i]..offsets[i + 1]` is cell `i`'s slice of `feat`/`count`.
     offsets: Vec<usize>,
@@ -32,7 +32,7 @@ impl EdgeTable {
         cells: &[(u32, &[u32], &[f32])],
         rows: &[u32],
         n_features: usize,
-        batch_divisor: Option<CellBatchDivisor>,
+        fold: Option<CellBatchFold>,
     ) -> Self {
         // Global feature id → pass-local id, or `u32::MAX` when the feature is not
         // in this pass's partition.
@@ -45,8 +45,8 @@ impl EdgeTable {
         let mut count = Vec::new();
         offsets.push(0);
         for &(cell, feats, counts) in cells {
-            // The `μ_residual` divide happens here, once, instead of per solve.
-            for (f, c) in cell_edges(cell, feats, counts, batch_divisor) {
+            // The batch divide happens here, once, instead of per solve.
+            for (f, c) in cell_edges(cell, feats, counts, fold) {
                 let l = local[f as usize];
                 if l != u32::MAX {
                     feat.push(l);

--- a/graph-embedding-util/src/fit/projection/block_sgd/mod.rs
+++ b/graph-embedding-util/src/fit/projection/block_sgd/mod.rs
@@ -95,7 +95,7 @@
 //! nodes, so a caller with more nodes than it wants resident can stream them past
 //! the same dictionary.
 
-use super::CellBatchDivisor;
+use super::CellBatchFold;
 use crate::progress::new_progress_bar;
 use candle_util::candle_core::Device;
 use log::info;
@@ -298,9 +298,9 @@ pub(crate) struct GaugeShift {
 ///
 /// `cells` is the flattened per-node view `(global id, feature ids, counts)` — the
 /// per-cell sampler flattening on the `super::cells` path, one entry per pb node on
-/// the `super::pseudobulk` path. `batch_divisor`, when set, applies the
-/// `μ_residual` fold-factor divide — **once**, while the edges are flattened,
-/// rather than on every solve.
+/// the `super::pseudobulk` path. `batch_fold`, when set, divides each cell's
+/// counts by its batch's per-gene fold — **once**, while the edges are flattened,
+/// rather than on every solve (see [`crate::fit::batch_fold`]).
 ///
 /// Without `unspliced_rows` (bge) there is one pass over every feature row. With
 /// it (gem β-sharing) there are two: identity `θ` from the spliced edges with the
@@ -312,15 +312,15 @@ pub(crate) struct GaugeShift {
 pub(crate) fn project_cells(
     input: &Phase2Input,
     cells: &[(u32, &[u32], &[f32])],
-    batch_divisor: Option<CellBatchDivisor>,
+    batch_fold: Option<CellBatchFold>,
     unspliced_rows: Option<&[bool]>,
 ) -> anyhow::Result<Phase2Out> {
-    let h = input.h;
     let n_features = input.b_feat.len();
     anyhow::ensure!(
-        input.feat.len() == n_features * h,
-        "phase-2: e_feat has {} entries, expected {n_features} × {h}",
-        input.feat.len()
+        input.feat.len() == n_features * input.h,
+        "phase-2: e_feat has {} entries, expected {n_features} × {}",
+        input.feat.len(),
+        input.h
     );
 
     // Per-pass feature partitions on the global feature axis. One pass (all rows)
@@ -346,11 +346,11 @@ pub(crate) fn project_cells(
         }
     };
 
-    // Flatten the sampler edges once, applying the batch divisor here so no solve
+    // Flatten the sampler edges once, applying the batch fold here so no solve
     // ever re-derives them. Grouped by the cell's position in `cells`.
-    let edges_a = EdgeTable::build(cells, &rows_a, n_features, batch_divisor);
+    let edges_a = EdgeTable::build(cells, &rows_a, n_features, batch_fold);
     let edges_b =
-        (!rows_b.is_empty()).then(|| EdgeTable::build(cells, &rows_b, n_features, batch_divisor));
+        (!rows_b.is_empty()).then(|| EdgeTable::build(cells, &rows_b, n_features, batch_fold));
 
     // The bar counts **cells**, across both passes, and advances *within* a block
     // in proportion to that block's Adam steps. Counting whole blocks would tick
@@ -410,7 +410,7 @@ pub(crate) fn project_cells(
 /// Project one group of nodes against a dictionary the caller has **already**
 /// built — the streaming counterpart of [`project_cells`].
 ///
-/// One feature partition (every row of the dictionary), no batch divisor and no
+/// One feature partition (every row of the dictionary), no batch fold and no
 /// splice pass, on the caller's own progress bar: the shape
 /// [`super::FrozenProjector`] needs to walk a query past a frozen side group by
 /// group.

--- a/graph-embedding-util/src/fit/projection/cells.rs
+++ b/graph-embedding-util/src/fit/projection/cells.rs
@@ -4,7 +4,7 @@
 //! [`super::pseudobulk`]; both drive the same engine.
 
 use super::block_sgd;
-use super::CellBatchDivisor;
+use super::CellBatchFold;
 use crate::loss::PerBatchStratifiedCellSampler;
 use crate::model::JointEmbedModel;
 use candle_util::candle_core::Device;
@@ -82,7 +82,7 @@ fn collect_sampler_cells(
 /// post-hoc aggregate.
 ///
 /// See [`Phase2Result`] for what comes back.
-#[allow(clippy::too_many_arguments)] // frozen dictionary + samplers + batch divisor + splice mask
+#[allow(clippy::too_many_arguments)] // frozen dictionary + samplers + batch fold + splice mask
 pub(crate) fn project_cells_phase2(
     model: &mut JointEmbedModel,
     varmap: &VarMap,
@@ -90,7 +90,7 @@ pub(crate) fn project_cells_phase2(
     n_cells: usize,
     lambda: f64,
     dev: &Device,
-    batch_divisor: Option<CellBatchDivisor>,
+    batch_fold: Option<CellBatchFold>,
     unspliced_rows: Option<&[bool]>,
     joint: bool,
 ) -> anyhow::Result<Phase2Result> {
@@ -107,10 +107,12 @@ pub(crate) fn project_cells_phase2(
         "Phase 2 — cell-block Poisson SGD over {n_cells} cells ({} with edges) on {dev:?}, \
          full log-partition, ridge λ={lambda}{}",
         cells.len(),
-        if batch_divisor.is_some() {
-            ", μ_residual batch-divided"
-        } else {
-            ""
+        match &batch_fold {
+            Some(bf) => format!(
+                ", counts divided by the per-batch gene fold ({} batches)",
+                bf.fold.n_batches()
+            ),
+            None => String::new(),
         }
     );
 
@@ -129,7 +131,7 @@ pub(crate) fn project_cells_phase2(
             joint,
         },
         &cells,
-        batch_divisor,
+        batch_fold,
         unspliced_rows,
     )?;
 

--- a/graph-embedding-util/src/fit/projection/pseudobulk.rs
+++ b/graph-embedding-util/src/fit/projection/pseudobulk.rs
@@ -29,7 +29,7 @@ pub struct PbLevelVelocity {
 /// per-node Newton solve gave up on, on `dev`, not a cache-hostile per-node Gram.
 ///
 /// The pb aggregates (`pb_blobs[level].triplets`) are already batch-corrected, so
-/// no batch divisor is applied; `gauge_fix` is **off**, so `θ_pb` stays in the raw
+/// no batch fold is applied; `gauge_fix` is **off**, so `θ_pb` stays in the raw
 /// as-trained frame the cell-lift differences cells against (pb landmarks are never
 /// co-embedded, so there is no common mode to remove). `frozen_e` is row-major
 /// `[n_features × h]`.
@@ -60,7 +60,7 @@ pub(crate) fn project_pbs_phase2(
         let nodes: Vec<(u32, &[u32], &[f32])> = (0..n_pb)
             .map(|p| (p as u32, feats[p].as_slice(), counts[p].as_slice()))
             .collect();
-        // No batch divisor — pb aggregates are already batch-corrected. `gauge_fix`
+        // No batch fold — pb aggregates are already batch-free. `gauge_fix`
         // off keeps pb θ raw: the cell-lift differences cells against raw pb θ, and
         // pb landmarks are never co-embedded, so there is no common mode to remove.
         let res = block_sgd::project_cells(

--- a/graph-embedding-util/src/fit/selection/tests.rs
+++ b/graph-embedding-util/src/fit/selection/tests.rs
@@ -66,6 +66,7 @@ fn free_with_heads(
                     shared_e_feat_logstd: None,
                     shared_gate_ibp_bias: None,
                     gate: None,
+                    shared_modules: None,
                 },
                 vm,
                 &dev(),

--- a/graph-embedding-util/src/lib.rs
+++ b/graph-embedding-util/src/lib.rs
@@ -36,6 +36,7 @@ pub mod posterior;
 pub mod postprocess;
 pub mod progress;
 pub mod training;
+pub mod transfer;
 pub mod type_annotation;
 
 pub use auxiliary_data::feature_names::FeatureNameKind;

--- a/graph-embedding-util/src/lib.rs
+++ b/graph-embedding-util/src/lib.rs
@@ -43,12 +43,12 @@ pub use data::{load_unified_data, validate_multiome_groups, LoadUnifiedArgs, Uni
 pub use data_beans_alg::refine_multilevel::RefineParams;
 pub use eval::{
     embedding_col_names, save_embedding, save_outputs, save_outputs_named,
-    write_feature_coembedding, EmbeddingFileNames, OutputContext,
+    write_feature_coembedding, write_module_tables, EmbeddingFileNames, OutputContext,
 };
 pub use feature_qc::{hvg_feature_qc, FeatureQcConfig, FeatureQcResult};
 pub use fit::{
-    fit, CellLineage, FeatFactorSpec, FeatureGateConfig, FitConfig, FitOutput, LineageQc,
-    PbLevelVelocity,
+    fit, warm_start_module_labels, CellLineage, FeatFactorSpec, FeatureGateConfig, FitConfig,
+    FitOutput, GeneModuleArgs, GeneModuleConfig, LineageQc, PbLevelVelocity,
 };
 pub use model::JointEmbedModel;
 pub use postprocess::{cell_clusters, feature_coembedding};

--- a/graph-embedding-util/src/lib.rs
+++ b/graph-embedding-util/src/lib.rs
@@ -49,7 +49,8 @@ pub use eval::{
 pub use feature_qc::{hvg_feature_qc, FeatureQcConfig, FeatureQcResult};
 pub use fit::{
     fit, warm_start_module_labels, CellLineage, FeatFactorSpec, FeatureGateConfig, FitConfig,
-    FitOutput, GeneModuleArgs, GeneModuleConfig, LineageQc, PbLevelVelocity, DEFAULT_GENE_MODULES,
+    FitOutput, GeneModuleArgs, GeneModuleConfig, LineageQc, ParentModulesOwned, PbLevelVelocity,
+    DEFAULT_GENE_MODULES,
 };
 pub use model::JointEmbedModel;
 pub use postprocess::{cell_clusters, feature_coembedding};

--- a/graph-embedding-util/src/lib.rs
+++ b/graph-embedding-util/src/lib.rs
@@ -50,7 +50,6 @@ pub use feature_qc::{hvg_feature_qc, FeatureQcConfig, FeatureQcResult};
 pub use fit::{
     fit, warm_start_module_labels, CellLineage, FeatFactorSpec, FeatureGateConfig, FitConfig,
     FitOutput, GeneModuleArgs, GeneModuleConfig, LineageQc, ParentModulesOwned, PbLevelVelocity,
-    DEFAULT_GENE_MODULES,
 };
 pub use model::JointEmbedModel;
 pub use postprocess::{cell_clusters, feature_coembedding};

--- a/graph-embedding-util/src/lib.rs
+++ b/graph-embedding-util/src/lib.rs
@@ -48,7 +48,7 @@ pub use eval::{
 pub use feature_qc::{hvg_feature_qc, FeatureQcConfig, FeatureQcResult};
 pub use fit::{
     fit, warm_start_module_labels, CellLineage, FeatFactorSpec, FeatureGateConfig, FitConfig,
-    FitOutput, GeneModuleArgs, GeneModuleConfig, LineageQc, PbLevelVelocity,
+    FitOutput, GeneModuleArgs, GeneModuleConfig, LineageQc, PbLevelVelocity, DEFAULT_GENE_MODULES,
 };
 pub use model::JointEmbedModel;
 pub use postprocess::{cell_clusters, feature_coembedding};

--- a/graph-embedding-util/src/loss/feat.rs
+++ b/graph-embedding-util/src/loss/feat.rs
@@ -6,6 +6,7 @@
 //! shape so the downstream NCE loss is sampler-agnostic.
 
 use crate::data::Triplet;
+use crate::loss::modules::ModulePools;
 use crate::loss::{logistic_nce, softmax_nce, NceObjective};
 use crate::model::JointEmbedModel;
 use crate::progress::new_progress_bar;
@@ -24,6 +25,9 @@ pub struct EdgeBatch {
     /// `[B*K]` row-major: negatives for positive `b` are at `[b*K..(b+1)*K]`.
     pub neg_feats: Vec<u32>,
     pub n_negatives: usize,
+    /// Positives whose within-module negative draw fell back to the global pool
+    /// (module too small in this sampler). `0` without module pools.
+    pub n_module_fallback: usize,
 }
 
 ///////////////////////////////////////////////////
@@ -69,6 +73,9 @@ pub struct PerBatchStratifiedEdgeBatchArgs<'a> {
     pub cell_coarsening: &'a FeatureCoarsening,
     pub batch_size: usize,
     pub n_negatives: usize,
+    /// Within-module negative pools for this sampler (module model only). `None`
+    /// keeps the global uniform draw and the RNG stream byte-identical.
+    pub module_pools: Option<&'a ModulePools>,
 }
 
 /// Two-stage draw: pick cell by `degree^alpha_cell`, then feature
@@ -94,9 +101,27 @@ pub fn sample_per_batch_stratified_edge_batch(
     }
 
     let mut neg_feats = Vec::with_capacity(args.batch_size * args.n_negatives);
-    for _ in 0..(args.batch_size * args.n_negatives) {
-        let local = s.neg.sample(rng);
-        neg_feats.push(s.feature_pool[local]);
+    let mut n_module_fallback = 0usize;
+    match args.module_pools {
+        // Within-module negatives: contrast the positive against its own module's
+        // members, so the NCE resolves features WITHIN a module and leaves the
+        // between-module structure to the exact module term.
+        Some(pools) => {
+            for &f in &fine_feats {
+                if !pools.draw_negatives(f, args.n_negatives, &mut neg_feats, rng) {
+                    n_module_fallback += 1;
+                    for _ in 0..args.n_negatives {
+                        neg_feats.push(s.feature_pool[s.neg.sample(rng)]);
+                    }
+                }
+            }
+        }
+        None => {
+            for _ in 0..(args.batch_size * args.n_negatives) {
+                let local = s.neg.sample(rng);
+                neg_feats.push(s.feature_pool[local]);
+            }
+        }
     }
 
     EdgeBatch {
@@ -104,6 +129,7 @@ pub fn sample_per_batch_stratified_edge_batch(
         fine_feats,
         neg_feats,
         n_negatives: args.n_negatives,
+        n_module_fallback,
     }
 }
 
@@ -163,6 +189,10 @@ pub struct PbFeatureSampler {
     /// draw emits both `features[i]` and `paired[i]` so δ_g trains at the spliced
     /// sampling frequency.
     pub paired: Vec<u32>,
+    /// The sampling weights aligned with `features` — the per-row count, or the
+    /// gene's total in gene-paired mode. Kept because the module term pools the
+    /// unit's whole count row, which the picker alone cannot give back.
+    pub counts: Vec<f32>,
     /// `WeightedIndex` over `features`; per-row weights = `μ_pf`,
     /// gene-paired weights = the gene's `total` count.
     pub picker: WeightedIndex<f32>,
@@ -314,12 +344,13 @@ pub fn build_stratified_sampler(
                     (features, Vec::new(), weights)
                 }
             };
-            let picker = WeightedIndex::new(weights).expect("non-empty pb feature weights");
+            let picker = WeightedIndex::new(weights.clone()).expect("non-empty pb feature weights");
             (
                 p as u32,
                 PbFeatureSampler {
                     features,
                     paired,
+                    counts: weights,
                     picker,
                 },
                 pb_size[p].max(1e-8).powf(alpha_pb),
@@ -373,14 +404,16 @@ pub struct StratifiedEdgeBatchArgs<'a> {
     pub sampler: &'a StratifiedSampler,
     pub batch_size: usize,
     pub n_negatives: usize,
+    /// See [`PerBatchStratifiedEdgeBatchArgs::module_pools`].
+    pub module_pools: Option<&'a ModulePools>,
 }
 
 /// Two-stage draw: pick pb by `q(p)`, then feature within pb. Output
 /// `EdgeBatch` is interchangeable with [`sample_edge_batch`]'s — the
 /// downstream NCE loss doesn't care how the batch was sampled.
-pub fn sample_stratified_edge_batch(
+pub fn sample_stratified_edge_batch<R: Rng>(
     args: StratifiedEdgeBatchArgs,
-    rng: &mut impl Rng,
+    rng: &mut R,
 ) -> EdgeBatch {
     let s = args.sampler;
     let mut coarse_cells = Vec::with_capacity(args.batch_size);
@@ -411,16 +444,36 @@ pub fn sample_stratified_edge_batch(
     let n_pos = fine_feats.len();
     let n_neg = n_pos * args.n_negatives;
     let mut neg_feats = Vec::with_capacity(n_neg);
+    let mut n_module_fallback = 0usize;
     // Half uniform, half degree-proportional — SIMBA's 100 + 100 split. Drawn by
     // alternating rather than by a coin flip so the ratio is exact for any
     // `n_negatives`, including odd ones.
-    for i in 0..n_neg {
-        let local = if i % 2 == 0 {
+    let global_draw = |i: usize, rng: &mut R| {
+        let local = if i.is_multiple_of(2) {
             s.neg.sample(rng)
         } else {
             s.neg_by_degree.sample(rng)
         };
-        neg_feats.push(s.feature_pool[local]);
+        s.feature_pool[local]
+    };
+    match args.module_pools {
+        // Within-module negatives (see the per-batch sampler); the global mixed
+        // draw is the fallback for a module too small to contrast within.
+        Some(pools) => {
+            for &f in &fine_feats {
+                if !pools.draw_negatives(f, args.n_negatives, &mut neg_feats, rng) {
+                    n_module_fallback += 1;
+                    for i in 0..args.n_negatives {
+                        neg_feats.push(global_draw(i, rng));
+                    }
+                }
+            }
+        }
+        None => {
+            for i in 0..n_neg {
+                neg_feats.push(global_draw(i, rng));
+            }
+        }
     }
 
     EdgeBatch {
@@ -428,6 +481,7 @@ pub fn sample_stratified_edge_batch(
         fine_feats,
         neg_feats,
         n_negatives: args.n_negatives,
+        n_module_fallback,
     }
 }
 
@@ -490,6 +544,23 @@ pub fn nce_loss_identity(
 /// learned path, the logits. Ungated with no `pip` it is the plain gather. This is the
 /// single feature-gather point for the bge + gem trainers.
 pub fn gather_feature_rows(model: &JointEmbedModel, idx: &Tensor) -> Result<Tensor> {
+    // Modules: compose the gathered rows as `π μ + r` on the live tables, then the
+    // same gate/effect machinery as the free path. Comes FIRST and never reads
+    // `e_feat`, which is a detached snapshot for this parameterization.
+    if let Some(m) = &model.modules {
+        let mu = m.compose_rows(idx)?;
+        let logstd = model
+            .e_feat_logstd
+            .as_ref()
+            .map(|l| l.index_select(idx, 0))
+            .transpose()?;
+        let w = model.gathered_gate_weights(
+            crate::model::GateKind::Identity,
+            model.s_feat.as_ref(),
+            idx,
+        )?;
+        return model.gated_rows(&mu, logstd.as_ref(), w.as_ref(), true);
+    }
     // Adapter: compose the gathered rows from the fixed dictionary and the
     // shared map, then let the same gate/effect machinery as the free path
     // apply on top. Mutually exclusive with `factor` by construction.

--- a/graph-embedding-util/src/loss/feat.rs
+++ b/graph-embedding-util/src/loss/feat.rs
@@ -25,9 +25,6 @@ pub struct EdgeBatch {
     /// `[B*K]` row-major: negatives for positive `b` are at `[b*K..(b+1)*K]`.
     pub neg_feats: Vec<u32>,
     pub n_negatives: usize,
-    /// Positives whose within-module negative draw fell back to the global pool
-    /// (module too small in this sampler). `0` without module pools.
-    pub n_module_fallback: usize,
 }
 
 ///////////////////////////////////////////////////
@@ -101,15 +98,14 @@ pub fn sample_per_batch_stratified_edge_batch(
     }
 
     let mut neg_feats = Vec::with_capacity(args.batch_size * args.n_negatives);
-    let mut n_module_fallback = 0usize;
     match args.module_pools {
         // Within-module negatives: contrast the positive against its own module's
         // members, so the NCE resolves features WITHIN a module and leaves the
-        // between-module structure to the exact module term.
+        // between-module structure to the exact module term. The pools count
+        // their own fallbacks.
         Some(pools) => {
             for &f in &fine_feats {
                 if !pools.draw_negatives(f, args.n_negatives, &mut neg_feats, rng) {
-                    n_module_fallback += 1;
                     for _ in 0..args.n_negatives {
                         neg_feats.push(s.feature_pool[s.neg.sample(rng)]);
                     }
@@ -129,7 +125,6 @@ pub fn sample_per_batch_stratified_edge_batch(
         fine_feats,
         neg_feats,
         n_negatives: args.n_negatives,
-        n_module_fallback,
     }
 }
 
@@ -444,7 +439,6 @@ pub fn sample_stratified_edge_batch<R: Rng>(
     let n_pos = fine_feats.len();
     let n_neg = n_pos * args.n_negatives;
     let mut neg_feats = Vec::with_capacity(n_neg);
-    let mut n_module_fallback = 0usize;
     // Half uniform, half degree-proportional — SIMBA's 100 + 100 split. Drawn by
     // alternating rather than by a coin flip so the ratio is exact for any
     // `n_negatives`, including odd ones.
@@ -462,7 +456,6 @@ pub fn sample_stratified_edge_batch<R: Rng>(
         Some(pools) => {
             for &f in &fine_feats {
                 if !pools.draw_negatives(f, args.n_negatives, &mut neg_feats, rng) {
-                    n_module_fallback += 1;
                     for i in 0..args.n_negatives {
                         neg_feats.push(global_draw(i, rng));
                     }
@@ -481,7 +474,6 @@ pub fn sample_stratified_edge_batch<R: Rng>(
         fine_feats,
         neg_feats,
         n_negatives: args.n_negatives,
-        n_module_fallback,
     }
 }
 
@@ -544,31 +536,11 @@ pub fn nce_loss_identity(
 /// learned path, the logits. Ungated with no `pip` it is the plain gather. This is the
 /// single feature-gather point for the bge + gem trainers.
 pub fn gather_feature_rows(model: &JointEmbedModel, idx: &Tensor) -> Result<Tensor> {
-    // Modules: compose the gathered rows as `π μ + r` on the live tables, then the
-    // same gate/effect machinery as the free path. Comes FIRST and never reads
-    // `e_feat`, which is a detached snapshot for this parameterization.
-    if let Some(m) = &model.modules {
-        let mu = m.compose_rows(idx)?;
-        let logstd = model
-            .e_feat_logstd
-            .as_ref()
-            .map(|l| l.index_select(idx, 0))
-            .transpose()?;
-        let w = model.gathered_gate_weights(
-            crate::model::GateKind::Identity,
-            model.s_feat.as_ref(),
-            idx,
-        )?;
-        return model.gated_rows(&mu, logstd.as_ref(), w.as_ref(), true);
-    }
-    // Adapter: compose the gathered rows from the fixed dictionary and the
-    // shared map, then let the same gate/effect machinery as the free path
-    // apply on top. Mutually exclusive with `factor` by construction.
-    if let Some(a) = &model.adapter {
-        let mut mu = a.rho.index_select(idx, 0)?.matmul(&a.w)?;
-        if let Some(r) = &a.residual {
-            mu = mu.add(&r.index_select(idx, 0)?)?;
-        }
+    // Composed feature side (adapter `ρ·W + r`, modules `π μ + r`): compose the
+    // gathered rows on the live parameters, then the same gate/effect machinery as
+    // the free path. Never reads `e_feat`, a detached snapshot for these models.
+    if let Some(c) = model.composed() {
+        let mu = c.compose_rows(idx)?;
         let logstd = model
             .e_feat_logstd
             .as_ref()

--- a/graph-embedding-util/src/loss/mod.rs
+++ b/graph-embedding-util/src/loss/mod.rs
@@ -47,9 +47,9 @@ pub use feat::{
     PerBatchStratifiedEdgeBatchArgs, StratifiedEdgeBatchArgs, StratifiedSampler,
 };
 pub use modules::{
-    dense_count_block, draw_gene_keep_mask, masked_membership, membership_diagnostics,
-    membership_rows_host, module_balance_prior, module_row_entropy, module_softmax_loss,
-    pool_module_counts, MembershipDiagnostics, ModulePools,
+    dense_count_block, draw_gene_keep_mask, log_membership_diagnostics, masked_membership,
+    membership_diagnostics, membership_rows_host, module_balance_prior, module_priors,
+    module_softmax_loss, module_step_loss, MembershipDiagnostics, ModulePools, MODULE_SMALL_FLOOR,
 };
 
 /// The one canonical numerically-stable `log σ(x)` lives in `candle_util`;

--- a/graph-embedding-util/src/loss/mod.rs
+++ b/graph-embedding-util/src/loss/mod.rs
@@ -28,6 +28,7 @@ use candle_util::candle_core::{Result, Tensor};
 pub(crate) mod cell;
 pub(crate) mod chain;
 pub(crate) mod feat;
+pub(crate) mod modules;
 
 #[cfg(test)]
 mod tests;
@@ -44,6 +45,11 @@ pub use feat::{
     sample_per_batch_stratified_edge_batch, sample_stratified_edge_batch, CellFeatureSampler,
     EdgeBatch, FeatPairing, PbFeatureSampler, PerBatchStratifiedCellSampler,
     PerBatchStratifiedEdgeBatchArgs, StratifiedEdgeBatchArgs, StratifiedSampler,
+};
+pub use modules::{
+    dense_count_block, draw_gene_keep_mask, masked_membership, membership_diagnostics,
+    membership_rows_host, module_balance_prior, module_row_entropy, module_softmax_loss,
+    pool_module_counts, MembershipDiagnostics, ModulePools,
 };
 
 /// The one canonical numerically-stable `log σ(x)` lives in `candle_util`;

--- a/graph-embedding-util/src/loss/modules.rs
+++ b/graph-embedding-util/src/loss/modules.rs
@@ -62,8 +62,8 @@ pub fn masked_membership(pi: &Tensor, keep: &Tensor) -> Result<Tensor> {
     kept.broadcast_mul(&scale)
 }
 
-/// Module-pooled counts `x̃ = X · π̃`, `[U, M]`. One matmul, with autograd into
-/// the membership.
+/// Module-pooled counts `x̃ = X · π̃`, `[U, M]`. One matmul; the exact term
+/// detaches it, so the membership sees no gradient from the pooled target.
 pub fn pool_module_counts(x_dense: &Tensor, pi_masked: &Tensor) -> Result<Tensor> {
     x_dense.matmul(pi_masked)
 }
@@ -104,6 +104,16 @@ pub fn dense_count_block(
 /// gives it (a mean over positives drawn per unit), so the two levels are
 /// commensurate at `λ = 1`. The cell bias cancels in the softmax and is not
 /// scored. A unit with no counts on the surviving features contributes zero.
+///
+/// The target `x̃` is DETACHED: this term trains `μ`, `b` and the cell side
+/// given the partition, and never the partition itself. Letting the gradient
+/// reach `π` through the target turns the term into a cross-entropy against a
+/// target it may reshape, and the cheapest reshaping is to put every expressed
+/// feature into one module — the target is then the same one-hot for every unit
+/// and the module bias fits it at zero loss. Measured on real marrow data: every
+/// marker gene at weight 1.0 in one module, with the identity pushed into the
+/// residual. The membership learns from the within-module NCE, which is
+/// discriminative and indifferent to a merge, and from the priors.
 pub fn module_softmax_loss(
     e_units: &Tensor,
     mu: &Tensor,
@@ -112,6 +122,7 @@ pub fn module_softmax_loss(
 ) -> Result<Tensor> {
     let s = e_units.matmul(&mu.t()?)?.broadcast_add(b_module)?; // [U, M]
     let log_q = log_softmax(&s, 1)?;
+    let x_cm = x_cm.detach();
     let total = x_cm.sum_keepdim(1)?; // [U, 1]
     let p = x_cm.broadcast_div(&total.clamp(EPS, f64::INFINITY)?)?;
     p.mul(&log_q)?.sum(1)?.neg()?.mean(0)

--- a/graph-embedding-util/src/loss/modules.rs
+++ b/graph-embedding-util/src/loss/modules.rs
@@ -14,16 +14,24 @@
 //! the counts are pooled — the module keeps its expected count through the
 //! survivors — so `μ` is fit under exactly the perturbation a later dataset with a
 //! different gene panel applies.
+//!
+//! [`module_step_loss`], [`module_priors`] and [`log_membership_diagnostics`] are
+//! the pieces every trainer with a module model shares (geu's composite trainer,
+//! `pinto cage`), so the objective is written once.
 
+use crate::model::FeatModules;
 use candle_util::candle_core::{Device, Result, Tensor};
 use candle_util::candle_nn::ops::log_softmax;
+use log::info;
 use rand::{Rng, RngExt};
-use rand_distr::weighted::WeightedIndex;
-use rand_distr::Distribution;
 use rayon::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Floor on a pooled or marginal mass before it divides or is logged.
 const EPS: f64 = 1e-6;
+
+/// A module with fewer argmax features than this is reported as small.
+pub const MODULE_SMALL_FLOOR: usize = 5;
 
 ///////////////////////////////////
 // Dropout and the pooled counts //
@@ -51,21 +59,16 @@ pub fn draw_gene_keep_mask(
 
 /// `π̃ = keep ⊙ π`, rescaled per MODULE so each column keeps the mass it had
 /// before the mask: a dropped feature contributes exactly zero, and the survivors
-/// of its modules are scaled up to stand in for it. The scale is detached — it is
-/// a normalizer, not a parameter — so the gradient into `π` is the plain masked
-/// one. A module with no survivor stays at zero.
+/// of its modules are scaled up to stand in for it. Detached throughout: the only
+/// consumer is the exact term's target, which never trains the membership. A
+/// module with no survivor stays at zero.
 pub fn masked_membership(pi: &Tensor, keep: &Tensor) -> Result<Tensor> {
+    let pi = pi.detach();
     let kept = pi.broadcast_mul(keep)?; // [D, M]
-    let full_mass = pi.sum_keepdim(0)?.detach(); // [1, M]
-    let kept_mass = kept.sum_keepdim(0)?.detach().clamp(EPS, f64::INFINITY)?;
+    let full_mass = pi.sum_keepdim(0)?; // [1, M]
+    let kept_mass = kept.sum_keepdim(0)?.clamp(EPS, f64::INFINITY)?;
     let scale = full_mass.div(&kept_mass)?;
     kept.broadcast_mul(&scale)
-}
-
-/// Module-pooled counts `x̃ = X · π̃`, `[U, M]`. One matmul; the exact term
-/// detaches it, so the membership sees no gradient from the pooled target.
-pub fn pool_module_counts(x_dense: &Tensor, pi_masked: &Tensor) -> Result<Tensor> {
-    x_dense.matmul(pi_masked)
 }
 
 /// Scatter sparse count rows into one dense `[U, D]` block on `dev`. Rows are
@@ -128,6 +131,23 @@ pub fn module_softmax_loss(
     p.mul(&log_q)?.sum(1)?.neg()?.mean(0)
 }
 
+/// One trainer step of the exact term: pool the units' dense count block
+/// `[U, D]` through the (dropout-masked, detached) membership `[D, M]`, score
+/// every module against the units' embeddings `[U, H]`, and weight by
+/// `lambda_module`. The one definition both geu's composite trainer and
+/// `pinto cage` call.
+pub fn module_step_loss(
+    modules: &FeatModules,
+    pi_masked: &Tensor,
+    x_dense: &Tensor,
+    e_units: &Tensor,
+    lambda_module: f32,
+) -> Result<Tensor> {
+    let x_cm = x_dense.matmul(pi_masked)?; // [U, M]
+    module_softmax_loss(e_units, &modules.mu, &modules.b_module, &x_cm)?
+        .affine(f64::from(lambda_module), 0.0)
+}
+
 ////////////
 // Priors //
 ////////////
@@ -144,10 +164,19 @@ pub fn module_balance_prior(pi: &Tensor) -> Result<Tensor> {
     occ.mul(&occ_safe.affine(m, 0.0)?.log()?)?.sum_all()
 }
 
-/// Mean row entropy `mean_g −Σ_m π_gm log π_gm`. Exact zeros contribute nothing.
-pub fn module_row_entropy(pi: &Tensor) -> Result<Tensor> {
-    let safe = pi.clamp(EPS, f64::INFINITY)?;
-    pi.mul(&safe.log()?)?.sum(1)?.neg()?.mean(0)
+/// The membership priors for one optimizer step, or `None` while the membership
+/// is frozen (it is detached then, and they would be constants).
+pub fn module_priors(
+    modules: &FeatModules,
+    pi: &Tensor,
+    lambda_balance: f32,
+) -> Result<Option<Tensor>> {
+    if modules.is_frozen() || lambda_balance <= 0.0 {
+        return Ok(None);
+    }
+    Ok(Some(
+        module_balance_prior(pi)?.affine(f64::from(lambda_balance), 0.0)?,
+    ))
 }
 
 /////////////////////////////////
@@ -159,29 +188,43 @@ pub fn module_row_entropy(pi: &Tensor) -> Result<Tensor> {
 /// epoch, the same granularity as the gate mask). One per sampler, because each
 /// sampler has its own expressed-feature pool.
 pub struct ModulePools {
-    /// Per feature: the nonzero `(module, weight)` entries of its membership row.
-    /// Shared by every sampler's pools; only `members` differs.
+    /// Per feature: the `(module, cumulative weight)` entries of its membership
+    /// row ABOVE the uniform level `1/M`, so a draw is one uniform number and a
+    /// scan. Shared by every sampler's pools; only `members` differs.
     rows: std::sync::Arc<Vec<Vec<(u32, f32)>>>,
-    /// Per module: the features with nonzero membership in it, restricted to this
-    /// sampler's feature pool.
+    /// Per module: the features with above-uniform membership in it, restricted
+    /// to this sampler's feature pool.
     members: Vec<Vec<u32>>,
+    /// Positives whose module was too small in this pool to contrast within, so
+    /// the caller drew globally. Read and reset by the diagnostics.
+    fallbacks: AtomicUsize,
 }
 
-/// The per-feature membership rows, built once per refresh and shared across the
-/// samplers' pools.
+/// The per-feature membership rows for the pools, built once per refresh and
+/// shared across the samplers' pools.
+///
+/// Only entries ABOVE the uniform level `1/M` count as membership here. The
+/// warm start deliberately keeps every module in every row's sparsemax support
+/// at a sliver of mass, so taking every nonzero would put every feature in every
+/// module: a "within-module" draw that is the global draw at `M ×` the memory.
 pub fn membership_rows_host(
     pi_host: &[f32],
     n_features: usize,
     n_modules: usize,
 ) -> std::sync::Arc<Vec<Vec<(u32, f32)>>> {
     assert_eq!(pi_host.len(), n_features * n_modules, "membership shape");
+    let floor = 1.0 / n_modules as f32;
     let rows: Vec<Vec<(u32, f32)>> = pi_host
         .par_chunks(n_modules)
         .map(|row| {
+            let mut cum = 0f32;
             row.iter()
                 .enumerate()
-                .filter(|(_, &w)| w > 0.0)
-                .map(|(m, &w)| (m as u32, w))
+                .filter(|(_, &w)| w > floor)
+                .map(|(m, &w)| {
+                    cum += w;
+                    (m as u32, cum)
+                })
                 .collect()
         })
         .collect();
@@ -202,20 +245,19 @@ impl ModulePools {
                 members[m as usize].push(f);
             }
         }
-        Self { rows, members }
-    }
-
-    /// Per-module member counts, for the diagnostics.
-    #[must_use]
-    pub fn member_counts(&self) -> Vec<usize> {
-        self.members.iter().map(Vec::len).collect()
+        Self {
+            rows,
+            members,
+            fallbacks: AtomicUsize::new(0),
+        }
     }
 
     /// Push `k` negatives for the positive `feat`: pick one of its modules with
     /// probability ∝ its membership weight, then draw uniformly from that module's
-    /// members. Returns `false` — pushing nothing — when the chosen module has
-    /// fewer than two members in this pool (a lone feature has nothing to contrast
-    /// with), so the caller falls back to the global draw.
+    /// members. Returns `false` — pushing nothing, and counting the fallback —
+    /// when the feature has no above-uniform module or the chosen module has
+    /// fewer than two members in this pool (a lone feature has nothing to
+    /// contrast with), so the caller falls back to the global draw.
     pub fn draw_negatives(
         &self,
         feat: u32,
@@ -224,26 +266,32 @@ impl ModulePools {
         rng: &mut impl Rng,
     ) -> bool {
         let row = &self.rows[feat as usize];
-        if row.is_empty() {
+        let Some(&(_, total)) = row.last() else {
+            self.fallbacks.fetch_add(1, Ordering::Relaxed);
             return false;
-        }
+        };
         let m = if row.len() == 1 {
             row[0].0
         } else {
-            let w: Vec<f32> = row.iter().map(|&(_, w)| w).collect();
-            let Ok(pick) = WeightedIndex::new(w) else {
-                return false;
-            };
-            row[pick.sample(rng)].0
+            let r = rng.random::<f32>() * total;
+            row.iter()
+                .find(|&&(_, cum)| r < cum)
+                .map_or(row[row.len() - 1].0, |&(m, _)| m)
         };
         let pool = &self.members[m as usize];
         if pool.len() < 2 {
+            self.fallbacks.fetch_add(1, Ordering::Relaxed);
             return false;
         }
         for _ in 0..k {
             out.push(pool[rng.random_range(0..pool.len())]);
         }
         true
+    }
+
+    /// Fallbacks since the last call, and reset.
+    pub fn take_fallbacks(&self) -> usize {
+        self.fallbacks.swap(0, Ordering::Relaxed)
     }
 }
 
@@ -296,6 +344,54 @@ pub fn membership_diagnostics(
         mean_row_entropy: (ent / d) as f32,
         mean_row_support: (support as f64 / d) as f32,
     }
+}
+
+/// One `info` line per epoch on the membership: occupancy, small modules, row
+/// entropy and support, the residual's share of the row norm, and how many
+/// positives fell back to global negatives. Collapse shows up here long before it
+/// shows up in the loss. `pi_host` is the current `[D × M]` membership.
+pub fn log_membership_diagnostics(
+    modules: &FeatModules,
+    pi_host: &[f32],
+    epoch: usize,
+    epochs: usize,
+    fallbacks: usize,
+) -> Result<()> {
+    let m = modules.n_modules;
+    let n_features = modules.logits.dim(0)?;
+    let dg = membership_diagnostics(pi_host, n_features, m, MODULE_SMALL_FLOOR);
+    let r2: f32 = modules
+        .residual
+        .detach()
+        .sqr()?
+        .sum(1)?
+        .mean_all()?
+        .to_scalar()?;
+    let rho2: f32 = modules
+        .compose()?
+        .detach()
+        .sqr()?
+        .sum(1)?
+        .mean_all()?
+        .to_scalar()?;
+    info!(
+        "epoch {}/{} modules{}: max occupancy {:.2}x uniform, {} of {} modules below {} \
+         features, row entropy {:.3} nats, {:.2} modules/feature, mean ‖r‖² {:.3} vs \
+         ‖ρ‖² {:.3}, {} positives fell back to global negatives",
+        epoch + 1,
+        epochs,
+        if modules.is_frozen() { " (frozen)" } else { "" },
+        dg.max_occupancy_ratio,
+        dg.n_small_modules,
+        m,
+        MODULE_SMALL_FLOOR,
+        dg.mean_row_entropy,
+        dg.mean_row_support,
+        r2,
+        rho2,
+        fallbacks,
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/graph-embedding-util/src/loss/modules.rs
+++ b/graph-embedding-util/src/loss/modules.rs
@@ -1,0 +1,291 @@
+//! The module-level terms of the composite objective, for a model whose feature
+//! side is [`crate::model::FeatModules`].
+//!
+//! Two levels. The EXACT term ([`module_softmax_loss`]) scores every module
+//! against a unit's module-pooled counts with a full softmax over `M` — no
+//! sampling, so every module receives gradient on every step, which is what
+//! lets a feature that is never drawn inherit a trained row. The within-module
+//! NCE reuses the ordinary sampled-softmax with negatives drawn from the
+//! positive's own module ([`ModulePools`]); with one module per feature `μ`
+//! cancels there and it trains only the residual, the feature bias and the cell
+//! side. Together: `log p(g|c) = log p(m|c) + log p(g|m,c)`.
+//!
+//! Gene dropout ([`masked_membership`]) hides a random subset of features when
+//! the counts are pooled — the module keeps its expected count through the
+//! survivors — so `μ` is fit under exactly the perturbation a later dataset with a
+//! different gene panel applies.
+
+use candle_util::candle_core::{Device, Result, Tensor};
+use candle_util::candle_nn::ops::log_softmax;
+use rand::{Rng, RngExt};
+use rand_distr::weighted::WeightedIndex;
+use rand_distr::Distribution;
+use rayon::prelude::*;
+
+/// Floor on a pooled or marginal mass before it divides or is logged.
+const EPS: f64 = 1e-6;
+
+///////////////////////////////////
+// Dropout and the pooled counts //
+///////////////////////////////////
+
+/// A `[D, 1]` survivor mask with each feature kept with probability `1 − p_drop`,
+/// drawn from the caller's RNG so it only touches the stream when modules are on.
+pub fn draw_gene_keep_mask(
+    n_features: usize,
+    p_drop: f32,
+    rng: &mut impl Rng,
+    dev: &Device,
+) -> Result<Tensor> {
+    let keep: Vec<f32> = (0..n_features)
+        .map(|_| {
+            if rng.random::<f32>() < p_drop {
+                0.0
+            } else {
+                1.0
+            }
+        })
+        .collect();
+    Tensor::from_vec(keep, (n_features, 1), dev)
+}
+
+/// `π̃ = keep ⊙ π`, rescaled per MODULE so each column keeps the mass it had
+/// before the mask: a dropped feature contributes exactly zero, and the survivors
+/// of its modules are scaled up to stand in for it. The scale is detached — it is
+/// a normalizer, not a parameter — so the gradient into `π` is the plain masked
+/// one. A module with no survivor stays at zero.
+pub fn masked_membership(pi: &Tensor, keep: &Tensor) -> Result<Tensor> {
+    let kept = pi.broadcast_mul(keep)?; // [D, M]
+    let full_mass = pi.sum_keepdim(0)?.detach(); // [1, M]
+    let kept_mass = kept.sum_keepdim(0)?.detach().clamp(EPS, f64::INFINITY)?;
+    let scale = full_mass.div(&kept_mass)?;
+    kept.broadcast_mul(&scale)
+}
+
+/// Module-pooled counts `x̃ = X · π̃`, `[U, M]`. One matmul, with autograd into
+/// the membership.
+pub fn pool_module_counts(x_dense: &Tensor, pi_masked: &Tensor) -> Result<Tensor> {
+    x_dense.matmul(pi_masked)
+}
+
+/// Scatter sparse count rows into one dense `[U, D]` block on `dev`. Rows are
+/// `(features, counts)` slices aligned per unit; filled with rayon, one unit per
+/// task.
+pub fn dense_count_block(
+    rows: &[(&[u32], &[f32])],
+    n_features: usize,
+    dev: &Device,
+) -> Result<Tensor> {
+    let u = rows.len();
+    let mut flat = vec![0f32; u * n_features];
+    flat.par_chunks_mut(n_features)
+        .zip(rows.par_iter())
+        .for_each(|(dst, (feats, counts))| {
+            for (&f, &c) in feats.iter().zip(counts.iter()) {
+                dst[f as usize] += c;
+            }
+        });
+    Tensor::from_vec(flat, (u, n_features), dev)
+}
+
+////////////////////
+// The exact term //
+////////////////////
+
+/// The exact cell–module term for one block of units:
+///
+/// ```text
+///   s_um   = e_u · μ_m + b_m
+///   ℓ_u    = − Σ_m ( x̃_um / Σ_m' x̃_um' ) · log_softmax_m(s_u)_m
+///   L      = mean_u ℓ_u
+/// ```
+///
+/// Per-unit normalization makes each unit one unit of weight, the same as the NCE
+/// gives it (a mean over positives drawn per unit), so the two levels are
+/// commensurate at `λ = 1`. The cell bias cancels in the softmax and is not
+/// scored. A unit with no counts on the surviving features contributes zero.
+pub fn module_softmax_loss(
+    e_units: &Tensor,
+    mu: &Tensor,
+    b_module: &Tensor,
+    x_cm: &Tensor,
+) -> Result<Tensor> {
+    let s = e_units.matmul(&mu.t()?)?.broadcast_add(b_module)?; // [U, M]
+    let log_q = log_softmax(&s, 1)?;
+    let total = x_cm.sum_keepdim(1)?; // [U, 1]
+    let p = x_cm.broadcast_div(&total.clamp(EPS, f64::INFINITY)?)?;
+    p.mul(&log_q)?.sum(1)?.neg()?.mean(0)
+}
+
+////////////
+// Priors //
+////////////
+
+/// Load-balance prior `KL(π̄ ‖ Uniform_M) = Σ_m π̄_m log(M π̄_m)` on the feature-
+/// marginal occupancy `π̄_m = mean_g π_gm`. Zero when every module carries the same
+/// share of the features; largest when one module holds them all — which is the
+/// direction the exact term rewards on its own. A uniform target, not a decaying
+/// ladder: for modules a decaying prior is precisely the collapse direction.
+pub fn module_balance_prior(pi: &Tensor) -> Result<Tensor> {
+    let m = pi.dim(1)? as f64;
+    let occ = pi.mean(0)?; // [M]
+    let occ_safe = occ.clamp(EPS, f64::INFINITY)?;
+    occ.mul(&occ_safe.affine(m, 0.0)?.log()?)?.sum_all()
+}
+
+/// Mean row entropy `mean_g −Σ_m π_gm log π_gm`. Exact zeros contribute nothing.
+pub fn module_row_entropy(pi: &Tensor) -> Result<Tensor> {
+    let safe = pi.clamp(EPS, f64::INFINITY)?;
+    pi.mul(&safe.log()?)?.sum(1)?.neg()?.mean(0)
+}
+
+/////////////////////////////////
+// Within-module negative pools //
+/////////////////////////////////
+
+/// Host-side view of the membership for the within-module negative draw, rebuilt
+/// once per epoch from the current `π` (the pools lag the membership by at most an
+/// epoch, the same granularity as the gate mask). One per sampler, because each
+/// sampler has its own expressed-feature pool.
+pub struct ModulePools {
+    /// Per feature: the nonzero `(module, weight)` entries of its membership row.
+    /// Shared by every sampler's pools; only `members` differs.
+    rows: std::sync::Arc<Vec<Vec<(u32, f32)>>>,
+    /// Per module: the features with nonzero membership in it, restricted to this
+    /// sampler's feature pool.
+    members: Vec<Vec<u32>>,
+}
+
+/// The per-feature membership rows, built once per refresh and shared across the
+/// samplers' pools.
+pub fn membership_rows_host(
+    pi_host: &[f32],
+    n_features: usize,
+    n_modules: usize,
+) -> std::sync::Arc<Vec<Vec<(u32, f32)>>> {
+    assert_eq!(pi_host.len(), n_features * n_modules, "membership shape");
+    let rows: Vec<Vec<(u32, f32)>> = pi_host
+        .par_chunks(n_modules)
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .filter(|(_, &w)| w > 0.0)
+                .map(|(m, &w)| (m as u32, w))
+                .collect()
+        })
+        .collect();
+    std::sync::Arc::new(rows)
+}
+
+impl ModulePools {
+    /// Build one sampler's pools from the shared rows and its feature pool.
+    #[must_use]
+    pub fn build(
+        rows: std::sync::Arc<Vec<Vec<(u32, f32)>>>,
+        n_modules: usize,
+        feature_pool: &[u32],
+    ) -> Self {
+        let mut members: Vec<Vec<u32>> = vec![Vec::new(); n_modules];
+        for &f in feature_pool {
+            for &(m, _) in &rows[f as usize] {
+                members[m as usize].push(f);
+            }
+        }
+        Self { rows, members }
+    }
+
+    /// Per-module member counts, for the diagnostics.
+    #[must_use]
+    pub fn member_counts(&self) -> Vec<usize> {
+        self.members.iter().map(Vec::len).collect()
+    }
+
+    /// Push `k` negatives for the positive `feat`: pick one of its modules with
+    /// probability ∝ its membership weight, then draw uniformly from that module's
+    /// members. Returns `false` — pushing nothing — when the chosen module has
+    /// fewer than two members in this pool (a lone feature has nothing to contrast
+    /// with), so the caller falls back to the global draw.
+    pub fn draw_negatives(
+        &self,
+        feat: u32,
+        k: usize,
+        out: &mut Vec<u32>,
+        rng: &mut impl Rng,
+    ) -> bool {
+        let row = &self.rows[feat as usize];
+        if row.is_empty() {
+            return false;
+        }
+        let m = if row.len() == 1 {
+            row[0].0
+        } else {
+            let w: Vec<f32> = row.iter().map(|&(_, w)| w).collect();
+            let Ok(pick) = WeightedIndex::new(w) else {
+                return false;
+            };
+            row[pick.sample(rng)].0
+        };
+        let pool = &self.members[m as usize];
+        if pool.len() < 2 {
+            return false;
+        }
+        for _ in 0..k {
+            out.push(pool[rng.random_range(0..pool.len())]);
+        }
+        true
+    }
+}
+
+/////////////////
+// Diagnostics //
+/////////////////
+
+/// Per-epoch membership summary, from the host copy of `π`.
+pub struct MembershipDiagnostics {
+    /// `max_m π̄_m / (1/M)`: 1 is balanced, `M` is total collapse.
+    pub max_occupancy_ratio: f32,
+    /// Modules whose argmax count is below `small_floor`.
+    pub n_small_modules: usize,
+    /// `mean_g H(π_g)` in nats.
+    pub mean_row_entropy: f32,
+    /// Mean number of modules a feature sits on with nonzero weight.
+    pub mean_row_support: f32,
+}
+
+#[must_use]
+pub fn membership_diagnostics(
+    pi_host: &[f32],
+    n_features: usize,
+    n_modules: usize,
+    small_floor: usize,
+) -> MembershipDiagnostics {
+    let mut occ = vec![0f64; n_modules];
+    let mut argmax_count = vec![0usize; n_modules];
+    let mut ent = 0f64;
+    let mut support = 0usize;
+    for row in pi_host.chunks(n_modules) {
+        let mut best = 0usize;
+        for (m, &w) in row.iter().enumerate() {
+            occ[m] += f64::from(w);
+            if w > 0.0 {
+                support += 1;
+                ent -= f64::from(w) * f64::from(w).ln();
+            }
+            if w > row[best] {
+                best = m;
+            }
+        }
+        argmax_count[best] += 1;
+    }
+    let d = n_features.max(1) as f64;
+    let max_occ = occ.iter().copied().fold(0f64, f64::max) / d;
+    MembershipDiagnostics {
+        max_occupancy_ratio: (max_occ * n_modules as f64) as f32,
+        n_small_modules: argmax_count.iter().filter(|&&c| c < small_floor).count(),
+        mean_row_entropy: (ent / d) as f32,
+        mean_row_support: (support as f64 / d) as f32,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/loss/modules/tests.rs
+++ b/graph-embedding-util/src/loss/modules/tests.rs
@@ -59,13 +59,15 @@ fn pooled_counts_ignore_dropped_features() {
     let c2: Vec<f32> = vec![2.0, 999.0, 1.0]; // dropped feature 1 perturbed
     let x1 = dense_count_block(&[(&f, &c1)], 6, &dev()).unwrap();
     let x2 = dense_count_block(&[(&f, &c2)], 6, &dev()).unwrap();
-    let a: Vec<f32> = pool_module_counts(&x1, &tilde)
+    let a: Vec<f32> = x1
+        .matmul(&tilde)
         .unwrap()
         .flatten_all()
         .unwrap()
         .to_vec1()
         .unwrap();
-    let b: Vec<f32> = pool_module_counts(&x2, &tilde)
+    let b: Vec<f32> = x2
+        .matmul(&tilde)
         .unwrap()
         .flatten_all()
         .unwrap()
@@ -121,14 +123,14 @@ fn module_softmax_gradient_matches_finite_difference() {
 
     let loss_fn = |logits: &Tensor, mu: &Tensor, b: &Tensor, e: &Tensor| -> f32 {
         let pi = sparsemax(logits).unwrap();
-        let xcm = pool_module_counts(&x, &pi).unwrap();
+        let xcm = x.matmul(&pi).unwrap();
         module_softmax_loss(e, mu, b, &xcm)
             .unwrap()
             .to_scalar::<f32>()
             .unwrap()
     };
     let pi = sparsemax(logits.as_tensor()).unwrap();
-    let xcm = pool_module_counts(&x, &pi).unwrap();
+    let xcm = x.matmul(&pi).unwrap();
     let loss = module_softmax_loss(e.as_tensor(), mu.as_tensor(), b.as_tensor(), &xcm).unwrap();
     let grads = loss.backward().unwrap();
 
@@ -209,16 +211,22 @@ fn pools_follow_membership_and_stay_inside_the_feature_pool() {
     let host: Vec<f32> = pi.flatten_all().unwrap().to_vec1().unwrap();
     let rows = membership_rows_host(&host, 6, 2);
     // Feature 5 is excluded from this sampler's pool.
+    // Above the uniform level 1/2: m0 = {0, 1, 3(0.5? no: 0.5 is not > 0.5)} — rows
+    // (1,0) (0.7,0.3) (0,1) (0.5,0.5) (0.2,0.8): m0 members 0,1; m1 members 2,4.
     let pool = ModulePools::build(rows, 2, &[0, 1, 2, 3, 4]);
-    assert_eq!(pool.member_counts(), vec![4, 4]); // m0: 0,1,3,4  m1: 1,2,3,4
     let mut rng = StdRng::seed_from_u64(1);
     let mut out = Vec::new();
-    // Feature 0 is only in module 0: negatives come from {0,1,3,4}.
+    // Feature 0 is only in module 0: negatives come from {0, 1}.
     for _ in 0..50 {
         assert!(pool.draw_negatives(0, 3, &mut out, &mut rng));
     }
     assert_eq!(out.len(), 150);
-    assert!(out.iter().all(|f| [0u32, 1, 3, 4].contains(f)), "{out:?}");
+    assert!(out.iter().all(|f| [0u32, 1].contains(f)), "{out:?}");
+    // Feature 3 sits exactly at the uniform level on both modules: no module
+    // above it, so it falls back and the fallback is counted.
+    assert!(!pool.draw_negatives(3, 2, &mut out, &mut rng));
+    assert_eq!(pool.take_fallbacks(), 1);
+    assert_eq!(pool.take_fallbacks(), 0);
 }
 
 #[test]
@@ -231,6 +239,7 @@ fn singleton_module_falls_back() {
     // Module 0 has one member: nothing to contrast with.
     assert!(!pool.draw_negatives(0, 2, &mut out, &mut rng));
     assert!(out.is_empty());
+    assert_eq!(pool.take_fallbacks(), 1);
     assert!(pool.draw_negatives(1, 2, &mut out, &mut rng));
     assert_eq!(out.len(), 2);
 }
@@ -306,7 +315,7 @@ fn entropy_stays_above_floor_on_random_counts() {
     .unwrap();
     for _ in 0..200 {
         let pi = sparsemax(logits.as_tensor()).unwrap();
-        let xcm = pool_module_counts(&x, &pi).unwrap();
+        let xcm = x.matmul(&pi).unwrap();
         let l = module_softmax_loss(e.as_tensor(), mu.as_tensor(), b.as_tensor(), &xcm).unwrap();
         let prior = module_balance_prior(&pi).unwrap();
         let loss = (l + prior).unwrap();

--- a/graph-embedding-util/src/loss/modules/tests.rs
+++ b/graph-embedding-util/src/loss/modules/tests.rs
@@ -93,7 +93,8 @@ fn dense_block_scatters_rows() {
     assert_eq!(v, vec![vec![1.0, 0.0, 3.0], vec![0.0, 7.0, 0.0]]);
 }
 
-/// Central finite differences on every parameter of the exact term.
+/// Central finite differences on every parameter the exact term trains; the
+/// membership logits must receive NO gradient from it (the target is detached).
 #[test]
 fn module_softmax_gradient_matches_finite_difference() {
     let d = dev();
@@ -150,10 +151,6 @@ fn module_softmax_gradient_matches_finite_difference() {
             let tu = Tensor::from_vec(up, shape.clone(), &d).unwrap();
             let td = Tensor::from_vec(dn, shape.clone(), &d).unwrap();
             let (lu, ld) = match name {
-                "logits" => (
-                    loss_fn(&tu, mu.as_tensor(), b.as_tensor(), e.as_tensor()),
-                    loss_fn(&td, mu.as_tensor(), b.as_tensor(), e.as_tensor()),
-                ),
                 "mu" => (
                     loss_fn(logits.as_tensor(), &tu, b.as_tensor(), e.as_tensor()),
                     loss_fn(logits.as_tensor(), &td, b.as_tensor(), e.as_tensor()),
@@ -176,7 +173,10 @@ fn module_softmax_gradient_matches_finite_difference() {
             );
         }
     };
-    check(&logits, "logits");
+    assert!(
+        grads.get(logits.as_tensor()).is_none(),
+        "the exact term must not reach the membership logits"
+    );
     check(&mu, "mu");
     check(&b, "b");
     check(&e, "e");

--- a/graph-embedding-util/src/loss/modules/tests.rs
+++ b/graph-embedding-util/src/loss/modules/tests.rs
@@ -1,0 +1,324 @@
+use super::*;
+use candle_util::candle_core::{DType, Var};
+use candle_util::nn::sparsemax;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+fn dev() -> Device {
+    Device::Cpu
+}
+
+fn pi_fixture() -> Tensor {
+    // D = 6, M = 2; rows on the simplex with a few exact zeros.
+    let v = vec![
+        1.0f32, 0.0, //
+        0.7, 0.3, //
+        0.0, 1.0, //
+        0.5, 0.5, //
+        0.2, 0.8, //
+        1.0, 0.0,
+    ];
+    Tensor::from_vec(v, (6, 2), &dev()).unwrap()
+}
+
+#[test]
+fn masked_membership_zeroes_dropped_rows_and_keeps_module_mass() {
+    let pi = pi_fixture();
+    // Drop features 1 and 4.
+    let keep = Tensor::from_vec(vec![1f32, 0.0, 1.0, 1.0, 0.0, 1.0], (6, 1), &dev()).unwrap();
+    let tilde = masked_membership(&pi, &keep).unwrap();
+    let t: Vec<Vec<f32>> = tilde.to_vec2().unwrap();
+    assert_eq!(t[1], vec![0.0, 0.0]);
+    assert_eq!(t[4], vec![0.0, 0.0]);
+    let full: Vec<f32> = pi.sum(0).unwrap().to_vec1().unwrap();
+    let masked: Vec<f32> = tilde.sum(0).unwrap().to_vec1().unwrap();
+    for (a, b) in full.iter().zip(&masked) {
+        assert!((a - b).abs() < 1e-5, "module mass {a} vs {b}");
+    }
+}
+
+#[test]
+fn no_dropout_is_the_identity() {
+    let pi = pi_fixture();
+    let keep = Tensor::ones((6, 1), DType::F32, &dev()).unwrap();
+    let tilde = masked_membership(&pi, &keep).unwrap();
+    let a: Vec<f32> = pi.flatten_all().unwrap().to_vec1().unwrap();
+    let b: Vec<f32> = tilde.flatten_all().unwrap().to_vec1().unwrap();
+    for (x, y) in a.iter().zip(&b) {
+        assert!((x - y).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn pooled_counts_ignore_dropped_features() {
+    let pi = pi_fixture();
+    let keep = Tensor::from_vec(vec![1f32, 0.0, 1.0, 1.0, 1.0, 1.0], (6, 1), &dev()).unwrap();
+    let tilde = masked_membership(&pi, &keep).unwrap();
+    let f: Vec<u32> = vec![0, 1, 3];
+    let c1: Vec<f32> = vec![2.0, 5.0, 1.0];
+    let c2: Vec<f32> = vec![2.0, 999.0, 1.0]; // dropped feature 1 perturbed
+    let x1 = dense_count_block(&[(&f, &c1)], 6, &dev()).unwrap();
+    let x2 = dense_count_block(&[(&f, &c2)], 6, &dev()).unwrap();
+    let a: Vec<f32> = pool_module_counts(&x1, &tilde)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .to_vec1()
+        .unwrap();
+    let b: Vec<f32> = pool_module_counts(&x2, &tilde)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .to_vec1()
+        .unwrap();
+    assert_eq!(a, b);
+    // Hand sum over survivors with the per-module rescale: module 0 full mass 3.4,
+    // kept mass 2.7 → scale 3.4/2.7; module 1 full 2.6, kept 2.3.
+    let s0 = 3.4f32 / 2.7;
+    let s1 = 2.6f32 / 2.3;
+    let want0 = (2.0 * 1.0 + 1.0 * 0.5) * s0;
+    let want1 = (1.0 * 0.5) * s1;
+    assert!((a[0] - want0).abs() < 1e-4, "{} vs {want0}", a[0]);
+    assert!((a[1] - want1).abs() < 1e-4, "{} vs {want1}", a[1]);
+}
+
+#[test]
+fn dense_block_scatters_rows() {
+    let f0: Vec<u32> = vec![0, 2];
+    let c0: Vec<f32> = vec![1.0, 3.0];
+    let f1: Vec<u32> = vec![1];
+    let c1: Vec<f32> = vec![7.0];
+    let x = dense_count_block(&[(&f0, &c0), (&f1, &c1)], 3, &dev()).unwrap();
+    let v: Vec<Vec<f32>> = x.to_vec2().unwrap();
+    assert_eq!(v, vec![vec![1.0, 0.0, 3.0], vec![0.0, 7.0, 0.0]]);
+}
+
+/// Central finite differences on every parameter of the exact term.
+#[test]
+fn module_softmax_gradient_matches_finite_difference() {
+    let d = dev();
+    let (u, m, h, nf) = (2usize, 3usize, 2usize, 4usize);
+    let logits = Var::from_tensor(
+        &Tensor::from_vec(
+            vec![
+                0.9f32, 0.1, 0.2, 0.3, 0.8, 0.1, 0.5, 0.5, 0.2, 0.1, 0.2, 0.9,
+            ],
+            (nf, m),
+            &d,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let mu = Var::from_tensor(
+        &Tensor::from_vec(vec![0.3f32, -0.2, 0.1, 0.4, -0.5, 0.2], (m, h), &d).unwrap(),
+    )
+    .unwrap();
+    let b = Var::from_tensor(&Tensor::from_vec(vec![0.1f32, -0.1, 0.0], m, &d).unwrap()).unwrap();
+    let e = Var::from_tensor(&Tensor::from_vec(vec![0.2f32, 0.7, -0.4, 0.3], (u, h), &d).unwrap())
+        .unwrap();
+    let x = Tensor::from_vec(vec![3f32, 0.0, 2.0, 1.0, 0.0, 4.0, 1.0, 0.0], (u, nf), &d).unwrap();
+
+    let loss_fn = |logits: &Tensor, mu: &Tensor, b: &Tensor, e: &Tensor| -> f32 {
+        let pi = sparsemax(logits).unwrap();
+        let xcm = pool_module_counts(&x, &pi).unwrap();
+        module_softmax_loss(e, mu, b, &xcm)
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap()
+    };
+    let pi = sparsemax(logits.as_tensor()).unwrap();
+    let xcm = pool_module_counts(&x, &pi).unwrap();
+    let loss = module_softmax_loss(e.as_tensor(), mu.as_tensor(), b.as_tensor(), &xcm).unwrap();
+    let grads = loss.backward().unwrap();
+
+    let check = |var: &Var, name: &str| {
+        let g: Vec<f32> = grads
+            .get(var.as_tensor())
+            .unwrap_or_else(|| panic!("no gradient reached {name}"))
+            .flatten_all()
+            .unwrap()
+            .to_vec1()
+            .unwrap();
+        let base: Vec<f32> = var.as_tensor().flatten_all().unwrap().to_vec1().unwrap();
+        let shape = var.as_tensor().shape().clone();
+        let eps = 1e-2f32;
+        for i in 0..base.len() {
+            let mut up = base.clone();
+            up[i] += eps;
+            let mut dn = base.clone();
+            dn[i] -= eps;
+            let tu = Tensor::from_vec(up, shape.clone(), &d).unwrap();
+            let td = Tensor::from_vec(dn, shape.clone(), &d).unwrap();
+            let (lu, ld) = match name {
+                "logits" => (
+                    loss_fn(&tu, mu.as_tensor(), b.as_tensor(), e.as_tensor()),
+                    loss_fn(&td, mu.as_tensor(), b.as_tensor(), e.as_tensor()),
+                ),
+                "mu" => (
+                    loss_fn(logits.as_tensor(), &tu, b.as_tensor(), e.as_tensor()),
+                    loss_fn(logits.as_tensor(), &td, b.as_tensor(), e.as_tensor()),
+                ),
+                "b" => (
+                    loss_fn(logits.as_tensor(), mu.as_tensor(), &tu, e.as_tensor()),
+                    loss_fn(logits.as_tensor(), mu.as_tensor(), &td, e.as_tensor()),
+                ),
+                _ => (
+                    loss_fn(logits.as_tensor(), mu.as_tensor(), b.as_tensor(), &tu),
+                    loss_fn(logits.as_tensor(), mu.as_tensor(), b.as_tensor(), &td),
+                ),
+            };
+            let fd = (lu - ld) / (2.0 * eps);
+            let tol = 2e-2 * (1.0 + fd.abs().max(g[i].abs()));
+            assert!(
+                (fd - g[i]).abs() < tol,
+                "{name}[{i}]: autograd {} vs finite-difference {fd}",
+                g[i]
+            );
+        }
+    };
+    check(&logits, "logits");
+    check(&mu, "mu");
+    check(&b, "b");
+    check(&e, "e");
+}
+
+#[test]
+fn balance_prior_is_zero_when_uniform_and_positive_when_collapsed() {
+    let uniform = Tensor::from_vec(vec![0.5f32; 8], (4, 2), &dev()).unwrap();
+    let z: f32 = module_balance_prior(&uniform).unwrap().to_scalar().unwrap();
+    assert!(z.abs() < 1e-5, "uniform occupancy should score 0, got {z}");
+    let collapsed = Tensor::from_vec(
+        vec![1f32, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+        (4, 2),
+        &dev(),
+    )
+    .unwrap();
+    let c: f32 = module_balance_prior(&collapsed)
+        .unwrap()
+        .to_scalar()
+        .unwrap();
+    assert!(
+        (c - 2f32.ln()).abs() < 1e-4,
+        "total collapse onto one of two modules is ln 2, got {c}"
+    );
+}
+
+#[test]
+fn pools_follow_membership_and_stay_inside_the_feature_pool() {
+    let pi = pi_fixture();
+    let host: Vec<f32> = pi.flatten_all().unwrap().to_vec1().unwrap();
+    let rows = membership_rows_host(&host, 6, 2);
+    // Feature 5 is excluded from this sampler's pool.
+    let pool = ModulePools::build(rows, 2, &[0, 1, 2, 3, 4]);
+    assert_eq!(pool.member_counts(), vec![4, 4]); // m0: 0,1,3,4  m1: 1,2,3,4
+    let mut rng = StdRng::seed_from_u64(1);
+    let mut out = Vec::new();
+    // Feature 0 is only in module 0: negatives come from {0,1,3,4}.
+    for _ in 0..50 {
+        assert!(pool.draw_negatives(0, 3, &mut out, &mut rng));
+    }
+    assert_eq!(out.len(), 150);
+    assert!(out.iter().all(|f| [0u32, 1, 3, 4].contains(f)), "{out:?}");
+}
+
+#[test]
+fn singleton_module_falls_back() {
+    let host = vec![1f32, 0.0, 0.0, 1.0, 0.0, 1.0];
+    let rows = membership_rows_host(&host, 3, 2);
+    let pool = ModulePools::build(rows, 2, &[0, 1, 2]);
+    let mut rng = StdRng::seed_from_u64(2);
+    let mut out = Vec::new();
+    // Module 0 has one member: nothing to contrast with.
+    assert!(!pool.draw_negatives(0, 2, &mut out, &mut rng));
+    assert!(out.is_empty());
+    assert!(pool.draw_negatives(1, 2, &mut out, &mut rng));
+    assert_eq!(out.len(), 2);
+}
+
+#[test]
+fn diagnostics_read_collapse() {
+    let host = vec![1f32, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+    let dg = membership_diagnostics(&host, 4, 2, 2);
+    assert!((dg.max_occupancy_ratio - 1.5).abs() < 1e-5);
+    assert_eq!(dg.n_small_modules, 1);
+    assert!(dg.mean_row_entropy.abs() < 1e-6);
+    assert!((dg.mean_row_support - 1.0).abs() < 1e-6);
+}
+
+/// The exact term alone plus the balance prior does not push a random start onto
+/// one module: after a few hundred AdamW steps the occupancy stays spread and rows
+/// keep some support.
+#[test]
+fn entropy_stays_above_floor_on_random_counts() {
+    use candle_util::candle_nn::{AdamW, Optimizer, ParamsAdamW};
+    let d = dev();
+    let (nf, m, h, u) = (40usize, 4usize, 3usize, 8usize);
+    let mut rng = StdRng::seed_from_u64(7);
+    let logits = Var::from_tensor(
+        &Tensor::from_vec(
+            (0..nf * m)
+                .map(|_| rng.random::<f32>() * 0.5)
+                .collect::<Vec<f32>>(),
+            (nf, m),
+            &d,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let mu = Var::from_tensor(
+        &Tensor::from_vec(
+            (0..m * h)
+                .map(|_| rng.random::<f32>() - 0.5)
+                .collect::<Vec<f32>>(),
+            (m, h),
+            &d,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let b = Var::zeros(m, DType::F32, &d).unwrap();
+    let e = Var::from_tensor(
+        &Tensor::from_vec(
+            (0..u * h)
+                .map(|_| rng.random::<f32>() - 0.5)
+                .collect::<Vec<f32>>(),
+            (u, h),
+            &d,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let x = Tensor::from_vec(
+        (0..u * nf)
+            .map(|_| (rng.random::<f32>() * 5.0).floor())
+            .collect::<Vec<f32>>(),
+        (u, nf),
+        &d,
+    )
+    .unwrap();
+    let mut opt = AdamW::new(
+        vec![logits.clone(), mu.clone(), b.clone(), e.clone()],
+        ParamsAdamW {
+            lr: 0.05,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    for _ in 0..200 {
+        let pi = sparsemax(logits.as_tensor()).unwrap();
+        let xcm = pool_module_counts(&x, &pi).unwrap();
+        let l = module_softmax_loss(e.as_tensor(), mu.as_tensor(), b.as_tensor(), &xcm).unwrap();
+        let prior = module_balance_prior(&pi).unwrap();
+        let loss = (l + prior).unwrap();
+        opt.backward_step(&loss).unwrap();
+    }
+    let pi = sparsemax(logits.as_tensor()).unwrap();
+    let host: Vec<f32> = pi.flatten_all().unwrap().to_vec1().unwrap();
+    let dg = membership_diagnostics(&host, nf, m, 1);
+    assert!(
+        dg.max_occupancy_ratio < 0.9 * m as f32,
+        "occupancy collapsed: ratio {}",
+        dg.max_occupancy_ratio
+    );
+    assert!(dg.n_small_modules < m, "every module emptied but one");
+}

--- a/graph-embedding-util/src/model/gate.rs
+++ b/graph-embedding-util/src/model/gate.rs
@@ -335,7 +335,16 @@ impl JointEmbedModel {
     pub fn materialize_e_feat(&mut self) -> Result<()> {
         // Compute the frozen dictionary first (borrows self immutably), then assign.
         // Uses effect MEANS (no reparam sampling) and bakes the gate(s) in.
-        let gated = if let Some(a) = &self.adapter {
+        let gated = if let Some(m) = &self.modules {
+            // Modules: recompose `π μ + r` from the live tables (idempotent), then bake
+            // whatever multiplies a free model's loading — same policy as the adapter.
+            let mu = m.compose()?;
+            let w = self.free_feature_multiplier()?;
+            Some(
+                self.gated_rows(&mu, self.e_feat_logstd.as_ref(), w.as_ref(), false)?
+                    .detach(),
+            )
+        } else if let Some(a) = &self.adapter {
             // Adapter: recompose from the fixed dictionary and the live map
             // (idempotent by construction), then bake whatever multiplies a
             // free model's loading — same policy as the free branch below.
@@ -900,7 +909,12 @@ impl JointEmbedModel {
         // taken at construction; the KL's mu^2 shrinkage must see the LIVE
         // composition or it prices alpha against loadings that no longer
         // exist and back-propagates nothing into the adapter parameters.
-        let adapter_mu = self.adapter.as_ref().map(|a| a.compose()).transpose()?;
+        // The module model has the same detached-snapshot contract as the adapter.
+        let adapter_mu = match (&self.adapter, &self.modules) {
+            (Some(a), _) => Some(a.compose()?),
+            (None, Some(m)) => Some(m.compose()?),
+            (None, None) => None,
+        };
         let mu = match (&adapter_mu, &self.factor) {
             (Some(m), _) => m,
             (None, Some(f)) => &f.beta,

--- a/graph-embedding-util/src/model/gate.rs
+++ b/graph-embedding-util/src/model/gate.rs
@@ -335,20 +335,11 @@ impl JointEmbedModel {
     pub fn materialize_e_feat(&mut self) -> Result<()> {
         // Compute the frozen dictionary first (borrows self immutably), then assign.
         // Uses effect MEANS (no reparam sampling) and bakes the gate(s) in.
-        let gated = if let Some(m) = &self.modules {
-            // Modules: recompose `π μ + r` from the live tables (idempotent), then bake
-            // whatever multiplies a free model's loading — same policy as the adapter.
-            let mu = m.compose()?;
-            let w = self.free_feature_multiplier()?;
-            Some(
-                self.gated_rows(&mu, self.e_feat_logstd.as_ref(), w.as_ref(), false)?
-                    .detach(),
-            )
-        } else if let Some(a) = &self.adapter {
-            // Adapter: recompose from the fixed dictionary and the live map
-            // (idempotent by construction), then bake whatever multiplies a
-            // free model's loading — same policy as the free branch below.
-            let mu = a.compose()?;
+        let gated = if let Some(c) = self.composed() {
+            // Composed (adapter / modules): recompose from the live parameters
+            // (idempotent by construction), then bake whatever multiplies a free
+            // model's loading — same policy as the free branch below.
+            let mu = c.compose()?;
             let w = self.free_feature_multiplier()?;
             Some(
                 self.gated_rows(&mu, self.e_feat_logstd.as_ref(), w.as_ref(), false)?
@@ -905,17 +896,12 @@ impl JointEmbedModel {
         if self.gate.is_none() {
             return Ok(None);
         }
-        // The adapted model's `e_feat`/`e_feat_raw` are detached snapshots
-        // taken at construction; the KL's mu^2 shrinkage must see the LIVE
-        // composition or it prices alpha against loadings that no longer
-        // exist and back-propagates nothing into the adapter parameters.
-        // The module model has the same detached-snapshot contract as the adapter.
-        let adapter_mu = match (&self.adapter, &self.modules) {
-            (Some(a), _) => Some(a.compose()?),
-            (None, Some(m)) => Some(m.compose()?),
-            (None, None) => None,
-        };
-        let mu = match (&adapter_mu, &self.factor) {
+        // A composed model's `e_feat`/`e_feat_raw` are detached snapshots taken
+        // at construction; the KL's mu^2 shrinkage must see the LIVE composition
+        // or it prices alpha against loadings that no longer exist and
+        // back-propagates nothing into the live parameters.
+        let composed_mu = self.composed().map(|c| c.compose()).transpose()?;
+        let mu = match (&composed_mu, &self.factor) {
             (Some(m), _) => m,
             (None, Some(f)) => &f.beta,
             (None, None) => self.e_feat_raw.as_ref().unwrap_or(&self.e_feat),

--- a/graph-embedding-util/src/model/mod.rs
+++ b/graph-embedding-util/src/model/mod.rs
@@ -29,7 +29,7 @@ pub use gate::{
     GATE_KL_WEIGHT,
 };
 pub use modules::{
-    module_logit_for_own_mass, FeatModules, ModuleInit, MODULE_BIAS_VAR_NAME,
+    module_logit_for_own_mass, FeatModules, ModuleInit, ModuleWarmStart, MODULE_BIAS_VAR_NAME,
     MODULE_LOGITS_VAR_NAME, MODULE_MU_VAR_NAME, MODULE_RESIDUAL_VAR_NAME,
 };
 use vars::{
@@ -249,14 +249,45 @@ pub struct FeatAdapter {
     pub residual: Option<Tensor>,
 }
 
-impl FeatAdapter {
+/// A feature side whose `e_feat` is a detached COMPOSED snapshot of live
+/// parameters — the adapter (`ρ·W + r`) and the module layer (`π μ + r`). The
+/// gather, the materialize, the gate KL and the ridge all treat these two the
+/// same way, so they dispatch on this trait rather than on each field.
+pub trait ComposedFeat {
     /// The full composed table `[n_features, H]`, on the live parameters.
-    pub fn compose(&self) -> Result<Tensor> {
+    fn compose(&self) -> Result<Tensor>;
+    /// Composed rows for `idx`, `[b, H]`, on the live parameters.
+    fn compose_rows(&self, idx: &Tensor) -> Result<Tensor>;
+    /// The per-row table that can overfit row by row and takes the ridge, if any.
+    fn ridge_table(&self) -> Option<&Tensor>;
+}
+
+impl ComposedFeat for FeatAdapter {
+    fn compose(&self) -> Result<Tensor> {
         let base = self.rho.matmul(&self.w)?;
         match &self.residual {
             Some(r) => base.add(r),
             None => Ok(base),
         }
+    }
+
+    fn compose_rows(&self, idx: &Tensor) -> Result<Tensor> {
+        let mut rows = self.rho.index_select(idx, 0)?.matmul(&self.w)?;
+        if let Some(r) = &self.residual {
+            rows = rows.add(&r.index_select(idx, 0)?)?;
+        }
+        Ok(rows)
+    }
+
+    fn ridge_table(&self) -> Option<&Tensor> {
+        self.residual.as_ref()
+    }
+}
+
+impl FeatAdapter {
+    /// The full composed table `[n_features, H]`, on the live parameters.
+    pub fn compose(&self) -> Result<Tensor> {
+        ComposedFeat::compose(self)
     }
 }
 
@@ -423,13 +454,8 @@ impl JointEmbedModel {
     /// Owning this here keeps a trainer from ridging `e_feat` on a model where
     /// that field is a detached snapshot, which is silently inert.
     pub fn feature_ridge(&self, lam: f64) -> Result<Option<Tensor>> {
-        // Modules: the residual is the only per-row table; `μ` is shared and the
-        // membership is a simplex, so neither can overfit row by row.
-        if let Some(m) = &self.modules {
-            return Ok(Some(crate::loss::embedding_ridge(&m.residual, lam)?));
-        }
-        if let Some(a) = &self.adapter {
-            return match &a.residual {
+        if let Some(c) = self.composed() {
+            return match c.ridge_table() {
                 Some(r) => Ok(Some(crate::loss::embedding_ridge(r, lam)?)),
                 None => Ok(None),
             };
@@ -441,16 +467,22 @@ impl JointEmbedModel {
         Ok(Some(crate::loss::embedding_ridge(table, lam)?))
     }
 
-    /// Refresh the `e_feat` snapshot of an ADAPTED model from the live
-    /// parameters WITHOUT baking any gate: the raw composed table. For the
-    /// gate-baked snapshot use [`Self::materialize_e_feat`]. A no-op for the
-    /// other parameterizations, whose `e_feat` is not adapter-derived.
-    pub fn recompose_e_feat_raw(&mut self) -> Result<()> {
-        if let Some(a) = &self.adapter {
-            self.e_feat = a.compose()?.detach();
-        }
+    /// The composed feature side, when this model has one (adapter or modules;
+    /// mutually exclusive by construction). `None` for free and factored models.
+    pub fn composed(&self) -> Option<&dyn ComposedFeat> {
         if let Some(m) = &self.modules {
-            self.e_feat = m.compose()?.detach();
+            return Some(m);
+        }
+        self.adapter.as_ref().map(|a| a as &dyn ComposedFeat)
+    }
+
+    /// Refresh the `e_feat` snapshot of a COMPOSED model (adapter or modules)
+    /// from the live parameters WITHOUT baking any gate: the raw composed table.
+    /// For the gate-baked snapshot use [`Self::materialize_e_feat`]. A no-op for
+    /// the other parameterizations, whose `e_feat` is the trained table itself.
+    pub fn recompose_e_feat_raw(&mut self) -> Result<()> {
+        if let Some(c) = self.composed() {
+            self.e_feat = c.compose()?.detach();
         }
         Ok(())
     }

--- a/graph-embedding-util/src/model/mod.rs
+++ b/graph-embedding-util/src/model/mod.rs
@@ -19,6 +19,7 @@ use candle_util::candle_nn::{self, VarBuilder, VarMap};
 use std::sync::{Arc, Mutex};
 
 mod gate;
+mod modules;
 mod score;
 mod vars;
 
@@ -26,6 +27,10 @@ pub use gate::{
     gate_kl_step_weight, gate_logit_init, ibp_alpha_for_drop, ibp_gate_logit_bias, FeatureGateSpec,
     GateKind, GATE_EFFECT_PRIOR_VAR, GATE_IBP_LOGIT_DROP, GATE_KL_REF_UNITS, GATE_KL_STEP_WEIGHT,
     GATE_KL_WEIGHT,
+};
+pub use modules::{
+    module_logit_for_own_mass, FeatModules, ModuleInit, MODULE_BIAS_VAR_NAME,
+    MODULE_LOGITS_VAR_NAME, MODULE_MU_VAR_NAME, MODULE_RESIDUAL_VAR_NAME,
 };
 use vars::{
     build_feat_factor, register_randn_seeded, register_var_from_mat, register_var_from_slice,
@@ -94,6 +99,11 @@ pub struct ShareFeaturesArgs<'a> {
     pub shared_gate_ibp_bias: Option<Tensor>,
     /// Gate configuration shared across heads. `None` when the gate is off.
     pub gate: Option<FeatureGateSpec>,
+    /// Shared module tables ([`FeatModules`]) for a module-parameterized primary
+    /// model. Every head must carry the SAME clone: a head without it gathers from
+    /// `e_feat`, which for this parameterization is a detached snapshot, and trains a
+    /// feature side nothing else sees.
+    pub shared_modules: Option<FeatModules>,
 }
 
 /// Inputs for [`JointEmbedModel::new_factored`] — a per-gene β-sharing feature
@@ -267,6 +277,10 @@ pub struct JointEmbedModel {
     /// Optional fixed-dictionary adapter parameterization (`None` = free
     /// `e_feat`). Mutually exclusive with `factor` by construction.
     pub adapter: Option<FeatAdapter>,
+    /// Optional learned-module parameterization (`None` = free `e_feat`): every
+    /// row is `Σ_m π_gm μ_m + r_g`. Mutually exclusive with `factor` and `adapter`.
+    /// The `e_feat` field is a detached composed snapshot, as for the adapter.
+    pub modules: Option<FeatModules>,
     pub embedding_dim: usize,
     /// Free-model gate logits `[n_features, H]` (see [`FeatureGateSpec`]). `None` for
     /// an ungated model, or for a factored one (its gate lives in `factor.s_beta`).
@@ -389,6 +403,7 @@ impl JointEmbedModel {
             b_cell,
             factor: None,
             adapter: None,
+            modules: None,
             embedding_dim: args.embedding_dim,
             s_feat: None,
             e_feat_raw: None,
@@ -401,13 +416,18 @@ impl JointEmbedModel {
     }
 
     /// The L2 term for whichever gene-side table can overfit row by row under
-    /// this parameterization: the free `e_feat` Var, the adapter's per-feature
-    /// residual, or nothing (an adapter without a residual trains only the
+    /// this parameterization: the free `e_feat` Var, the adapter's or the module
+    /// model's per-feature residual, or nothing (an adapter without a residual trains only the
     /// shared map, and a factored model's ridge is the trainer's `delta_l2`).
     ///
     /// Owning this here keeps a trainer from ridging `e_feat` on a model where
     /// that field is a detached snapshot, which is silently inert.
     pub fn feature_ridge(&self, lam: f64) -> Result<Option<Tensor>> {
+        // Modules: the residual is the only per-row table; `μ` is shared and the
+        // membership is a simplex, so neither can overfit row by row.
+        if let Some(m) = &self.modules {
+            return Ok(Some(crate::loss::embedding_ridge(&m.residual, lam)?));
+        }
         if let Some(a) = &self.adapter {
             return match &a.residual {
                 Some(r) => Ok(Some(crate::loss::embedding_ridge(r, lam)?)),
@@ -428,6 +448,9 @@ impl JointEmbedModel {
     pub fn recompose_e_feat_raw(&mut self) -> Result<()> {
         if let Some(a) = &self.adapter {
             self.e_feat = a.compose()?.detach();
+        }
+        if let Some(m) = &self.modules {
+            self.e_feat = m.compose()?.detach();
         }
         Ok(())
     }
@@ -501,6 +524,7 @@ impl JointEmbedModel {
             b_cell,
             factor: None,
             adapter: Some(adapter),
+            modules: None,
             embedding_dim: args.embedding_dim,
             s_feat: None,
             e_feat_raw: None,
@@ -538,6 +562,7 @@ impl JointEmbedModel {
             shared_e_feat_logstd,
             shared_gate_ibp_bias,
             gate,
+            shared_modules,
         } = args;
         let e_name = format!("{var_prefix}_e_cell");
         let b_name = format!("{var_prefix}_b_cell");
@@ -554,6 +579,7 @@ impl JointEmbedModel {
             b_cell,
             factor: None,
             adapter: None,
+            modules: shared_modules,
             embedding_dim,
             s_feat: shared_s_feat,
             e_feat_raw: shared_e_feat_raw,
@@ -614,6 +640,7 @@ impl JointEmbedModel {
             b_cell,
             factor: Some(factor),
             adapter: None,
+            modules: None,
             embedding_dim: args.embedding_dim,
             s_feat: None,
             e_feat_raw: None,
@@ -661,6 +688,7 @@ impl JointEmbedModel {
                 shared_e_feat_logstd: None,
                 shared_gate_ibp_bias: self.gate_ibp_bias.clone(),
                 gate: self.gate,
+                shared_modules: None,
             },
             varmap,
             dev,
@@ -675,3 +703,6 @@ mod tests;
 
 #[cfg(test)]
 mod adapter_tests;
+
+#[cfg(test)]
+mod module_tests;

--- a/graph-embedding-util/src/model/module_tests.rs
+++ b/graph-embedding-util/src/model/module_tests.rs
@@ -18,6 +18,8 @@ fn build(labels: Option<&[u32]>, own_mass: f32) -> (JointEmbedModel, VarMap) {
             n_modules: 3,
             init_labels: labels,
             init_own_mass: own_mass,
+            init_logits: None,
+            init_mu: None,
             b_feat: &[0f32; 6],
             b_cell: &[0f32; 3],
             seed: 9,
@@ -270,4 +272,65 @@ fn gate_rides_on_the_composed_rows() {
         grads.get(mu.as_tensor()).is_some(),
         "the effect KL must see the live μ"
     );
+}
+
+/// A parent's membership rows are simplex points, and sparsemax of a simplex point
+/// is that point, so explicit logits reproduce the parent's membership exactly and
+/// an explicit μ is registered verbatim — the warm start `update` carries.
+#[test]
+fn explicit_logits_and_mu_reproduce_the_parent() {
+    let vm = VarMap::new();
+    let pi = nalgebra::DMatrix::<f32>::from_row_slice(
+        6,
+        3,
+        &[
+            1.0, 0.0, 0.0, //
+            0.5, 0.5, 0.0, //
+            0.0, 0.2, 0.8, //
+            0.0, 0.0, 1.0, //
+            0.3, 0.3, 0.4, //
+            0.0, 1.0, 0.0,
+        ],
+    );
+    let mu = nalgebra::DMatrix::<f32>::from_fn(3, 4, |m, h| (m * 4 + h) as f32 * 0.1);
+    let model = JointEmbedModel::new_with_modules(
+        ModuleInit {
+            n_features: 6,
+            n_cells: 3,
+            embedding_dim: 4,
+            n_modules: 3,
+            init_labels: None,
+            init_own_mass: 0.9,
+            init_logits: Some(&pi),
+            init_mu: Some(&mu),
+            b_feat: &[0f32; 6],
+            b_cell: &[0f32; 3],
+            seed: 9,
+        },
+        &vm,
+        &dev(),
+    )
+    .unwrap();
+    let got: Vec<Vec<f32>> = model
+        .module_membership()
+        .unwrap()
+        .unwrap()
+        .to_vec2()
+        .unwrap();
+    for g in 0..6 {
+        for m in 0..3 {
+            assert!(
+                (got[g][m] - pi[(g, m)]).abs() < 1e-6,
+                "π[{g},{m}]: {} vs {}",
+                got[g][m],
+                pi[(g, m)]
+            );
+        }
+    }
+    let mu_got: Vec<Vec<f32>> = model.modules.as_ref().unwrap().mu.to_vec2().unwrap();
+    for m in 0..3 {
+        for h in 0..4 {
+            assert!((mu_got[m][h] - mu[(m, h)]).abs() < 1e-6);
+        }
+    }
 }

--- a/graph-embedding-util/src/model/module_tests.rs
+++ b/graph-embedding-util/src/model/module_tests.rs
@@ -1,0 +1,273 @@
+//! Tests of the learned-module parameterization.
+
+use super::*;
+use candle_util::candle_core::{Device, Var};
+use candle_util::nn::sparsemax;
+
+fn dev() -> Device {
+    Device::Cpu
+}
+
+fn build(labels: Option<&[u32]>, own_mass: f32) -> (JointEmbedModel, VarMap) {
+    let vm = VarMap::new();
+    let m = JointEmbedModel::new_with_modules(
+        ModuleInit {
+            n_features: 6,
+            n_cells: 3,
+            embedding_dim: 4,
+            n_modules: 3,
+            init_labels: labels,
+            init_own_mass: own_mass,
+            b_feat: &[0f32; 6],
+            b_cell: &[0f32; 3],
+            seed: 9,
+        },
+        &vm,
+        &dev(),
+    )
+    .unwrap();
+    (m, vm)
+}
+
+fn var(vm: &VarMap, name: &str) -> Var {
+    vm.data()
+        .lock()
+        .unwrap()
+        .get(name)
+        .unwrap_or_else(|| panic!("{name} not registered"))
+        .clone()
+}
+
+#[test]
+fn own_mass_formula_holds_under_sparsemax() {
+    for &(p, m) in &[(0.9f32, 3usize), (0.6, 8), (0.5, 128), (1.0, 16)] {
+        let kappa = module_logit_for_own_mass(p, m);
+        let mut row = vec![0f32; m];
+        row[0] = kappa;
+        let t = Tensor::from_vec(row, (1, m), &dev()).unwrap();
+        let out: Vec<Vec<f32>> = sparsemax(&t).unwrap().to_vec2().unwrap();
+        assert!(
+            (out[0][0] - p).abs() < 1e-5,
+            "M={m}: own mass {} for target {p} (κ={kappa})",
+            out[0][0]
+        );
+        let rest: f32 = out[0][1..].iter().sum();
+        assert!((rest - (1.0 - p)).abs() < 1e-5);
+    }
+}
+
+#[test]
+fn registers_exactly_the_module_vars_and_no_free_e_feat() {
+    let (_, vm) = build(Some(&[0, 0, 1, 1, 2, 2]), 0.9);
+    let names: Vec<String> = vm.data().lock().unwrap().keys().cloned().collect();
+    for want in [
+        MODULE_LOGITS_VAR_NAME,
+        MODULE_MU_VAR_NAME,
+        MODULE_RESIDUAL_VAR_NAME,
+        MODULE_BIAS_VAR_NAME,
+        "e_cell",
+        "b_feat",
+        "b_cell",
+    ] {
+        assert!(
+            names.iter().any(|n| n == want),
+            "{want} missing from {names:?}"
+        );
+    }
+    assert!(
+        !names.iter().any(|n| n == E_FEAT_VAR_NAME),
+        "a module model must not register a free e_feat Var"
+    );
+}
+
+#[test]
+fn warm_start_labels_set_the_membership() {
+    let labels = [0u32, 0, 1, 1, 2, 2];
+    let (m, _) = build(Some(&labels), 0.9);
+    let pi: Vec<Vec<f32>> = m.module_membership().unwrap().unwrap().to_vec2().unwrap();
+    for (g, &l) in labels.iter().enumerate() {
+        assert!(
+            (pi[g][l as usize] - 0.9).abs() < 1e-5,
+            "row {g}: {:?}",
+            pi[g]
+        );
+    }
+}
+
+#[test]
+fn gather_matches_the_dense_composition() {
+    let (m, _) = build(Some(&[0, 1, 2, 0, 1, 2]), 0.8);
+    let full = m.modules.as_ref().unwrap().compose().unwrap();
+    let idx = Tensor::from_vec(vec![4u32, 1, 5], 3, &dev()).unwrap();
+    let rows = crate::loss::gather_feature_rows(&m, &idx).unwrap();
+    let want = full.index_select(&idx, 0).unwrap();
+    let a: Vec<f32> = rows.flatten_all().unwrap().to_vec1().unwrap();
+    let b: Vec<f32> = want.flatten_all().unwrap().to_vec1().unwrap();
+    for (x, y) in a.iter().zip(&b) {
+        assert!((x - y).abs() < 1e-5);
+    }
+}
+
+#[test]
+fn materialize_composes_and_is_idempotent() {
+    let (mut m, vm) = build(Some(&[0, 1, 2, 0, 1, 2]), 0.8);
+    // Move μ so the snapshot taken at construction is stale.
+    let mu = var(&vm, MODULE_MU_VAR_NAME);
+    mu.set(&(mu.as_tensor() * 3.0).unwrap()).unwrap();
+    m.materialize_e_feat().unwrap();
+    let once: Vec<f32> = m.e_feat.flatten_all().unwrap().to_vec1().unwrap();
+    let want: Vec<f32> = m
+        .modules
+        .as_ref()
+        .unwrap()
+        .compose()
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .to_vec1()
+        .unwrap();
+    assert_eq!(once, want);
+    m.materialize_e_feat().unwrap();
+    let twice: Vec<f32> = m.e_feat.flatten_all().unwrap().to_vec1().unwrap();
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn ridge_lands_on_the_residual() {
+    let (m, vm) = build(Some(&[0, 1, 2, 0, 1, 2]), 0.8);
+    let r = var(&vm, MODULE_RESIDUAL_VAR_NAME);
+    r.set(&Tensor::ones((6, 4), candle_util::candle_core::DType::F32, &dev()).unwrap())
+        .unwrap();
+    let pen = m
+        .feature_ridge(0.5)
+        .unwrap()
+        .expect("module model has a ridge");
+    let grads = pen.backward().unwrap();
+    assert!(
+        grads.get(r.as_tensor()).is_some(),
+        "ridge gradient must reach the residual"
+    );
+    let v: f32 = pen.to_scalar().unwrap();
+    assert!(
+        (v - 0.5 * 4.0).abs() < 1e-5,
+        "λ·mean_g‖r_g‖² = 0.5·4, got {v}"
+    );
+}
+
+#[test]
+fn frozen_membership_receives_no_gradient() {
+    let (m, vm) = build(Some(&[0, 1, 2, 0, 1, 2]), 0.8);
+    let modules = m.modules.as_ref().unwrap();
+    let logits = var(&vm, MODULE_LOGITS_VAR_NAME);
+    let mu = var(&vm, MODULE_MU_VAR_NAME);
+    let idx = Tensor::from_vec(vec![0u32, 3], 2, &dev()).unwrap();
+
+    modules.set_frozen(true);
+    let loss = crate::loss::gather_feature_rows(&m, &idx)
+        .unwrap()
+        .sqr()
+        .unwrap()
+        .sum_all()
+        .unwrap();
+    let grads = loss.backward().unwrap();
+    assert!(
+        grads.get(logits.as_tensor()).is_none(),
+        "frozen logits must not get a gradient"
+    );
+    assert!(
+        grads.get(mu.as_tensor()).is_some(),
+        "μ trains during the warm-up"
+    );
+
+    modules.set_frozen(false);
+    let loss = crate::loss::gather_feature_rows(&m, &idx)
+        .unwrap()
+        .sqr()
+        .unwrap()
+        .sum_all()
+        .unwrap();
+    let grads = loss.backward().unwrap();
+    assert!(
+        grads.get(logits.as_tensor()).is_some(),
+        "released logits train"
+    );
+}
+
+/// Every sharing head must carry the module tables: a head without them gathers
+/// from `e_feat`, a detached snapshot, and trains a feature side nobody sees.
+#[test]
+fn every_shared_head_carries_the_modules() {
+    let (m, vm) = build(Some(&[0, 1, 2, 0, 1, 2]), 0.8);
+    let head = JointEmbedModel::new_sharing_features(
+        ShareFeaturesArgs {
+            n_cells: 5,
+            embedding_dim: 4,
+            shared_e_feat: m.e_feat.clone(),
+            shared_b_feat: m.b_feat.clone(),
+            e_cell_init: None,
+            b_cell_init: &[0f32; 5],
+            var_prefix: "pb_l0",
+            seed: 3,
+            shared_s_feat: None,
+            shared_e_feat_raw: None,
+            shared_e_feat_logstd: None,
+            shared_gate_ibp_bias: None,
+            gate: None,
+            shared_modules: m.modules.clone(),
+        },
+        &vm,
+        &dev(),
+    )
+    .unwrap();
+    let mu = var(&vm, MODULE_MU_VAR_NAME);
+    let idx = Tensor::from_vec(vec![2u32], 1, &dev()).unwrap();
+    let loss = crate::loss::gather_feature_rows(&head, &idx)
+        .unwrap()
+        .sqr()
+        .unwrap()
+        .sum_all()
+        .unwrap();
+    let grads = loss.backward().unwrap();
+    assert!(
+        grads.get(mu.as_tensor()).is_some(),
+        "the head's gather must reach the shared μ"
+    );
+    // And the frozen flag is one cell shared by both.
+    m.modules.as_ref().unwrap().set_frozen(true);
+    assert!(head.modules.as_ref().unwrap().is_frozen());
+}
+
+/// The gate sits on the composed ρ: with a gate enabled, the gather still reaches
+/// μ and the residual through the gate multiplier, and the KL prices the LIVE
+/// composition.
+#[test]
+fn gate_rides_on_the_composed_rows() {
+    let (mut m, vm) = build(Some(&[0, 1, 2, 0, 1, 2]), 0.8);
+    m.enable_feature_gate(
+        FeatureGateSpec {
+            temperature: 1.0,
+            ibp_alpha: None,
+        },
+        &vm,
+        &dev(),
+    )
+    .unwrap();
+    let mu = var(&vm, MODULE_MU_VAR_NAME);
+    let s = var(&vm, "s_feat");
+    let idx = Tensor::from_vec(vec![1u32, 4], 2, &dev()).unwrap();
+    let loss = crate::loss::gather_feature_rows(&m, &idx)
+        .unwrap()
+        .sqr()
+        .unwrap()
+        .sum_all()
+        .unwrap();
+    let grads = loss.backward().unwrap();
+    assert!(grads.get(mu.as_tensor()).is_some());
+    assert!(grads.get(s.as_tensor()).is_some());
+    let kl = m.gate_kl().unwrap().expect("gated model has a KL");
+    let grads = kl.backward().unwrap();
+    assert!(
+        grads.get(mu.as_tensor()).is_some(),
+        "the effect KL must see the live μ"
+    );
+}

--- a/graph-embedding-util/src/model/module_tests.rs
+++ b/graph-embedding-util/src/model/module_tests.rs
@@ -10,16 +10,17 @@ fn dev() -> Device {
 
 fn build(labels: Option<&[u32]>, own_mass: f32) -> (JointEmbedModel, VarMap) {
     let vm = VarMap::new();
+    let warm = match labels {
+        Some(labels) => ModuleWarmStart::Labels { labels, own_mass },
+        None => ModuleWarmStart::Uniform,
+    };
     let m = JointEmbedModel::new_with_modules(
         ModuleInit {
             n_features: 6,
             n_cells: 3,
             embedding_dim: 4,
             n_modules: 3,
-            init_labels: labels,
-            init_own_mass: own_mass,
-            init_logits: None,
-            init_mu: None,
+            warm,
             b_feat: &[0f32; 6],
             b_cell: &[0f32; 3],
             seed: 9,
@@ -299,10 +300,10 @@ fn explicit_logits_and_mu_reproduce_the_parent() {
             n_cells: 3,
             embedding_dim: 4,
             n_modules: 3,
-            init_labels: None,
-            init_own_mass: 0.9,
-            init_logits: Some(&pi),
-            init_mu: Some(&mu),
+            warm: ModuleWarmStart::Explicit {
+                logits: &pi,
+                mu: Some(&mu),
+            },
             b_feat: &[0f32; 6],
             b_cell: &[0f32; 3],
             seed: 9,

--- a/graph-embedding-util/src/model/modules.rs
+++ b/graph-embedding-util/src/model/modules.rs
@@ -31,10 +31,10 @@ use candle_util::candle_core::{Device, Result, Tensor};
 use candle_util::candle_nn::VarMap;
 use candle_util::nn::sparsemax;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use super::vars::{register_randn_seeded, register_var_from_mat, register_var_from_slice};
-use super::JointEmbedModel;
+use super::{ComposedFeat, JointEmbedModel};
 
 /// Registered names of the module Vars, so a caller that owns the `VarMap` can
 /// fetch them without hard-coding strings this crate chose.
@@ -43,26 +43,32 @@ pub const MODULE_MU_VAR_NAME: &str = "module_mu";
 pub const MODULE_RESIDUAL_VAR_NAME: &str = "module_residual";
 pub const MODULE_BIAS_VAR_NAME: &str = "module_bias";
 
+/// How the membership starts.
+pub enum ModuleWarmStart<'a> {
+    /// One module per feature from a clustering, holding `own_mass` of the
+    /// row on it and spreading the rest evenly so every module stays in the
+    /// sparsemax support and can still earn the feature
+    /// (see [`module_logit_for_own_mass`]).
+    Labels { labels: &'a [u32], own_mass: f32 },
+    /// Explicit logits `[n_features, M]`, and optionally the module dictionary
+    /// `[M, H]`. A membership row is a simplex point and sparsemax of a simplex
+    /// point is itself, so a parent's `π` passed here is reproduced exactly —
+    /// the warm start `update` carries.
+    Explicit {
+        logits: &'a nalgebra::DMatrix<f32>,
+        mu: Option<&'a nalgebra::DMatrix<f32>>,
+    },
+    /// Every module in the support with equal mass; the data alone decides.
+    Uniform,
+}
+
 /// Inputs for [`JointEmbedModel::new_with_modules`].
 pub struct ModuleInit<'a> {
     pub n_features: usize,
     pub n_cells: usize,
     pub embedding_dim: usize,
     pub n_modules: usize,
-    /// Warm-start module per feature (`len == n_features`, values `< n_modules`).
-    /// `None` seeds every feature uniformly across modules.
-    pub init_labels: Option<&'a [u32]>,
-    /// Share of a feature's membership placed on its warm-start module; the rest
-    /// is spread evenly over the others so every module stays in the sparsemax
-    /// support and can still earn the feature. See [`module_logit_for_own_mass`].
-    pub init_own_mass: f32,
-    /// Explicit membership logits `[n_features, M]`, taking precedence over
-    /// `init_labels`. A membership row is a simplex point and sparsemax of a
-    /// simplex point is itself, so a parent's `π` passed here is reproduced
-    /// exactly — the warm start `update` carries.
-    pub init_logits: Option<&'a nalgebra::DMatrix<f32>>,
-    /// Explicit module dictionary `[M, H]` instead of the seeded randn.
-    pub init_mu: Option<&'a nalgebra::DMatrix<f32>>,
+    pub warm: ModuleWarmStart<'a>,
     pub b_feat: &'a [f32],
     pub b_cell: &'a [f32],
     /// Base seed for the reproducible randn init of `μ` and the cell side.
@@ -88,6 +94,10 @@ pub struct FeatModules {
     /// While set, the membership is detached in every forward, so the warm-start
     /// partition is held and only `μ` / `r` train.
     pub frozen: Arc<AtomicBool>,
+    /// The detached membership while frozen: the logits cannot move, so one
+    /// sparsemax serves every step of the warm-up. Cleared on release. Shared
+    /// across heads like `frozen`.
+    frozen_pi: Arc<Mutex<Option<Tensor>>>,
 }
 
 /// The logit that puts a share `p` of a feature's sparsemax membership on one
@@ -115,45 +125,65 @@ impl FeatModules {
     /// Hold (`true`) or release (`false`) the membership. Shared across heads.
     pub fn set_frozen(&self, frozen: bool) {
         self.frozen.store(frozen, Ordering::Relaxed);
-    }
-
-    fn live_logits(&self) -> Tensor {
-        if self.is_frozen() {
-            self.logits.detach()
-        } else {
-            self.logits.clone()
+        if !frozen {
+            *self.frozen_pi.lock().expect("frozen membership poisoned") = None;
         }
     }
 
-    /// The full membership `π [n_features, M]` on the live logits (detached while
-    /// frozen). Rows are on the simplex with exact zeros.
+    /// The full membership `π [n_features, M]`: the live sparsemax, or, while
+    /// frozen, the detached table computed once. Rows are on the simplex with
+    /// exact zeros.
     pub fn membership(&self) -> Result<Tensor> {
-        sparsemax(&self.live_logits())
+        if !self.is_frozen() {
+            return sparsemax(&self.logits);
+        }
+        let mut cache = self.frozen_pi.lock().expect("frozen membership poisoned");
+        if let Some(pi) = cache.as_ref() {
+            return Ok(pi.clone());
+        }
+        let pi = sparsemax(&self.logits.detach())?;
+        *cache = Some(pi.clone());
+        Ok(pi)
     }
 
     /// Membership rows for `idx` — sparsemax is row-wise, so gathering first is
-    /// exact and keeps the per-step work at `[b, M]`.
+    /// exact and keeps the per-step work at `[b, M]` (or an `index_select` of the
+    /// cached table while frozen).
     pub fn membership_rows(&self, idx: &Tensor) -> Result<Tensor> {
-        sparsemax(&self.live_logits().index_select(idx, 0)?)
+        if self.is_frozen() {
+            return self.membership()?.index_select(idx, 0);
+        }
+        sparsemax(&self.logits.index_select(idx, 0)?)
     }
 
     /// The full composed table `ρ = π μ + r`, `[n_features, H]`, on the live
     /// parameters.
     pub fn compose(&self) -> Result<Tensor> {
+        ComposedFeat::compose(self)
+    }
+}
+
+impl ComposedFeat for FeatModules {
+    fn compose(&self) -> Result<Tensor> {
         self.membership()?.matmul(&self.mu)?.add(&self.residual)
     }
 
-    /// Composed rows for `idx`, `[b, H]`, on the live parameters.
-    pub fn compose_rows(&self, idx: &Tensor) -> Result<Tensor> {
+    fn compose_rows(&self, idx: &Tensor) -> Result<Tensor> {
         self.membership_rows(idx)?
             .matmul(&self.mu)?
             .add(&self.residual.index_select(idx, 0)?)
     }
+
+    /// The residual is the only per-row table; `μ` is shared and the membership
+    /// is a simplex, so neither can overfit row by row.
+    fn ridge_table(&self) -> Option<&Tensor> {
+        Some(&self.residual)
+    }
 }
 
 impl JointEmbedModel {
-    /// Module constructor: allocate the membership logits (warm-started from
-    /// `init_labels`), the randn module dictionary, the zero residual and the
+    /// Module constructor: allocate the membership logits (from the warm start),
+    /// the module dictionary (randn, or the parent's), the zero residual and the
     /// module bias, plus a fresh cell side. The `e_feat` field is seeded with the
     /// composed table and refreshed after phase 1 via [`Self::materialize_e_feat`].
     pub fn new_with_modules(args: ModuleInit, varmap: &VarMap, dev: &Device) -> Result<Self> {
@@ -174,28 +204,17 @@ impl JointEmbedModel {
                 args.n_cells
             );
         }
-        let kappa = module_logit_for_own_mass(args.init_own_mass, m);
         let mut logits_host = nalgebra::DMatrix::<f32>::zeros(d, m);
-        if let Some(l) = args.init_logits {
-            if l.nrows() != d || l.ncols() != m {
-                candle_util::candle_core::bail!(
-                    "new_with_modules: init_logits is {}×{} but the model is {d}×{m}",
-                    l.nrows(),
-                    l.ncols()
-                );
-            }
-            logits_host.copy_from(l);
-        }
-        // No warm start leaves every module in the support with equal mass, so
-        // the data alone decides the partition. Explicit logits win over labels.
-        if let (Some(labels), None) = (args.init_labels, args.init_logits) {
-            {
+        let mut mu_init: Option<&nalgebra::DMatrix<f32>> = None;
+        match args.warm {
+            ModuleWarmStart::Labels { labels, own_mass } => {
                 if labels.len() != d {
                     candle_util::candle_core::bail!(
                         "new_with_modules: {} warm-start labels for {d} features",
                         labels.len()
                     );
                 }
+                let kappa = module_logit_for_own_mass(own_mass, m);
                 for (g, &lab) in labels.iter().enumerate() {
                     if lab as usize >= m {
                         candle_util::candle_core::bail!(
@@ -206,19 +225,31 @@ impl JointEmbedModel {
                     logits_host[(g, lab as usize)] = kappa;
                 }
             }
-        }
-        let logits = register_var_from_mat(varmap, dev, MODULE_LOGITS_VAR_NAME, &logits_host)?;
-        let mu = match args.init_mu {
-            Some(parent) => {
-                if parent.nrows() != m || parent.ncols() != h {
+            ModuleWarmStart::Explicit { logits, mu } => {
+                if logits.nrows() != d || logits.ncols() != m {
                     candle_util::candle_core::bail!(
-                        "new_with_modules: init_mu is {}×{} but the model needs {m}×{h}",
-                        parent.nrows(),
-                        parent.ncols()
+                        "new_with_modules: warm-start logits are {}×{} but the model is {d}×{m}",
+                        logits.nrows(),
+                        logits.ncols()
                     );
                 }
-                register_var_from_mat(varmap, dev, MODULE_MU_VAR_NAME, parent)?
+                if let Some(parent) = mu {
+                    if parent.nrows() != m || parent.ncols() != h {
+                        candle_util::candle_core::bail!(
+                            "new_with_modules: warm-start μ is {}×{} but the model needs {m}×{h}",
+                            parent.nrows(),
+                            parent.ncols()
+                        );
+                    }
+                }
+                logits_host.copy_from(logits);
+                mu_init = mu;
             }
+            ModuleWarmStart::Uniform => {}
+        }
+        let logits = register_var_from_mat(varmap, dev, MODULE_LOGITS_VAR_NAME, &logits_host)?;
+        let mu = match mu_init {
+            Some(parent) => register_var_from_mat(varmap, dev, MODULE_MU_VAR_NAME, parent)?,
             None => register_randn_seeded(varmap, dev, MODULE_MU_VAR_NAME, m, h, args.seed)?,
         };
         let residual = register_var_from_mat(
@@ -239,6 +270,7 @@ impl JointEmbedModel {
             b_module,
             n_modules: m,
             frozen: Arc::new(AtomicBool::new(false)),
+            frozen_pi: Arc::new(Mutex::new(None)),
         };
         let e_feat = modules.compose()?.detach();
         Ok(Self {
@@ -254,7 +286,7 @@ impl JointEmbedModel {
             e_feat_raw: None,
             e_feat_logstd: None,
             gate_pip: None,
-            gate_mask: Arc::new(std::sync::Mutex::new(None)),
+            gate_mask: Arc::new(Mutex::new(None)),
             gate_ibp_bias: None,
             gate: None,
         })

--- a/graph-embedding-util/src/model/modules.rs
+++ b/graph-embedding-util/src/model/modules.rs
@@ -176,9 +176,19 @@ impl JointEmbedModel {
         }
         let kappa = module_logit_for_own_mass(args.init_own_mass, m);
         let mut logits_host = nalgebra::DMatrix::<f32>::zeros(d, m);
+        if let Some(l) = args.init_logits {
+            if l.nrows() != d || l.ncols() != m {
+                candle_util::candle_core::bail!(
+                    "new_with_modules: init_logits is {}×{} but the model is {d}×{m}",
+                    l.nrows(),
+                    l.ncols()
+                );
+            }
+            logits_host.copy_from(l);
+        }
         // No warm start leaves every module in the support with equal mass, so
-        // the data alone decides the partition.
-        if let Some(labels) = args.init_labels {
+        // the data alone decides the partition. Explicit logits win over labels.
+        if let (Some(labels), None) = (args.init_labels, args.init_logits) {
             {
                 if labels.len() != d {
                     candle_util::candle_core::bail!(
@@ -198,7 +208,19 @@ impl JointEmbedModel {
             }
         }
         let logits = register_var_from_mat(varmap, dev, MODULE_LOGITS_VAR_NAME, &logits_host)?;
-        let mu = register_randn_seeded(varmap, dev, MODULE_MU_VAR_NAME, m, h, args.seed)?;
+        let mu = match args.init_mu {
+            Some(parent) => {
+                if parent.nrows() != m || parent.ncols() != h {
+                    candle_util::candle_core::bail!(
+                        "new_with_modules: init_mu is {}×{} but the model needs {m}×{h}",
+                        parent.nrows(),
+                        parent.ncols()
+                    );
+                }
+                register_var_from_mat(varmap, dev, MODULE_MU_VAR_NAME, parent)?
+            }
+            None => register_randn_seeded(varmap, dev, MODULE_MU_VAR_NAME, m, h, args.seed)?,
+        };
         let residual = register_var_from_mat(
             varmap,
             dev,

--- a/graph-embedding-util/src/model/modules.rs
+++ b/graph-embedding-util/src/model/modules.rs
@@ -56,6 +56,13 @@ pub struct ModuleInit<'a> {
     /// is spread evenly over the others so every module stays in the sparsemax
     /// support and can still earn the feature. See [`module_logit_for_own_mass`].
     pub init_own_mass: f32,
+    /// Explicit membership logits `[n_features, M]`, taking precedence over
+    /// `init_labels`. A membership row is a simplex point and sparsemax of a
+    /// simplex point is itself, so a parent's `π` passed here is reproduced
+    /// exactly — the warm start `update` carries.
+    pub init_logits: Option<&'a nalgebra::DMatrix<f32>>,
+    /// Explicit module dictionary `[M, H]` instead of the seeded randn.
+    pub init_mu: Option<&'a nalgebra::DMatrix<f32>>,
     pub b_feat: &'a [f32],
     pub b_cell: &'a [f32],
     /// Base seed for the reproducible randn init of `μ` and the cell side.

--- a/graph-embedding-util/src/model/modules.rs
+++ b/graph-embedding-util/src/model/modules.rs
@@ -1,0 +1,242 @@
+//! Learned gene modules: a mixed-membership mixture of module vectors in front
+//! of the feature embedding.
+//!
+//! A free model trains one row `ρ_g` per feature, and that row receives gradient
+//! only on the steps that draw its feature as a positive or a negative. A feature
+//! that is rare, or absent from a later dataset, has nothing standing in for it.
+//! Here every row is a mixture of `M` shared module vectors plus a small residual:
+//!
+//!   `ρ_g = Σ_m π_gm · μ_m + r_g`,   `π_g = sparsemax(logits_g)`
+//!
+//! so an edge on any member of a module updates `μ_m`, and a feature that is never
+//! drawn still inherits a trained row through its siblings. `sparsemax` puts each
+//! feature on a few modules with exact zeros elsewhere — mixed membership by
+//! construction, never a uniform average of every module, which is the one-point
+//! degeneracy a soft pool collapses into.
+//!
+//! The membership is a learned `Var`, warm-started from a clustering of the
+//! feature profiles and held fixed for the first epochs (see
+//! [`FeatModules::set_frozen`]): a learned partition trained from a cold start is
+//! rich-get-richer, and the exact module term (`crate::loss::modules`) rewards
+//! putting every feature in one module unless a load-balance prior and the residual
+//! ridge push back. The trainer owns those terms; this type owns the tables and the
+//! composition.
+//!
+//! Follows the adapter's contract: `e_feat` on the model is a detached composed
+//! snapshot, the per-batch gather composes the live parameters, and
+//! [`super::JointEmbedModel::materialize_e_feat`] refreshes the snapshot after
+//! training so phase 2 and every output reader see a fixed dictionary.
+
+use candle_util::candle_core::{Device, Result, Tensor};
+use candle_util::candle_nn::VarMap;
+use candle_util::nn::sparsemax;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use super::vars::{register_randn_seeded, register_var_from_mat, register_var_from_slice};
+use super::JointEmbedModel;
+
+/// Registered names of the module Vars, so a caller that owns the `VarMap` can
+/// fetch them without hard-coding strings this crate chose.
+pub const MODULE_LOGITS_VAR_NAME: &str = "module_logits";
+pub const MODULE_MU_VAR_NAME: &str = "module_mu";
+pub const MODULE_RESIDUAL_VAR_NAME: &str = "module_residual";
+pub const MODULE_BIAS_VAR_NAME: &str = "module_bias";
+
+/// Inputs for [`JointEmbedModel::new_with_modules`].
+pub struct ModuleInit<'a> {
+    pub n_features: usize,
+    pub n_cells: usize,
+    pub embedding_dim: usize,
+    pub n_modules: usize,
+    /// Warm-start module per feature (`len == n_features`, values `< n_modules`).
+    /// `None` seeds every feature uniformly across modules.
+    pub init_labels: Option<&'a [u32]>,
+    /// Share of a feature's membership placed on its warm-start module; the rest
+    /// is spread evenly over the others so every module stays in the sparsemax
+    /// support and can still earn the feature. See [`module_logit_for_own_mass`].
+    pub init_own_mass: f32,
+    pub b_feat: &'a [f32],
+    pub b_cell: &'a [f32],
+    /// Base seed for the reproducible randn init of `μ` and the cell side.
+    pub seed: u64,
+}
+
+/// The module tables. Cloned into every sharing head so all heads train the
+/// SAME Vars; `frozen` is shared through the `Arc` so a warm-up flip is seen by
+/// every axis at once.
+#[derive(Clone)]
+pub struct FeatModules {
+    /// Membership logits `[n_features, M]` (Var). `sparsemax` per row.
+    pub logits: Tensor,
+    /// Module dictionary `[M, H]` (Var).
+    pub mu: Tensor,
+    /// Per-feature residual `[n_features, H]` (Var, zero-init, ridge-shrunk by the
+    /// trainer). What no combination of a feature's modules explains.
+    pub residual: Tensor,
+    /// Per-module bias `[M]` (Var), the module-level abundance in the exact
+    /// module term. Not part of `ρ`.
+    pub b_module: Tensor,
+    pub n_modules: usize,
+    /// While set, the membership is detached in every forward, so the warm-start
+    /// partition is held and only `μ` / `r` train.
+    pub frozen: Arc<AtomicBool>,
+}
+
+/// The logit that puts a share `p` of a feature's sparsemax membership on one
+/// module when every other module's logit is zero.
+///
+/// With `logits = (κ, 0, …, 0)` and `κ < 1` every module is in the sparsemax
+/// support, the threshold is `τ = (κ − 1)/M`, the own module gets `κ − τ` and each
+/// other gets `−τ`; solving `κ − τ = p` gives `κ = (p·M − 1)/(M − 1)`. Valid for
+/// `1/M ≤ p ≤ 1`; `p = 1` (`κ = 1`) is the hard one-hot start. A softmax would
+/// have needed `ln(p/(1−p)·(M−1))` here — a flat `+3` gives only a few percent at
+/// large `M` — so the number is derived, not chosen.
+#[must_use]
+pub fn module_logit_for_own_mass(own_mass: f32, n_modules: usize) -> f32 {
+    let m = n_modules.max(2) as f32;
+    let p = own_mass.clamp(1.0 / m, 1.0);
+    (p * m - 1.0) / (m - 1.0)
+}
+
+impl FeatModules {
+    #[must_use]
+    pub fn is_frozen(&self) -> bool {
+        self.frozen.load(Ordering::Relaxed)
+    }
+
+    /// Hold (`true`) or release (`false`) the membership. Shared across heads.
+    pub fn set_frozen(&self, frozen: bool) {
+        self.frozen.store(frozen, Ordering::Relaxed);
+    }
+
+    fn live_logits(&self) -> Tensor {
+        if self.is_frozen() {
+            self.logits.detach()
+        } else {
+            self.logits.clone()
+        }
+    }
+
+    /// The full membership `π [n_features, M]` on the live logits (detached while
+    /// frozen). Rows are on the simplex with exact zeros.
+    pub fn membership(&self) -> Result<Tensor> {
+        sparsemax(&self.live_logits())
+    }
+
+    /// Membership rows for `idx` — sparsemax is row-wise, so gathering first is
+    /// exact and keeps the per-step work at `[b, M]`.
+    pub fn membership_rows(&self, idx: &Tensor) -> Result<Tensor> {
+        sparsemax(&self.live_logits().index_select(idx, 0)?)
+    }
+
+    /// The full composed table `ρ = π μ + r`, `[n_features, H]`, on the live
+    /// parameters.
+    pub fn compose(&self) -> Result<Tensor> {
+        self.membership()?.matmul(&self.mu)?.add(&self.residual)
+    }
+
+    /// Composed rows for `idx`, `[b, H]`, on the live parameters.
+    pub fn compose_rows(&self, idx: &Tensor) -> Result<Tensor> {
+        self.membership_rows(idx)?
+            .matmul(&self.mu)?
+            .add(&self.residual.index_select(idx, 0)?)
+    }
+}
+
+impl JointEmbedModel {
+    /// Module constructor: allocate the membership logits (warm-started from
+    /// `init_labels`), the randn module dictionary, the zero residual and the
+    /// module bias, plus a fresh cell side. The `e_feat` field is seeded with the
+    /// composed table and refreshed after phase 1 via [`Self::materialize_e_feat`].
+    pub fn new_with_modules(args: ModuleInit, varmap: &VarMap, dev: &Device) -> Result<Self> {
+        let (d, m, h) = (args.n_features, args.n_modules, args.embedding_dim);
+        if m < 2 {
+            candle_util::candle_core::bail!("new_with_modules: need at least 2 modules, got {m}");
+        }
+        if args.b_feat.len() != d {
+            candle_util::candle_core::bail!(
+                "new_with_modules: b_feat has {} entries but n_features is {d}",
+                args.b_feat.len()
+            );
+        }
+        if args.b_cell.len() != args.n_cells {
+            candle_util::candle_core::bail!(
+                "new_with_modules: b_cell has {} entries but n_cells is {}",
+                args.b_cell.len(),
+                args.n_cells
+            );
+        }
+        let kappa = module_logit_for_own_mass(args.init_own_mass, m);
+        let mut logits_host = nalgebra::DMatrix::<f32>::zeros(d, m);
+        // No warm start leaves every module in the support with equal mass, so
+        // the data alone decides the partition.
+        if let Some(labels) = args.init_labels {
+            {
+                if labels.len() != d {
+                    candle_util::candle_core::bail!(
+                        "new_with_modules: {} warm-start labels for {d} features",
+                        labels.len()
+                    );
+                }
+                for (g, &lab) in labels.iter().enumerate() {
+                    if lab as usize >= m {
+                        candle_util::candle_core::bail!(
+                            "new_with_modules: warm-start label {lab} for feature {g} is not \
+                             below the module count {m}"
+                        );
+                    }
+                    logits_host[(g, lab as usize)] = kappa;
+                }
+            }
+        }
+        let logits = register_var_from_mat(varmap, dev, MODULE_LOGITS_VAR_NAME, &logits_host)?;
+        let mu = register_randn_seeded(varmap, dev, MODULE_MU_VAR_NAME, m, h, args.seed)?;
+        let residual = register_var_from_mat(
+            varmap,
+            dev,
+            MODULE_RESIDUAL_VAR_NAME,
+            &nalgebra::DMatrix::<f32>::zeros(d, h),
+        )?;
+        let b_module = register_var_from_slice(varmap, dev, MODULE_BIAS_VAR_NAME, &vec![0f32; m])?;
+        let e_cell = register_randn_seeded(varmap, dev, "e_cell", args.n_cells, h, args.seed)?;
+        let b_feat = register_var_from_slice(varmap, dev, "b_feat", args.b_feat)?;
+        let b_cell = register_var_from_slice(varmap, dev, "b_cell", args.b_cell)?;
+
+        let modules = FeatModules {
+            logits,
+            mu,
+            residual,
+            b_module,
+            n_modules: m,
+            frozen: Arc::new(AtomicBool::new(false)),
+        };
+        let e_feat = modules.compose()?.detach();
+        Ok(Self {
+            e_feat,
+            e_cell,
+            b_feat,
+            b_cell,
+            factor: None,
+            adapter: None,
+            modules: Some(modules),
+            embedding_dim: h,
+            s_feat: None,
+            e_feat_raw: None,
+            e_feat_logstd: None,
+            gate_pip: None,
+            gate_mask: Arc::new(std::sync::Mutex::new(None)),
+            gate_ibp_bias: None,
+            gate: None,
+        })
+    }
+
+    /// The membership `π` as a detached `[n_features, M]` table for output — the
+    /// mean parameter, never a frozen view. `None` without modules.
+    pub fn module_membership(&self) -> Result<Option<Tensor>> {
+        self.modules
+            .as_ref()
+            .map(|m| sparsemax(&m.logits)?.detach().contiguous())
+            .transpose()
+    }
+}

--- a/graph-embedding-util/src/model/tests.rs
+++ b/graph-embedding-util/src/model/tests.rs
@@ -685,6 +685,7 @@ fn a_sharing_head_still_has_a_gate_kl() {
             shared_e_feat_logstd: m.e_feat_logstd.clone(),
             shared_gate_ibp_bias: m.gate_ibp_bias.clone(),
             gate: m.gate,
+            shared_modules: None,
         },
         &vm,
         &dev(),

--- a/graph-embedding-util/src/training.rs
+++ b/graph-embedding-util/src/training.rs
@@ -693,7 +693,9 @@ struct AxisModuleStep<'a> {
 /// The exact module term for one axis step: draw `units_per_step` units from the
 /// axis's own picker (the same `degree^α` weighting the positives use, so the two
 /// levels weight units alike), pool their count rows through the (dropout-masked)
-/// membership, and score every module with a full softmax.
+/// membership, and score every module with a full softmax. The pooled target is
+/// detached inside the loss, so this term trains `μ`, the module bias and the
+/// cell side; the membership trains through the within-module NCE and the priors.
 fn module_term(
     axis: &CompositeAxis,
     cc: &data_beans_alg::feature_coarsening::FeatureCoarsening,

--- a/graph-embedding-util/src/training.rs
+++ b/graph-embedding-util/src/training.rs
@@ -18,11 +18,11 @@ use crate::coarsen::AxisCoarsenings;
 use crate::data::UnifiedData;
 use crate::fit::lineage::PbLineageLevel;
 use crate::loss::{
-    dense_count_block, draw_gene_keep_mask, masked_membership, membership_diagnostics,
-    membership_rows_host, module_balance_prior, module_row_entropy, module_softmax_loss, nce_loss,
-    nce_loss_identity, pool_module_counts, sample_per_batch_stratified_edge_batch,
-    sample_stratified_edge_batch, EdgeBatch, ModulePools, PerBatchStratifiedCellSampler,
-    PerBatchStratifiedEdgeBatchArgs, StratifiedEdgeBatchArgs, StratifiedSampler,
+    dense_count_block, draw_gene_keep_mask, log_membership_diagnostics, masked_membership,
+    membership_rows_host, module_priors, module_step_loss, nce_loss, nce_loss_identity,
+    sample_per_batch_stratified_edge_batch, sample_stratified_edge_batch, EdgeBatch, ModulePools,
+    PerBatchStratifiedCellSampler, PerBatchStratifiedEdgeBatchArgs, StratifiedEdgeBatchArgs,
+    StratifiedSampler,
 };
 use crate::model::{FeatModules, JointEmbedModel, GATE_KL_REF_UNITS, GATE_KL_STEP_WEIGHT};
 use crate::progress::new_progress_bar;
@@ -31,6 +31,7 @@ use candle_util::candle_nn::AdamW;
 use log::info;
 use rand::{rngs::StdRng, RngExt, SeedableRng};
 use rand_distr::Distribution;
+use rayon::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -111,13 +112,12 @@ pub struct ModuleTrainParams {
     pub units_per_step: usize,
     pub lambda_module: f32,
     pub lambda_balance: f32,
-    pub lambda_entropy: f32,
     pub residual_l2: f32,
 }
 
 /// Per-run state of the module layer that lives with the training loop rather
 /// than the model: the host-side negative pools per axis and sampler, refreshed
-/// from the membership once per epoch, and the fallback tally.
+/// from the membership once per epoch.
 struct ModuleState<'a> {
     modules: &'a FeatModules,
     params: &'a ModuleTrainParams,
@@ -125,8 +125,6 @@ struct ModuleState<'a> {
     pools: Vec<Vec<ModulePools>>,
     /// The host copy of `π` the pools were built from; also feeds the diagnostics.
     pi_host: Vec<f32>,
-    n_features: usize,
-    n_fallback: usize,
 }
 
 impl<'a> ModuleState<'a> {
@@ -135,14 +133,11 @@ impl<'a> ModuleState<'a> {
         params: &'a ModuleTrainParams,
         ctx: &CompositeTrainContext,
     ) -> anyhow::Result<Self> {
-        let n_features = modules.logits.dim(0)?;
         let mut st = Self {
             modules,
             params,
             pools: Vec::new(),
             pi_host: Vec::new(),
-            n_features,
-            n_fallback: 0,
         };
         st.refresh(ctx)?;
         Ok(st)
@@ -152,10 +147,11 @@ impl<'a> ModuleState<'a> {
     fn refresh(&mut self, ctx: &CompositeTrainContext) -> anyhow::Result<()> {
         let pi = candle_util::nn::sparsemax(&self.modules.logits.detach())?;
         self.pi_host = pi.flatten_all()?.to_vec1::<f32>()?;
-        let rows = membership_rows_host(&self.pi_host, self.n_features, self.modules.n_modules);
+        let n_features = self.modules.logits.dim(0)?;
+        let rows = membership_rows_host(&self.pi_host, n_features, self.modules.n_modules);
         self.pools = ctx
             .axes
-            .iter()
+            .par_iter()
             .map(|axis| {
                 axis.sampler
                     .feature_pools()
@@ -167,57 +163,17 @@ impl<'a> ModuleState<'a> {
         Ok(())
     }
 
-    /// One `info` line per epoch on the membership: occupancy, dead modules, row
-    /// entropy and support, the residual's share of the row norm, and how many
-    /// positives fell back to global negatives. Collapse shows up here long before
-    /// it shows up in the loss.
-    fn log_diagnostics(&mut self, epoch: usize, epochs: usize) -> anyhow::Result<()> {
-        let m = self.modules.n_modules;
-        let dg = membership_diagnostics(&self.pi_host, self.n_features, m, MODULE_SMALL_FLOOR);
-        let r2: f32 = self
-            .modules
-            .residual
-            .detach()
-            .sqr()?
-            .sum(1)?
-            .mean_all()?
-            .to_scalar()?;
-        let rho2: f32 = self
-            .modules
-            .compose()?
-            .detach()
-            .sqr()?
-            .sum(1)?
-            .mean_all()?
-            .to_scalar()?;
-        info!(
-            "epoch {}/{} modules{}: max occupancy {:.2}x uniform, {} of {} modules below {} \
-             features, row entropy {:.3} nats, {:.2} modules/feature, mean ‖r‖² {:.3} vs \
-             ‖ρ‖² {:.3}, {} positives fell back to global negatives",
-            epoch + 1,
-            epochs,
-            if self.modules.is_frozen() {
-                " (frozen)"
-            } else {
-                ""
-            },
-            dg.max_occupancy_ratio,
-            dg.n_small_modules,
-            m,
-            MODULE_SMALL_FLOOR,
-            dg.mean_row_entropy,
-            dg.mean_row_support,
-            r2,
-            rho2,
-            self.n_fallback,
-        );
-        self.n_fallback = 0;
+    fn log_diagnostics(&self, epoch: usize, epochs: usize) -> anyhow::Result<()> {
+        let fallbacks: usize = self
+            .pools
+            .iter()
+            .flatten()
+            .map(ModulePools::take_fallbacks)
+            .sum();
+        log_membership_diagnostics(self.modules, &self.pi_host, epoch, epochs, fallbacks)?;
         Ok(())
     }
 }
-
-/// A module with fewer argmax features than this is reported as small.
-const MODULE_SMALL_FLOOR: usize = 5;
 
 #[derive(Clone)]
 pub struct TrainingParams {
@@ -489,7 +445,7 @@ pub fn train_composite(
         let mut n_steps = 0usize;
 
         for _ in 0..batches_per_epoch {
-            let loss = sum_step(ctx, &mut rng, params, module_state.as_mut())?;
+            let loss = sum_step(ctx, &mut rng, params, module_state.as_ref())?;
             let Some(mut loss) = loss else { continue };
             if ridge_lambda > 0.0 {
                 // `λ · mean_g ‖e_g‖²` on whichever per-row table this parameterization
@@ -630,52 +586,51 @@ fn sum_step(
     ctx: &CompositeTrainContext,
     rng: &mut StdRng,
     params: &TrainingParams,
-    mut module_state: Option<&mut ModuleState>,
+    module_state: Option<&ModuleState>,
 ) -> anyhow::Result<Option<Tensor>> {
-    // The full membership once per step: every axis's exact term and the priors
-    // read the same `π`, and it is detached while frozen.
-    let pi: Option<Tensor> = match &module_state {
-        Some(st) => Some(st.modules.membership()?),
+    // The module layer's per-step tensors, once for every axis: the live
+    // membership (detached while frozen), and — when dropout is on — one keep mask
+    // and its renormalized membership, shared so every axis pools under the same
+    // hidden genes this step.
+    let per_step: Option<(Tensor, Tensor)> = match module_state {
+        Some(st) => {
+            let pi = st.modules.membership()?;
+            let pi_masked = if st.params.gene_dropout > 0.0 {
+                let n_features = pi.dim(0)?;
+                let keep = draw_gene_keep_mask(n_features, st.params.gene_dropout, rng, ctx.dev)?;
+                masked_membership(&pi, &keep)?
+            } else {
+                pi.detach()
+            };
+            Some((pi, pi_masked))
+        }
         None => None,
     };
     let mut total_loss: Option<Tensor> = None;
     for (axis_idx, axis) in ctx.axes.iter().enumerate() {
-        let step_modules = match (&module_state, &pi) {
-            (Some(st), Some(pi)) => Some(AxisModuleStep {
+        let step_modules = match (module_state, &per_step) {
+            (Some(st), Some((_, pi_masked))) => Some(AxisModuleStep {
+                modules: st.modules,
                 params: st.params,
                 pools: &st.pools[axis_idx],
-                pi,
+                pi_masked,
             }),
             _ => None,
         };
-        let Some((loss, n_fallback)) =
-            single_axis_step(axis, rng, params, ctx.dev, step_modules.as_ref())?
+        let Some(loss) = single_axis_step(axis, rng, params, ctx.dev, step_modules.as_ref())?
         else {
             continue;
         };
-        if let Some(st) = module_state.as_deref_mut() {
-            st.n_fallback += n_fallback;
-        }
         let scaled = (loss * f64::from(axis.lambda))?;
         total_loss = Some(match total_loss {
             Some(prev) => (prev + scaled)?,
             None => scaled,
         });
     }
-    // Membership priors, once per step (not per axis), and only once the
-    // membership trains — while frozen `π` is detached and they would be constants.
-    if let (Some(st), Some(pi), Some(loss)) = (&module_state, &pi, total_loss.as_mut()) {
-        if !st.modules.is_frozen() {
-            if st.params.lambda_balance > 0.0 {
-                let bal =
-                    module_balance_prior(pi)?.affine(f64::from(st.params.lambda_balance), 0.0)?;
-                *loss = (&*loss + bal)?;
-            }
-            if st.params.lambda_entropy > 0.0 {
-                let ent =
-                    module_row_entropy(pi)?.affine(f64::from(st.params.lambda_entropy), 0.0)?;
-                *loss = (&*loss + ent)?;
-            }
+    // Membership priors, once per step (not per axis); `None` while frozen.
+    if let (Some(st), Some((pi, _)), Some(loss)) = (module_state, &per_step, total_loss.as_mut()) {
+        if let Some(prior) = module_priors(st.modules, pi, st.params.lambda_balance)? {
+            *loss = (&*loss + prior)?;
         }
     }
     Ok(total_loss)
@@ -683,16 +638,17 @@ fn sum_step(
 
 /// What one axis step needs from the module layer.
 struct AxisModuleStep<'a> {
+    modules: &'a FeatModules,
     params: &'a ModuleTrainParams,
     /// This axis's pools, one per sampler.
     pools: &'a [ModulePools],
-    /// The full live membership for this step.
-    pi: &'a Tensor,
+    /// This step's (dropout-masked, detached) membership `[D, M]`.
+    pi_masked: &'a Tensor,
 }
 
 /// The exact module term for one axis step: draw `units_per_step` units from the
 /// axis's own picker (the same `degree^α` weighting the positives use, so the two
-/// levels weight units alike), pool their count rows through the (dropout-masked)
+/// levels weight units alike), pool their count rows through the masked
 /// membership, and score every module with a full softmax. The pooled target is
 /// detached inside the loss, so this term trains `μ`, the module bias and the
 /// cell side; the membership trains through the within-module NCE and the priors.
@@ -730,42 +686,32 @@ fn module_term(
         }
     }
     let x = dense_count_block(&rows, n_features, dev)?;
-    // Gene dropout on the membership side: a hidden feature's row is exactly zero
-    // and its modules' survivors are scaled up to keep the module's mass.
-    let pi_masked = if step.params.gene_dropout > 0.0 {
-        let keep = draw_gene_keep_mask(n_features, step.params.gene_dropout, rng, dev)?;
-        masked_membership(step.pi, &keep)?
-    } else {
-        step.pi.clone()
-    };
-    let x_cm = pool_module_counts(&x, &pi_masked)?;
     let e_units = if axis.cell_axis.is_identity {
         let idx = Tensor::from_vec(coarse, u, dev)?;
         axis.model.e_cell.index_select(&idx, 0)?
     } else {
         axis.model.pool_cells(&coarse, &cc.coarse_to_fine, dev)?.0
     };
-    let m = axis
-        .model
-        .modules
-        .as_ref()
-        .expect("module step on a model without modules");
-    let term = module_softmax_loss(&e_units, &m.mu, &m.b_module, &x_cm)?;
-    Ok(Some(
-        term.affine(f64::from(step.params.lambda_module), 0.0)?,
-    ))
+    Ok(Some(module_step_loss(
+        step.modules,
+        step.pi_masked,
+        &x,
+        &e_units,
+        step.params.lambda_module,
+    )?))
 }
 
 /// Sample a minibatch from a single axis and compute its bipartite NCE
 /// loss (taking the identity fast path when the axis has identity
-/// coarsening). Returns `None` when the axis has no positives to sample.
+/// coarsening), plus the exact module term when the model has modules.
+/// Returns `None` when the axis has no positives to sample.
 fn single_axis_step(
     axis: &CompositeAxis,
     rng: &mut StdRng,
     params: &TrainingParams,
     dev: &Device,
     modules: Option<&AxisModuleStep>,
-) -> anyhow::Result<Option<(Tensor, usize)>> {
+) -> anyhow::Result<Option<Tensor>> {
     if axis.sampler.is_empty() {
         return Ok(None);
     }
@@ -805,7 +751,6 @@ fn single_axis_step(
             rng,
         ),
     };
-    let n_fallback = batch.n_module_fallback;
 
     let mut loss = if axis.cell_axis.is_identity {
         nce_loss_identity(axis.model, batch, params.objective, dev)?
@@ -817,7 +762,7 @@ fn single_axis_step(
             loss = (loss + term)?;
         }
     }
-    Ok(Some((loss, n_fallback)))
+    Ok(Some(loss))
 }
 
 #[cfg(test)]

--- a/graph-embedding-util/src/training.rs
+++ b/graph-embedding-util/src/training.rs
@@ -18,16 +18,19 @@ use crate::coarsen::AxisCoarsenings;
 use crate::data::UnifiedData;
 use crate::fit::lineage::PbLineageLevel;
 use crate::loss::{
-    nce_loss, nce_loss_identity, sample_per_batch_stratified_edge_batch,
-    sample_stratified_edge_batch, EdgeBatch, PerBatchStratifiedCellSampler,
+    dense_count_block, draw_gene_keep_mask, masked_membership, membership_diagnostics,
+    membership_rows_host, module_balance_prior, module_row_entropy, module_softmax_loss, nce_loss,
+    nce_loss_identity, pool_module_counts, sample_per_batch_stratified_edge_batch,
+    sample_stratified_edge_batch, EdgeBatch, ModulePools, PerBatchStratifiedCellSampler,
     PerBatchStratifiedEdgeBatchArgs, StratifiedEdgeBatchArgs, StratifiedSampler,
 };
-use crate::model::{JointEmbedModel, GATE_KL_REF_UNITS, GATE_KL_STEP_WEIGHT};
+use crate::model::{FeatModules, JointEmbedModel, GATE_KL_REF_UNITS, GATE_KL_STEP_WEIGHT};
 use crate::progress::new_progress_bar;
 use candle_util::candle_core::{Device, Tensor};
 use candle_util::candle_nn::AdamW;
 use log::info;
 use rand::{rngs::StdRng, RngExt, SeedableRng};
+use rand_distr::Distribution;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -87,7 +90,134 @@ impl AxisSampler<'_> {
             Self::Stratified(s) => s.active_pbs.len(),
         }
     }
+
+    /// One expressed-feature pool per sampler on this axis, in sampler order — the
+    /// index the within-module negative pools are keyed by.
+    fn feature_pools(&self) -> Vec<&[u32]> {
+        match self {
+            Self::PerBatchStratified(s) => s.iter().map(|x| x.feature_pool.as_slice()).collect(),
+            Self::Stratified(s) => vec![s.feature_pool.as_slice()],
+        }
+    }
 }
+
+/// Training-side knobs of the learned gene modules (see
+/// [`crate::fit::GeneModuleConfig`] for the caller-facing form and the meaning of
+/// each field). `Some` only for a module-parameterized model.
+#[derive(Clone, Debug)]
+pub struct ModuleTrainParams {
+    pub warmup_epochs: usize,
+    pub gene_dropout: f32,
+    pub units_per_step: usize,
+    pub lambda_module: f32,
+    pub lambda_balance: f32,
+    pub lambda_entropy: f32,
+    pub residual_l2: f32,
+}
+
+/// Per-run state of the module layer that lives with the training loop rather
+/// than the model: the host-side negative pools per axis and sampler, refreshed
+/// from the membership once per epoch, and the fallback tally.
+struct ModuleState<'a> {
+    modules: &'a FeatModules,
+    params: &'a ModuleTrainParams,
+    /// `pools[axis][sampler]`.
+    pools: Vec<Vec<ModulePools>>,
+    /// The host copy of `π` the pools were built from; also feeds the diagnostics.
+    pi_host: Vec<f32>,
+    n_features: usize,
+    n_fallback: usize,
+}
+
+impl<'a> ModuleState<'a> {
+    fn new(
+        modules: &'a FeatModules,
+        params: &'a ModuleTrainParams,
+        ctx: &CompositeTrainContext,
+    ) -> anyhow::Result<Self> {
+        let n_features = modules.logits.dim(0)?;
+        let mut st = Self {
+            modules,
+            params,
+            pools: Vec::new(),
+            pi_host: Vec::new(),
+            n_features,
+            n_fallback: 0,
+        };
+        st.refresh(ctx)?;
+        Ok(st)
+    }
+
+    /// Rebuild the pools from the current membership (one device→host copy).
+    fn refresh(&mut self, ctx: &CompositeTrainContext) -> anyhow::Result<()> {
+        let pi = candle_util::nn::sparsemax(&self.modules.logits.detach())?;
+        self.pi_host = pi.flatten_all()?.to_vec1::<f32>()?;
+        let rows = membership_rows_host(&self.pi_host, self.n_features, self.modules.n_modules);
+        self.pools = ctx
+            .axes
+            .iter()
+            .map(|axis| {
+                axis.sampler
+                    .feature_pools()
+                    .into_iter()
+                    .map(|pool| ModulePools::build(rows.clone(), self.modules.n_modules, pool))
+                    .collect()
+            })
+            .collect();
+        Ok(())
+    }
+
+    /// One `info` line per epoch on the membership: occupancy, dead modules, row
+    /// entropy and support, the residual's share of the row norm, and how many
+    /// positives fell back to global negatives. Collapse shows up here long before
+    /// it shows up in the loss.
+    fn log_diagnostics(&mut self, epoch: usize, epochs: usize) -> anyhow::Result<()> {
+        let m = self.modules.n_modules;
+        let dg = membership_diagnostics(&self.pi_host, self.n_features, m, MODULE_SMALL_FLOOR);
+        let r2: f32 = self
+            .modules
+            .residual
+            .detach()
+            .sqr()?
+            .sum(1)?
+            .mean_all()?
+            .to_scalar()?;
+        let rho2: f32 = self
+            .modules
+            .compose()?
+            .detach()
+            .sqr()?
+            .sum(1)?
+            .mean_all()?
+            .to_scalar()?;
+        info!(
+            "epoch {}/{} modules{}: max occupancy {:.2}x uniform, {} of {} modules below {} \
+             features, row entropy {:.3} nats, {:.2} modules/feature, mean ‖r‖² {:.3} vs \
+             ‖ρ‖² {:.3}, {} positives fell back to global negatives",
+            epoch + 1,
+            epochs,
+            if self.modules.is_frozen() {
+                " (frozen)"
+            } else {
+                ""
+            },
+            dg.max_occupancy_ratio,
+            dg.n_small_modules,
+            m,
+            MODULE_SMALL_FLOOR,
+            dg.mean_row_entropy,
+            dg.mean_row_support,
+            r2,
+            rho2,
+            self.n_fallback,
+        );
+        self.n_fallback = 0;
+        Ok(())
+    }
+}
+
+/// A module with fewer argmax features than this is reported as small.
+const MODULE_SMALL_FLOOR: usize = 5;
 
 #[derive(Clone)]
 pub struct TrainingParams {
@@ -123,6 +253,8 @@ pub struct TrainingParams {
     /// loss — a dense prior that fits the (dense) per-gene γ structure and is
     /// well-behaved under AdamW. `0.0` disables (plain β-sharing, no `δ_g`).
     pub delta_l2: f32,
+    /// Learned-module training knobs; `Some` iff the model is module-parameterized.
+    pub module: Option<ModuleTrainParams>,
 }
 
 pub struct CompositeTrainContext<'a> {
@@ -235,9 +367,28 @@ pub fn train_composite(
     let mut rng = StdRng::seed_from_u64(params.seed);
     let mut last_avg = 0f32; // final-epoch mean loss, returned as the fit-hygiene signal
 
-    // `--feature-embedding-l2` penalizes the *shared* E_feat — pull it from the
-    // first axis (every axis points at the same tensor).
-    let shared_e_feat = ctx.axes[0].model.e_feat.clone();
+    // The module layer, when the model has one: hold the warm-start membership for
+    // the warm-up, build the within-module negative pools, and pick the ridge that
+    // applies (the residual is the module model's only per-row table).
+    let mut module_state = match (ctx.axes[0].model.modules.as_ref(), params.module.as_ref()) {
+        (Some(m), Some(p)) => {
+            m.set_frozen(p.warmup_epochs > 0);
+            info!(
+                "gene modules: membership held for {} of {} epochs, then trained; {} units per \
+                 step per axis pooled for the exact module term, gene dropout {}",
+                p.warmup_epochs, params.epochs, p.units_per_step, p.gene_dropout
+            );
+            Some(ModuleState::new(m, p, ctx)?)
+        }
+        (Some(_), None) => {
+            anyhow::bail!("a module-parameterized model needs `TrainingParams::module`; got None")
+        }
+        _ => None,
+    };
+    let ridge_lambda = match &module_state {
+        Some(st) => st.params.residual_l2,
+        None => params.feature_embedding_l2,
+    };
 
     // Shared per-gene splice offset δ_g (factored splice models), for the L2 (ridge)
     // penalty below. `None` for free / plain-β-sharing models.
@@ -270,7 +421,7 @@ pub fn train_composite(
                 |n| {
                     let mut probe_params = params.clone();
                     probe_params.batch_size = n;
-                    match sum_step(ctx, &mut probe_rng, &probe_params) {
+                    match sum_step(ctx, &mut probe_rng, &probe_params, None) {
                         Ok(Some(loss)) => Ok(loss),
                         Ok(None) => Err(candle_util::candle_core::Error::Msg(
                             "probe sampled nothing".into(),
@@ -316,6 +467,20 @@ pub fn train_composite(
         // draw would model it as if each minibatch had its own inclusion state and would
         // add gradient variance for nothing. No-op unless a `gate_pip` is installed.
         ctx.axes[0].model.resample_gate_mask()?;
+        // Release the membership once the warm-up is over. Pools are refreshed at the
+        // END of each epoch below, so the first trained epoch still contrasts within
+        // the warm-start modules — one epoch of lag, the same as the gate mask.
+        if let Some(st) = &module_state {
+            if epoch == st.params.warmup_epochs && st.modules.is_frozen() {
+                st.modules.set_frozen(false);
+                info!(
+                    "epoch {}/{}: module membership released — π now trains with the exact \
+                     module term and the balance prior",
+                    epoch + 1,
+                    params.epochs
+                );
+            }
+        }
         // Loss kept **on-device** and synced to a scalar once per epoch (not
         // per minibatch) — `detach()` keeps the running sum off the autograd
         // graph so each step's forward graph is still freed immediately,
@@ -324,16 +489,17 @@ pub fn train_composite(
         let mut n_steps = 0usize;
 
         for _ in 0..batches_per_epoch {
-            let loss = sum_step(ctx, &mut rng, params)?;
+            let loss = sum_step(ctx, &mut rng, params, module_state.as_mut())?;
             let Some(mut loss) = loss else { continue };
-            if params.feature_embedding_l2 > 0.0 {
-                // `λ · mean_g ‖e_g‖²` — see `loss::embedding_ridge` for why the
-                // reduction sums over the latent axis instead of averaging over it.
-                let l2 = crate::loss::embedding_ridge(
-                    &shared_e_feat,
-                    f64::from(params.feature_embedding_l2),
-                )?;
-                loss = (loss + l2)?;
+            if ridge_lambda > 0.0 {
+                // `λ · mean_g ‖e_g‖²` on whichever per-row table this parameterization
+                // trains — see `loss::embedding_ridge` for the reduction, and
+                // `JointEmbedModel::feature_ridge` for why the model picks the table:
+                // ridging `e_feat` directly is silently inert on a model where that
+                // field is a detached snapshot.
+                if let Some(l2) = ctx.axes[0].model.feature_ridge(f64::from(ridge_lambda))? {
+                    loss = (loss + l2)?;
+                }
             }
             // SuSiE single-effect KL on the gate (identity + velocity): the fixed
             // `GATE_KL_WEIGHT · (categorical + Gaussian) KL`. `None` when the gate is
@@ -413,6 +579,14 @@ pub fn train_composite(
         last_avg = avg;
         prog_bar.set_message(format!("loss={avg:.3}"));
         prog_bar.inc(1);
+        if let Some(st) = &mut module_state {
+            // The membership moves only once released; the pools and the host copy
+            // stay valid until then.
+            if !st.modules.is_frozen() {
+                st.refresh(ctx)?;
+            }
+            st.log_diagnostics(epoch, params.epochs)?;
+        }
         // Every-epoch info; senna/pinto's `--verbose` flag raises the
         // log level to `info`, so this is gated by the user's choice
         // there. Quiet runs (warn level) suppress it.
@@ -456,19 +630,128 @@ fn sum_step(
     ctx: &CompositeTrainContext,
     rng: &mut StdRng,
     params: &TrainingParams,
+    mut module_state: Option<&mut ModuleState>,
 ) -> anyhow::Result<Option<Tensor>> {
+    // The full membership once per step: every axis's exact term and the priors
+    // read the same `π`, and it is detached while frozen.
+    let pi: Option<Tensor> = match &module_state {
+        Some(st) => Some(st.modules.membership()?),
+        None => None,
+    };
     let mut total_loss: Option<Tensor> = None;
-    for axis in ctx.axes {
-        let Some(loss) = single_axis_step(axis, rng, params, ctx.dev)? else {
+    for (axis_idx, axis) in ctx.axes.iter().enumerate() {
+        let step_modules = match (&module_state, &pi) {
+            (Some(st), Some(pi)) => Some(AxisModuleStep {
+                params: st.params,
+                pools: &st.pools[axis_idx],
+                pi,
+            }),
+            _ => None,
+        };
+        let Some((loss, n_fallback)) =
+            single_axis_step(axis, rng, params, ctx.dev, step_modules.as_ref())?
+        else {
             continue;
         };
+        if let Some(st) = module_state.as_deref_mut() {
+            st.n_fallback += n_fallback;
+        }
         let scaled = (loss * f64::from(axis.lambda))?;
         total_loss = Some(match total_loss {
             Some(prev) => (prev + scaled)?,
             None => scaled,
         });
     }
+    // Membership priors, once per step (not per axis), and only once the
+    // membership trains — while frozen `π` is detached and they would be constants.
+    if let (Some(st), Some(pi), Some(loss)) = (&module_state, &pi, total_loss.as_mut()) {
+        if !st.modules.is_frozen() {
+            if st.params.lambda_balance > 0.0 {
+                let bal =
+                    module_balance_prior(pi)?.affine(f64::from(st.params.lambda_balance), 0.0)?;
+                *loss = (&*loss + bal)?;
+            }
+            if st.params.lambda_entropy > 0.0 {
+                let ent =
+                    module_row_entropy(pi)?.affine(f64::from(st.params.lambda_entropy), 0.0)?;
+                *loss = (&*loss + ent)?;
+            }
+        }
+    }
     Ok(total_loss)
+}
+
+/// What one axis step needs from the module layer.
+struct AxisModuleStep<'a> {
+    params: &'a ModuleTrainParams,
+    /// This axis's pools, one per sampler.
+    pools: &'a [ModulePools],
+    /// The full live membership for this step.
+    pi: &'a Tensor,
+}
+
+/// The exact module term for one axis step: draw `units_per_step` units from the
+/// axis's own picker (the same `degree^α` weighting the positives use, so the two
+/// levels weight units alike), pool their count rows through the (dropout-masked)
+/// membership, and score every module with a full softmax.
+fn module_term(
+    axis: &CompositeAxis,
+    cc: &data_beans_alg::feature_coarsening::FeatureCoarsening,
+    rng: &mut StdRng,
+    step: &AxisModuleStep,
+    dev: &Device,
+) -> anyhow::Result<Option<Tensor>> {
+    let u = step.params.units_per_step;
+    if u == 0 || step.params.lambda_module <= 0.0 {
+        return Ok(None);
+    }
+    let n_features = axis.unified.n_features();
+    let mut rows: Vec<(&[u32], &[f32])> = Vec::with_capacity(u);
+    let mut coarse: Vec<u32> = Vec::with_capacity(u);
+    match axis.sampler {
+        AxisSampler::PerBatchStratified(samplers) => {
+            let s = &samplers[rng.random_range(0..samplers.len())];
+            for _ in 0..u {
+                let lc = s.cell_picker.sample(rng);
+                let pf = &s.per_cell[lc];
+                rows.push((&pf.features, &pf.counts));
+                coarse.push(cc.fine_to_coarse[s.active_cells[lc] as usize] as u32);
+            }
+        }
+        AxisSampler::Stratified(s) => {
+            for _ in 0..u {
+                let lp = s.pb_picker.sample(rng);
+                let pf = &s.per_pb[lp];
+                rows.push((&pf.features, &pf.counts));
+                coarse.push(s.active_pbs[lp]);
+            }
+        }
+    }
+    let x = dense_count_block(&rows, n_features, dev)?;
+    // Gene dropout on the membership side: a hidden feature's row is exactly zero
+    // and its modules' survivors are scaled up to keep the module's mass.
+    let pi_masked = if step.params.gene_dropout > 0.0 {
+        let keep = draw_gene_keep_mask(n_features, step.params.gene_dropout, rng, dev)?;
+        masked_membership(step.pi, &keep)?
+    } else {
+        step.pi.clone()
+    };
+    let x_cm = pool_module_counts(&x, &pi_masked)?;
+    let e_units = if axis.cell_axis.is_identity {
+        let idx = Tensor::from_vec(coarse, u, dev)?;
+        axis.model.e_cell.index_select(&idx, 0)?
+    } else {
+        axis.model.pool_cells(&coarse, &cc.coarse_to_fine, dev)?.0
+    };
+    let m = axis
+        .model
+        .modules
+        .as_ref()
+        .expect("module step on a model without modules");
+    let term = module_softmax_loss(&e_units, &m.mu, &m.b_module, &x_cm)?;
+    Ok(Some(
+        term.affine(f64::from(step.params.lambda_module), 0.0)?,
+    ))
 }
 
 /// Sample a minibatch from a single axis and compute its bipartite NCE
@@ -479,7 +762,8 @@ fn single_axis_step(
     rng: &mut StdRng,
     params: &TrainingParams,
     dev: &Device,
-) -> anyhow::Result<Option<Tensor>> {
+    modules: Option<&AxisModuleStep>,
+) -> anyhow::Result<Option<(Tensor, usize)>> {
     if axis.sampler.is_empty() {
         return Ok(None);
     }
@@ -504,6 +788,7 @@ fn single_axis_step(
                     cell_coarsening: cc,
                     batch_size: params.batch_size,
                     n_negatives: params.num_negatives,
+                    module_pools: modules.map(|m| &m.pools[id]),
                 },
                 rng,
             )
@@ -513,17 +798,24 @@ fn single_axis_step(
                 sampler: s,
                 batch_size: params.batch_size,
                 n_negatives: params.num_negatives,
+                module_pools: modules.map(|m| &m.pools[0]),
             },
             rng,
         ),
     };
+    let n_fallback = batch.n_module_fallback;
 
-    let bip_loss = if axis.cell_axis.is_identity {
+    let mut loss = if axis.cell_axis.is_identity {
         nce_loss_identity(axis.model, batch, params.objective, dev)?
     } else {
         nce_loss(axis.model, batch, &cc.coarse_to_fine, params.objective, dev)?
     };
-    Ok(Some(bip_loss))
+    if let Some(step) = modules {
+        if let Some(term) = module_term(axis, cc, rng, step, dev)? {
+            loss = (loss + term)?;
+        }
+    }
+    Ok(Some((loss, n_fallback)))
 }
 
 #[cfg(test)]

--- a/graph-embedding-util/src/training/tests.rs
+++ b/graph-embedding-util/src/training/tests.rs
@@ -139,6 +139,7 @@ fn batches_per_epoch_resolves_auto_and_explicit() {
     use crate::training::resolve_batches_per_epoch;
 
     let params = |batch_size, batches_per_epoch| TrainingParams {
+        module: None,
         epochs: 1,
         batches_per_epoch,
         batch_size,

--- a/graph-embedding-util/src/transfer.rs
+++ b/graph-embedding-util/src/transfer.rs
@@ -1,0 +1,133 @@
+//! Gene-axis alignment: carrying a trained gene side onto a new dataset's gene
+//! axis with a stated status and provenance per gene.
+//!
+//! Every gene of the UNION of the model's axis and the new data's axis ends up
+//! in exactly one of four states:
+//!
+//! * `Matched` — in both; the trained row, bias and membership verbatim.
+//! * `Missing` — in the model, absent from the data; the trained row is kept
+//!   (it stays in the partition and its rate can be predicted), nothing is
+//!   observed for it.
+//! * `Initialized` — in the data, absent from the model; a row placed by
+//!   membership: `π̂_g` is the similarity-weighted mean of the membership rows
+//!   of the `k` matched genes whose count profiles are closest, `ρ̂_g = π̂_g μ`,
+//!   and the bias is set later by moment matching against pass-1 latents.
+//! * `Dropped` — in the data, absent from the model, and no way to place it
+//!   (no profiles were given, or the model has neither modules nor a usable
+//!   neighbour).
+//!
+//! Pure functions over matrices: no names, no manifests, no files. The caller
+//! owns name matching (`new_to_train`), the profile matrix, and where the
+//! alignment is written. An initialized row is a PRIOR, never a measurement,
+//! and the provenance carried here is what lets every consumer say so.
+
+use nalgebra::DMatrix;
+
+/// Where a union gene came from and what it carries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GeneStatus {
+    Matched,
+    Missing,
+    Initialized,
+    Dropped,
+}
+
+/// The trained module tables, when the model has them.
+pub struct ModuleTables<'a> {
+    /// `[D_train × M]` membership.
+    pub pi: &'a DMatrix<f32>,
+    /// `[M × H]` module dictionary.
+    pub mu: &'a DMatrix<f32>,
+}
+
+/// Inputs to [`align_gene_axis`].
+pub struct AlignInputs<'a> {
+    /// Trained composed rows `[D_train × H]`.
+    pub rho: &'a DMatrix<f32>,
+    /// Trained per-gene bias `[D_train]`.
+    pub b_feat: &'a [f32],
+    /// Module tables; `None` for a free model, in which case an unseen gene is
+    /// placed on the similarity-weighted mean of its neighbours' ROWS instead.
+    pub modules: Option<ModuleTables<'a>>,
+    /// For each NEW-data gene, the training row it matched by name, or `None`.
+    pub new_to_train: &'a [Option<usize>],
+    /// Count profiles of the NEW data's genes over its pseudobulks `[G_new × S]`;
+    /// `None` makes every unseen gene `Dropped`.
+    pub profiles_new: Option<&'a DMatrix<f32>>,
+    /// Neighbours used for an initialized gene.
+    pub k: usize,
+    /// Below this best cosine similarity a gene is placed on the module-average
+    /// (or row-average) prior and flagged `diffuse`.
+    pub similarity_floor: f32,
+}
+
+/// How an `Initialized` gene was placed.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Provenance {
+    /// Training rows of the neighbours used, best first. Empty when diffuse.
+    pub neighbours: Vec<usize>,
+    /// Cosine similarity of the best neighbour (`0` when none).
+    pub best_similarity: f32,
+    /// Placed on the average prior because no neighbour reached the floor.
+    pub diffuse: bool,
+}
+
+/// The aligned gene side on the union axis: training genes first, in training
+/// order, then the new-only genes in the new data's order.
+pub struct GeneAlignment {
+    pub rows: DMatrix<f32>,
+    pub bias: Vec<f32>,
+    pub status: Vec<GeneStatus>,
+    /// `[G_union × M]` when the model has modules: trained rows for `Matched` /
+    /// `Missing`, `π̂` for `Initialized`, zeros for `Dropped`.
+    pub membership: Option<DMatrix<f32>>,
+    /// Per union gene; `None` unless `Initialized`.
+    pub provenance: Vec<Option<Provenance>>,
+    /// Union gene → training row.
+    pub union_to_train: Vec<Option<usize>>,
+    /// Union gene → new-data gene.
+    pub union_to_new: Vec<Option<usize>>,
+}
+
+impl GeneAlignment {
+    pub fn n_union(&self) -> usize {
+        self.status.len()
+    }
+
+    /// Union genes with a given status.
+    pub fn with_status(&self, s: GeneStatus) -> Vec<usize> {
+        (0..self.n_union())
+            .filter(|&g| self.status[g] == s)
+            .collect()
+    }
+}
+
+/// Build the alignment. See the module doc for the four states.
+pub fn align_gene_axis(inputs: &AlignInputs) -> GeneAlignment {
+    let _ = inputs;
+    todo!("align_gene_axis")
+}
+
+/// Moment-matched bias for initialized rows: with pass-1 latents `theta [N × H]`
+/// and cell biases `b_cell [N]` fixed, the bias that makes each gene's total
+/// predicted count equal its total observed count,
+///
+/// ```text
+///   â_g = log Σ_c x_cg − log Σ_c exp(ρ̂_g · θ_c + b_c)
+/// ```
+///
+/// `rows` is `[G × H]` (the initialized rows), `observed_total` is `[G]`. A gene
+/// with no observed counts gets `fallback`.
+pub fn moment_matched_bias(
+    rows: &DMatrix<f32>,
+    theta: &DMatrix<f32>,
+    b_cell: &[f32],
+    observed_total: &[f32],
+    fallback: f32,
+) -> Vec<f32> {
+    let _ = (rows, theta, b_cell, observed_total, fallback);
+    todo!("moment_matched_bias")
+}
+
+#[cfg(test)]
+mod tests;

--- a/graph-embedding-util/src/transfer.rs
+++ b/graph-embedding-util/src/transfer.rs
@@ -22,6 +22,7 @@
 //! and the provenance carried here is what lets every consumer say so.
 
 use nalgebra::DMatrix;
+use rayon::prelude::*;
 
 /// Where a union gene came from and what it carries.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -103,9 +104,229 @@ impl GeneAlignment {
 }
 
 /// Build the alignment. See the module doc for the four states.
+///
+/// Initialized genes get bias `0.0` here: the bias is a scale the membership
+/// says nothing about, and [`moment_matched_bias`] sets it once the caller has
+/// pass-1 latents.
 pub fn align_gene_axis(inputs: &AlignInputs) -> GeneAlignment {
-    let _ = inputs;
-    todo!("align_gene_axis")
+    let n_train = inputs.rho.nrows();
+    let h = inputs.rho.ncols();
+    let n_new = inputs.new_to_train.len();
+    assert_eq!(
+        inputs.b_feat.len(),
+        n_train,
+        "b_feat must match the training rows"
+    );
+    let n_modules = inputs.modules.as_ref().map(|m| m.pi.ncols());
+    if let Some(m) = &inputs.modules {
+        assert_eq!(m.pi.nrows(), n_train, "π must match the training rows");
+        assert_eq!(m.mu.ncols(), h, "μ must match the embedding width");
+    }
+
+    // Training row → the new gene that matched it (first wins on a duplicate).
+    let mut train_to_new: Vec<Option<usize>> = vec![None; n_train];
+    for (n, t) in inputs.new_to_train.iter().enumerate() {
+        if let Some(t) = t {
+            assert!(*t < n_train, "new_to_train points past the training axis");
+            if train_to_new[*t].is_none() {
+                train_to_new[*t] = Some(n);
+            }
+        }
+    }
+    let new_only: Vec<usize> = (0..n_new)
+        .filter(|&n| inputs.new_to_train[n].is_none())
+        .collect();
+    let n_union = n_train + new_only.len();
+
+    let mut rows = DMatrix::<f32>::zeros(n_union, h);
+    let mut bias = vec![0f32; n_union];
+    let mut status = vec![GeneStatus::Dropped; n_union];
+    let mut membership = n_modules.map(|m| DMatrix::<f32>::zeros(n_union, m));
+    let mut provenance: Vec<Option<Provenance>> = vec![None; n_union];
+    let mut union_to_train: Vec<Option<usize>> = vec![None; n_union];
+    let mut union_to_new: Vec<Option<usize>> = vec![None; n_union];
+
+    // Training genes: verbatim, matched or missing.
+    for t in 0..n_train {
+        rows.set_row(t, &inputs.rho.row(t));
+        bias[t] = inputs.b_feat[t];
+        if let (Some(pm), Some(m)) = (membership.as_mut(), inputs.modules.as_ref()) {
+            pm.set_row(t, &m.pi.row(t));
+        }
+        union_to_train[t] = Some(t);
+        union_to_new[t] = train_to_new[t];
+        status[t] = if train_to_new[t].is_some() {
+            GeneStatus::Matched
+        } else {
+            GeneStatus::Missing
+        };
+    }
+    for (i, &n) in new_only.iter().enumerate() {
+        union_to_new[n_train + i] = Some(n);
+    }
+    let Some(profiles) = inputs.profiles_new else {
+        return GeneAlignment {
+            rows,
+            bias,
+            status,
+            membership,
+            provenance,
+            union_to_train,
+            union_to_new,
+        };
+    };
+    assert_eq!(
+        profiles.nrows(),
+        n_new,
+        "profiles must match the new gene axis"
+    );
+
+    // Unit-norm, centred log profiles — the same reading of a profile the module
+    // warm start uses, so "similar" means the same thing in both places.
+    let unit = unit_profile_rows(profiles);
+    // The matched genes are the only ones whose membership / row is known.
+    let matched_new: Vec<usize> = (0..n_new)
+        .filter(|&n| inputs.new_to_train[n].is_some())
+        .collect();
+
+    // Average priors for a gene that resembles nothing.
+    let avg_membership: Option<Vec<f32>> = inputs.modules.as_ref().map(|m| {
+        (0..m.pi.ncols())
+            .map(|c| m.pi.column(c).iter().sum::<f32>() / n_train.max(1) as f32)
+            .collect()
+    });
+    let avg_row: Vec<f32> = (0..h)
+        .map(|j| inputs.rho.column(j).iter().sum::<f32>() / n_train.max(1) as f32)
+        .collect();
+
+    let placed: Vec<(Vec<f32>, Option<Vec<f32>>, Provenance)> = new_only
+        .par_iter()
+        .map(|&n| {
+            // Cosine against every matched gene, best first.
+            let q = &unit[n];
+            let mut sims: Vec<(f32, usize)> = matched_new
+                .iter()
+                .map(|&mn| {
+                    let s: f32 = q.iter().zip(&unit[mn]).map(|(a, b)| a * b).sum();
+                    (s, inputs.new_to_train[mn].expect("matched"))
+                })
+                .collect();
+            sims.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+            sims.truncate(inputs.k.max(1));
+            let best = sims.first().map_or(0.0, |s| s.0);
+            let weights: Vec<f32> = sims.iter().map(|s| s.0.max(0.0)).collect();
+            let wsum: f32 = weights.iter().sum();
+            if sims.is_empty() || best < inputs.similarity_floor || wsum <= 0.0 {
+                let row = match (&avg_membership, &inputs.modules) {
+                    (Some(pm), Some(m)) => membership_to_row(pm, m.mu),
+                    _ => avg_row.clone(),
+                };
+                return (
+                    row,
+                    avg_membership.clone(),
+                    Provenance {
+                        neighbours: Vec::new(),
+                        best_similarity: best.max(0.0),
+                        diffuse: true,
+                    },
+                );
+            }
+            let neighbours: Vec<usize> = sims.iter().map(|s| s.1).collect();
+            let (row, pm) = match &inputs.modules {
+                Some(m) => {
+                    let mut pm = vec![0f32; m.pi.ncols()];
+                    for (&w, &t) in weights.iter().zip(&neighbours) {
+                        for (c, v) in pm.iter_mut().enumerate() {
+                            *v += w * m.pi[(t, c)] / wsum;
+                        }
+                    }
+                    (membership_to_row(&pm, m.mu), Some(pm))
+                }
+                None => {
+                    let mut row = vec![0f32; h];
+                    for (&w, &t) in weights.iter().zip(&neighbours) {
+                        for (j, v) in row.iter_mut().enumerate() {
+                            *v += w * inputs.rho[(t, j)] / wsum;
+                        }
+                    }
+                    (row, None)
+                }
+            };
+            (
+                row,
+                pm,
+                Provenance {
+                    neighbours,
+                    best_similarity: best,
+                    diffuse: false,
+                },
+            )
+        })
+        .collect();
+
+    for (i, (row, pm, prov)) in placed.into_iter().enumerate() {
+        let g = n_train + i;
+        for (j, v) in row.iter().enumerate() {
+            rows[(g, j)] = *v;
+        }
+        if let (Some(table), Some(pm)) = (membership.as_mut(), pm) {
+            for (c, v) in pm.iter().enumerate() {
+                table[(g, c)] = *v;
+            }
+        }
+        status[g] = GeneStatus::Initialized;
+        provenance[g] = Some(prov);
+    }
+
+    GeneAlignment {
+        rows,
+        bias,
+        status,
+        membership,
+        provenance,
+        union_to_train,
+        union_to_new,
+    }
+}
+
+/// `π̂ μ` for one membership row.
+fn membership_to_row(pm: &[f32], mu: &DMatrix<f32>) -> Vec<f32> {
+    (0..mu.ncols())
+        .map(|j| pm.iter().enumerate().map(|(m, &w)| w * mu[(m, j)]).sum())
+        .collect()
+}
+
+/// Depth-normalize the pseudobulk columns to a common total, `log1p`, centre
+/// each gene's row and scale it to unit norm, so a dot product is a cosine on
+/// the SHAPE of the profile. A constant row (no shape) becomes the zero vector
+/// and is similar to nothing.
+fn unit_profile_rows(profiles: &DMatrix<f32>) -> Vec<Vec<f32>> {
+    let (d, s) = (profiles.nrows(), profiles.ncols());
+    let col_tot: Vec<f32> = (0..s)
+        .map(|j| profiles.column(j).iter().sum::<f32>().max(1e-8))
+        .collect();
+    let mean_tot = col_tot.iter().sum::<f32>() / s.max(1) as f32;
+    (0..d)
+        .into_par_iter()
+        .map(|i| {
+            let mut r: Vec<f32> = (0..s)
+                .map(|j| (profiles[(i, j)] * mean_tot / col_tot[j]).ln_1p())
+                .collect();
+            let mean = r.iter().sum::<f32>() / s.max(1) as f32;
+            for x in &mut r {
+                *x -= mean;
+            }
+            let norm = r.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if norm > 1e-6 {
+                for x in &mut r {
+                    *x /= norm;
+                }
+            } else {
+                r.fill(0.0);
+            }
+            r
+        })
+        .collect()
 }
 
 /// Moment-matched bias for initialized rows: with pass-1 latents `theta [N × H]`
@@ -125,8 +346,28 @@ pub fn moment_matched_bias(
     observed_total: &[f32],
     fallback: f32,
 ) -> Vec<f32> {
-    let _ = (rows, theta, b_cell, observed_total, fallback);
-    todo!("moment_matched_bias")
+    let (g_n, h) = (rows.nrows(), rows.ncols());
+    let n = theta.nrows();
+    assert_eq!(theta.ncols(), h, "latent width must match the rows");
+    assert_eq!(b_cell.len(), n, "one cell bias per latent row");
+    assert_eq!(observed_total.len(), g_n, "one observed total per row");
+    (0..g_n)
+        .into_par_iter()
+        .map(|g| {
+            let obs = f64::from(observed_total[g]);
+            if obs <= 0.0 {
+                return fallback;
+            }
+            let pred: f64 = (0..n)
+                .map(|c| {
+                    let s: f32 =
+                        (0..h).map(|j| rows[(g, j)] * theta[(c, j)]).sum::<f32>() + b_cell[c];
+                    f64::from(s).exp()
+                })
+                .sum();
+            (obs.ln() - pred.max(1e-300).ln()) as f32
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/graph-embedding-util/src/transfer.rs
+++ b/graph-embedding-util/src/transfer.rs
@@ -16,10 +16,12 @@
 //!   (no profiles were given, or the model has neither modules nor a usable
 //!   neighbour).
 //!
-//! Pure functions over matrices: no names, no manifests, no files. The caller
-//! owns name matching (`new_to_train`), the profile matrix, and where the
-//! alignment is written. An initialized row is a PRIOR, never a measurement,
-//! and the provenance carried here is what lets every consumer say so.
+//! Pure functions over matrices: no names, no manifests, no files (except the
+//! two small table helpers at the end, which every consumer needs identically).
+//! The caller owns name matching (`new_to_train`), the profile matrix, and
+//! where the alignment is written. An initialized row is a PRIOR, never a
+//! measurement, and the provenance carried here is what lets every consumer say
+//! so.
 
 use nalgebra::DMatrix;
 use rayon::prelude::*;
@@ -33,6 +35,51 @@ pub enum GeneStatus {
     Dropped,
 }
 
+impl GeneStatus {
+    /// The wire spelling shared by every table that records a status.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Matched => "matched",
+            Self::Missing => "missing",
+            Self::Initialized => "initialized",
+            Self::Dropped => "dropped",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "matched" => Some(Self::Matched),
+            "missing" => Some(Self::Missing),
+            "initialized" => Some(Self::Initialized),
+            "dropped" => Some(Self::Dropped),
+            _ => None,
+        }
+    }
+}
+
+/// The neighbourhood an unseen gene is initialized from: `k` matched genes by
+/// profile similarity, and the best similarity below which the diffuse prior is
+/// used instead. One home for the two numbers every CLI exposes.
+#[derive(Clone, Copy, Debug)]
+pub struct AlignKnobs {
+    pub k: usize,
+    pub similarity_floor: f32,
+}
+
+impl Default for AlignKnobs {
+    fn default() -> Self {
+        Self {
+            k: DEFAULT_INIT_NEIGHBOURS,
+            similarity_floor: DEFAULT_SIMILARITY_FLOOR,
+        }
+    }
+}
+
+pub const DEFAULT_INIT_NEIGHBOURS: usize = 10;
+pub const DEFAULT_SIMILARITY_FLOOR: f32 = 0.2;
+
 /// The trained module tables, when the model has them.
 pub struct ModuleTables<'a> {
     /// `[D_train × M]` membership.
@@ -45,8 +92,10 @@ pub struct ModuleTables<'a> {
 pub struct AlignInputs<'a> {
     /// Trained composed rows `[D_train × H]`.
     pub rho: &'a DMatrix<f32>,
-    /// Trained per-gene bias `[D_train]`.
-    pub b_feat: &'a [f32],
+    /// Trained per-gene bias `[D_train]`; `None` when the caller has none to
+    /// carry (the alignment's own bias for initialized rows is set later by
+    /// [`moment_matched_bias`] either way).
+    pub b_feat: Option<&'a [f32]>,
     /// Module tables; `None` for a free model, in which case an unseen gene is
     /// placed on the similarity-weighted mean of its neighbours' ROWS instead.
     pub modules: Option<ModuleTables<'a>>,
@@ -55,11 +104,7 @@ pub struct AlignInputs<'a> {
     /// Count profiles of the NEW data's genes over its pseudobulks `[G_new × S]`;
     /// `None` makes every unseen gene `Dropped`.
     pub profiles_new: Option<&'a DMatrix<f32>>,
-    /// Neighbours used for an initialized gene.
-    pub k: usize,
-    /// Below this best cosine similarity a gene is placed on the module-average
-    /// (or row-average) prior and flagged `diffuse`.
-    pub similarity_floor: f32,
+    pub knobs: AlignKnobs,
 }
 
 /// How an `Initialized` gene was placed.
@@ -73,8 +118,9 @@ pub struct Provenance {
     pub diffuse: bool,
 }
 
-/// The aligned gene side on the union axis: training genes first, in training
-/// order, then the new-only genes in the new data's order.
+/// The aligned gene side on the union axis: the training genes first, in
+/// training order (union index = training row), then the new-only genes in the
+/// new data's order.
 pub struct GeneAlignment {
     pub rows: DMatrix<f32>,
     pub bias: Vec<f32>,
@@ -84,10 +130,12 @@ pub struct GeneAlignment {
     pub membership: Option<DMatrix<f32>>,
     /// Per union gene; `None` unless `Initialized`.
     pub provenance: Vec<Option<Provenance>>,
-    /// Union gene → training row.
-    pub union_to_train: Vec<Option<usize>>,
+    /// Number of training genes; union gene `g < n_train` IS training row `g`.
+    pub n_train: usize,
     /// Union gene → new-data gene.
     pub union_to_new: Vec<Option<usize>>,
+    /// New-data gene → union gene (`None` for a dropped gene).
+    pub new_to_union: Vec<Option<usize>>,
 }
 
 impl GeneAlignment {
@@ -101,6 +149,12 @@ impl GeneAlignment {
             .filter(|&g| self.status[g] == s)
             .collect()
     }
+
+    /// The model's own genes enter the comparable score; initialized ones do not.
+    #[must_use]
+    pub fn is_scored(&self, g: usize) -> bool {
+        g < self.n_train
+    }
 }
 
 /// Build the alignment. See the module doc for the four states.
@@ -112,11 +166,9 @@ pub fn align_gene_axis(inputs: &AlignInputs) -> GeneAlignment {
     let n_train = inputs.rho.nrows();
     let h = inputs.rho.ncols();
     let n_new = inputs.new_to_train.len();
-    assert_eq!(
-        inputs.b_feat.len(),
-        n_train,
-        "b_feat must match the training rows"
-    );
+    if let Some(b) = inputs.b_feat {
+        assert_eq!(b.len(), n_train, "b_feat must match the training rows");
+    }
     let n_modules = inputs.modules.as_ref().map(|m| m.pi.ncols());
     if let Some(m) = &inputs.modules {
         assert_eq!(m.pi.nrows(), n_train, "π must match the training rows");
@@ -143,17 +195,18 @@ pub fn align_gene_axis(inputs: &AlignInputs) -> GeneAlignment {
     let mut status = vec![GeneStatus::Dropped; n_union];
     let mut membership = n_modules.map(|m| DMatrix::<f32>::zeros(n_union, m));
     let mut provenance: Vec<Option<Provenance>> = vec![None; n_union];
-    let mut union_to_train: Vec<Option<usize>> = vec![None; n_union];
     let mut union_to_new: Vec<Option<usize>> = vec![None; n_union];
+    let mut new_to_union: Vec<Option<usize>> = inputs.new_to_train.to_vec();
 
     // Training genes: verbatim, matched or missing.
     for t in 0..n_train {
         rows.set_row(t, &inputs.rho.row(t));
-        bias[t] = inputs.b_feat[t];
+        if let Some(b) = inputs.b_feat {
+            bias[t] = b[t];
+        }
         if let (Some(pm), Some(m)) = (membership.as_mut(), inputs.modules.as_ref()) {
             pm.set_row(t, &m.pi.row(t));
         }
-        union_to_train[t] = Some(t);
         union_to_new[t] = train_to_new[t];
         status[t] = if train_to_new[t].is_some() {
             GeneStatus::Matched
@@ -164,45 +217,78 @@ pub fn align_gene_axis(inputs: &AlignInputs) -> GeneAlignment {
     for (i, &n) in new_only.iter().enumerate() {
         union_to_new[n_train + i] = Some(n);
     }
-    let Some(profiles) = inputs.profiles_new else {
-        return GeneAlignment {
-            rows,
-            bias,
-            status,
-            membership,
-            provenance,
-            union_to_train,
-            union_to_new,
-        };
-    };
-    assert_eq!(
-        profiles.nrows(),
-        n_new,
-        "profiles must match the new gene axis"
-    );
 
+    // Unseen genes: placed from their profiles, or dropped without any.
+    let placed = match inputs.profiles_new {
+        Some(profiles) => {
+            assert_eq!(
+                profiles.nrows(),
+                n_new,
+                "profiles must match the new gene axis"
+            );
+            place_unseen(inputs, &new_only, profiles)
+        }
+        None => Vec::new(),
+    };
+    for (i, (row, pm, prov)) in placed.into_iter().enumerate() {
+        let g = n_train + i;
+        for (j, v) in row.iter().enumerate() {
+            rows[(g, j)] = *v;
+        }
+        if let (Some(table), Some(pm)) = (membership.as_mut(), pm) {
+            for (c, v) in pm.iter().enumerate() {
+                table[(g, c)] = *v;
+            }
+        }
+        status[g] = GeneStatus::Initialized;
+        provenance[g] = Some(prov);
+        new_to_union[new_only[i]] = Some(g);
+    }
+
+    GeneAlignment {
+        rows,
+        bias,
+        status,
+        membership,
+        provenance,
+        n_train,
+        union_to_new,
+        new_to_union,
+    }
+}
+
+/// One placed unseen gene: its row, its membership (with modules), and how.
+type Placed = (Vec<f32>, Option<Vec<f32>>, Provenance);
+
+/// Place every unseen gene from its profile: `k` nearest matched genes by cosine
+/// on the unit profiles, similarity-weighted average of their memberships (or
+/// rows, without modules), the module/row average below the floor.
+fn place_unseen(inputs: &AlignInputs, new_only: &[usize], profiles: &DMatrix<f32>) -> Vec<Placed> {
+    let n_train = inputs.rho.nrows();
+    let h = inputs.rho.ncols();
     // Unit-norm, centred log profiles — the same reading of a profile the module
     // warm start uses, so "similar" means the same thing in both places.
-    let unit = unit_profile_rows(profiles);
+    let unit = unit_log_profile_rows(profiles);
     // The matched genes are the only ones whose membership / row is known.
-    let matched_new: Vec<usize> = (0..n_new)
+    let matched_new: Vec<usize> = (0..inputs.new_to_train.len())
         .filter(|&n| inputs.new_to_train[n].is_some())
         .collect();
-
     // Average priors for a gene that resembles nothing.
     let avg_membership: Option<Vec<f32>> = inputs.modules.as_ref().map(|m| {
         (0..m.pi.ncols())
             .map(|c| m.pi.column(c).iter().sum::<f32>() / n_train.max(1) as f32)
             .collect()
     });
-    let avg_row: Vec<f32> = (0..h)
-        .map(|j| inputs.rho.column(j).iter().sum::<f32>() / n_train.max(1) as f32)
-        .collect();
-
-    let placed: Vec<(Vec<f32>, Option<Vec<f32>>, Provenance)> = new_only
+    let avg_row: Vec<f32> = match (&avg_membership, &inputs.modules) {
+        (Some(pm), Some(m)) => membership_to_row(pm, m.mu),
+        _ => (0..h)
+            .map(|j| inputs.rho.column(j).iter().sum::<f32>() / n_train.max(1) as f32)
+            .collect(),
+    };
+    let k = inputs.knobs.k.max(1);
+    new_only
         .par_iter()
         .map(|&n| {
-            // Cosine against every matched gene, best first.
             let q = &unit[n];
             let mut sims: Vec<(f32, usize)> = matched_new
                 .iter()
@@ -211,18 +297,18 @@ pub fn align_gene_axis(inputs: &AlignInputs) -> GeneAlignment {
                     (s, inputs.new_to_train[mn].expect("matched"))
                 })
                 .collect();
-            sims.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-            sims.truncate(inputs.k.max(1));
+            // Top-k by similarity: a partial select, then sort just those.
+            if sims.len() > k {
+                sims.select_nth_unstable_by(k - 1, |a, b| b.0.total_cmp(&a.0));
+                sims.truncate(k);
+            }
+            sims.sort_by(|a, b| b.0.total_cmp(&a.0));
             let best = sims.first().map_or(0.0, |s| s.0);
             let weights: Vec<f32> = sims.iter().map(|s| s.0.max(0.0)).collect();
             let wsum: f32 = weights.iter().sum();
-            if sims.is_empty() || best < inputs.similarity_floor || wsum <= 0.0 {
-                let row = match (&avg_membership, &inputs.modules) {
-                    (Some(pm), Some(m)) => membership_to_row(pm, m.mu),
-                    _ => avg_row.clone(),
-                };
+            if sims.is_empty() || best < inputs.knobs.similarity_floor || wsum <= 0.0 {
                 return (
-                    row,
+                    avg_row.clone(),
                     avg_membership.clone(),
                     Provenance {
                         neighbours: Vec::new(),
@@ -262,31 +348,7 @@ pub fn align_gene_axis(inputs: &AlignInputs) -> GeneAlignment {
                 },
             )
         })
-        .collect();
-
-    for (i, (row, pm, prov)) in placed.into_iter().enumerate() {
-        let g = n_train + i;
-        for (j, v) in row.iter().enumerate() {
-            rows[(g, j)] = *v;
-        }
-        if let (Some(table), Some(pm)) = (membership.as_mut(), pm) {
-            for (c, v) in pm.iter().enumerate() {
-                table[(g, c)] = *v;
-            }
-        }
-        status[g] = GeneStatus::Initialized;
-        provenance[g] = Some(prov);
-    }
-
-    GeneAlignment {
-        rows,
-        bias,
-        status,
-        membership,
-        provenance,
-        union_to_train,
-        union_to_new,
-    }
+        .collect()
 }
 
 /// `π̂ μ` for one membership row.
@@ -299,8 +361,10 @@ fn membership_to_row(pm: &[f32], mu: &DMatrix<f32>) -> Vec<f32> {
 /// Depth-normalize the pseudobulk columns to a common total, `log1p`, centre
 /// each gene's row and scale it to unit norm, so a dot product is a cosine on
 /// the SHAPE of the profile. A constant row (no shape) becomes the zero vector
-/// and is similar to nothing.
-fn unit_profile_rows(profiles: &DMatrix<f32>) -> Vec<Vec<f32>> {
+/// and is similar to nothing. Returns one contiguous row per gene. The one
+/// reading of a profile shared by the alignment and the module warm start.
+#[must_use]
+pub fn unit_log_profile_rows(profiles: &DMatrix<f32>) -> Vec<Vec<f32>> {
     let (d, s) = (profiles.nrows(), profiles.ncols());
     let col_tot: Vec<f32> = (0..s)
         .map(|j| profiles.column(j).iter().sum::<f32>().max(1e-8))
@@ -329,6 +393,34 @@ fn unit_profile_rows(profiles: &DMatrix<f32>) -> Vec<Vec<f32>> {
         .collect()
 }
 
+/// Log-rates `[N × G]`: `ρ_g · θ_c + a_g + b_c`, one gemm. The one form of the
+/// bge rate shared by the bias fit, the initialized-gene score and the rate
+/// tables.
+#[must_use]
+pub fn log_rates(
+    theta: &DMatrix<f32>,
+    rows: &DMatrix<f32>,
+    bias: &[f32],
+    b_cell: &[f32],
+) -> DMatrix<f32> {
+    let (n, g) = (theta.nrows(), rows.nrows());
+    assert_eq!(
+        theta.ncols(),
+        rows.ncols(),
+        "latent width must match the rows"
+    );
+    assert_eq!(bias.len(), g, "one bias per row");
+    assert_eq!(b_cell.len(), n, "one cell bias per latent row");
+    let mut s = theta * rows.transpose(); // [N × G]
+    for (j, &a) in bias.iter().enumerate() {
+        let mut col = s.column_mut(j);
+        for (c, v) in col.iter_mut().enumerate() {
+            *v += a + b_cell[c];
+        }
+    }
+    s
+}
+
 /// Moment-matched bias for initialized rows: with pass-1 latents `theta [N × H]`
 /// and cell biases `b_cell [N]` fixed, the bias that makes each gene's total
 /// predicted count equal its total observed count,
@@ -346,11 +438,10 @@ pub fn moment_matched_bias(
     observed_total: &[f32],
     fallback: f32,
 ) -> Vec<f32> {
-    let (g_n, h) = (rows.nrows(), rows.ncols());
-    let n = theta.nrows();
-    assert_eq!(theta.ncols(), h, "latent width must match the rows");
-    assert_eq!(b_cell.len(), n, "one cell bias per latent row");
+    let g_n = rows.nrows();
     assert_eq!(observed_total.len(), g_n, "one observed total per row");
+    let zero_bias = vec![0f32; g_n];
+    let s = log_rates(theta, rows, &zero_bias, b_cell); // [N × G]
     (0..g_n)
         .into_par_iter()
         .map(|g| {
@@ -358,16 +449,124 @@ pub fn moment_matched_bias(
             if obs <= 0.0 {
                 return fallback;
             }
-            let pred: f64 = (0..n)
-                .map(|c| {
-                    let s: f32 =
-                        (0..h).map(|j| rows[(g, j)] * theta[(c, j)]).sum::<f32>() + b_cell[c];
-                    f64::from(s).exp()
-                })
-                .sum();
+            let pred: f64 = s.column(g).iter().map(|&v| f64::from(v).exp()).sum();
             (obs.ln() - pred.max(1e-300).ln()) as f32
         })
         .collect()
+}
+
+/// Pseudobulks to form profiles over for `n_cells` query cells: about one per
+/// fifty cells, between 8 and 256, never more than the cells.
+#[must_use]
+pub fn pseudobulk_count(n_cells: usize) -> usize {
+    (n_cells / 50).clamp(8, 256).min(n_cells.max(1))
+}
+
+////////////////////////////////
+// Module tables on disk       //
+////////////////////////////////
+
+/// The suffixes `write_module_tables` writes under a run prefix, and every
+/// reader looks for.
+pub const MODULE_MEMBERSHIP_SUFFIX: &str = "module_membership.parquet";
+pub const MODULE_DICTIONARY_SUFFIX: &str = "module_dictionary.parquet";
+pub const MODULE_RESIDUAL_SUFFIX: &str = "module_residual.parquet";
+pub const MODULE_BIAS_SUFFIX: &str = "module_bias.parquet";
+
+/// The module-table paths beside a dictionary file: strip the dictionary's own
+/// suffix (`feature_loading`, `dictionary`, `feature_embedding`, or a bare
+/// `.parquet`) to the run prefix, then append the table suffixes.
+#[must_use]
+pub fn module_table_paths(dictionary_path: &str) -> (String, String) {
+    let stem = ["feature_loading", "dictionary", "feature_embedding"]
+        .iter()
+        .find_map(|slot| dictionary_path.strip_suffix(&format!(".{slot}.parquet")))
+        .or_else(|| dictionary_path.strip_suffix(".parquet"))
+        .unwrap_or(dictionary_path);
+    (
+        format!("{stem}.{MODULE_MEMBERSHIP_SUFFIX}"),
+        format!("{stem}.{MODULE_DICTIONARY_SUFFIX}"),
+    )
+}
+
+/// Read `(π, μ)` from their two files and check them against the dictionary's
+/// genes and width: π's rows must be exactly `dict_names` in order, μ must be
+/// `[M × h]`. The one validation every reader of the tables performs.
+pub fn read_module_tables(
+    pi_path: &str,
+    mu_path: &str,
+    dict_names: &[Box<str>],
+    h: usize,
+) -> anyhow::Result<(DMatrix<f32>, DMatrix<f32>)> {
+    use matrix_util::traits::IoOps;
+    let pi = <DMatrix<f32> as IoOps>::from_parquet(pi_path)?;
+    let mu = <DMatrix<f32> as IoOps>::from_parquet(mu_path)?;
+    anyhow::ensure!(
+        pi.rows.len() == dict_names.len() && pi.rows.iter().zip(dict_names).all(|(a, b)| a == b),
+        "{pi_path}: rows are not the dictionary's genes in the dictionary's order"
+    );
+    anyhow::ensure!(
+        mu.mat.nrows() == pi.mat.ncols() && mu.mat.ncols() == h,
+        "{mu_path}: {}×{} but {pi_path} has {} modules and the dictionary is {h} wide",
+        mu.mat.nrows(),
+        mu.mat.ncols(),
+        pi.mat.ncols()
+    );
+    Ok((pi.mat, mu.mat))
+}
+
+/// Write the alignment's audit table: one row per union gene — status, best
+/// profile similarity, whether the diffuse prior was used, the neighbours'
+/// names, and the bias. `names` are the union genes' names in union order;
+/// `train_names` resolve the neighbour indices. The provenance every reader of
+/// an initialized row is entitled to, written the same way by every consumer.
+pub fn write_alignment_table(
+    path: &str,
+    names: &[Box<str>],
+    train_names: &[Box<str>],
+    al: &GeneAlignment,
+) -> anyhow::Result<()> {
+    use matrix_util::parquet::{write_named_table, Column};
+    let status: Vec<Box<str>> = al.status.iter().map(|s| Box::from(s.as_str())).collect();
+    let similarity: Vec<f32> = al
+        .provenance
+        .iter()
+        .map(|p| p.as_ref().map_or(f32::NAN, |p| p.best_similarity))
+        .collect();
+    let diffuse: Vec<i32> = al
+        .provenance
+        .iter()
+        .map(|p| i32::from(p.as_ref().is_some_and(|p| p.diffuse)))
+        .collect();
+    let neighbours: Vec<Box<str>> = al
+        .provenance
+        .iter()
+        .map(|p| {
+            p.as_ref().map_or_else(
+                || Box::from(""),
+                |p| {
+                    p.neighbours
+                        .iter()
+                        .map(|&t| train_names[t].as_ref())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                        .into_boxed_str()
+                },
+            )
+        })
+        .collect();
+    write_named_table(
+        path,
+        "gene",
+        names,
+        &[
+            (Box::from("status"), Column::Str(&status)),
+            (Box::from("best_similarity"), Column::F32(&similarity)),
+            (Box::from("diffuse"), Column::I32(&diffuse)),
+            (Box::from("neighbours"), Column::Str(&neighbours)),
+            (Box::from("bias"), Column::F32(&al.bias)),
+        ],
+    )
 }
 
 #[cfg(test)]

--- a/graph-embedding-util/src/transfer/tests.rs
+++ b/graph-embedding-util/src/transfer/tests.rs
@@ -49,12 +49,14 @@ fn align(k: usize, floor: f32) -> GeneAlignment {
     let (n2t, p) = new_data();
     align_gene_axis(&AlignInputs {
         rho: &rho,
-        b_feat: &b,
+        b_feat: Some(&b),
         modules: Some(ModuleTables { pi: &pi, mu: &mu }),
         new_to_train: &n2t,
         profiles_new: Some(&p),
-        k,
-        similarity_floor: floor,
+        knobs: AlignKnobs {
+            k,
+            similarity_floor: floor,
+        },
     })
 }
 
@@ -62,8 +64,8 @@ fn align(k: usize, floor: f32) -> GeneAlignment {
 fn union_axis_is_training_genes_then_new_only_genes() {
     let a = align(1, 0.5);
     assert_eq!(a.n_union(), 4 + 2);
-    assert_eq!(a.union_to_train[..4], [Some(0), Some(1), Some(2), Some(3)]);
-    assert_eq!(a.union_to_train[4..], [None, None]);
+    assert_eq!(a.n_train, 4);
+    assert!(a.is_scored(3) && !a.is_scored(4));
     assert_eq!(
         a.union_to_new,
         vec![Some(2), Some(0), None, Some(1), Some(3), Some(4)]
@@ -156,15 +158,18 @@ fn without_profiles_unseen_genes_are_dropped() {
     let (n2t, _) = new_data();
     let a = align_gene_axis(&AlignInputs {
         rho: &rho,
-        b_feat: &b,
+        b_feat: Some(&b),
         modules: Some(ModuleTables { pi: &pi, mu: &mu }),
         new_to_train: &n2t,
         profiles_new: None,
-        k: 3,
-        similarity_floor: 0.5,
+        knobs: AlignKnobs {
+            k: 3,
+            similarity_floor: 0.5,
+        },
     });
     assert_eq!(a.status[4], GeneStatus::Dropped);
     assert_eq!(a.status[5], GeneStatus::Dropped);
+    assert_eq!(a.new_to_union[3], None);
     assert!(a.rows.row(4).iter().all(|&v| v == 0.0));
     assert_eq!(a.with_status(GeneStatus::Matched).len(), 3);
 }
@@ -175,12 +180,14 @@ fn without_modules_an_unseen_gene_takes_its_neighbours_row() {
     let (n2t, p) = new_data();
     let a = align_gene_axis(&AlignInputs {
         rho: &rho,
-        b_feat: &b,
+        b_feat: Some(&b),
         modules: None,
         new_to_train: &n2t,
         profiles_new: Some(&p),
-        k: 1,
-        similarity_floor: 0.5,
+        knobs: AlignKnobs {
+            k: 1,
+            similarity_floor: 0.5,
+        },
     });
     assert!(a.membership.is_none());
     let g = 4;
@@ -217,4 +224,40 @@ fn moment_matching_recovers_a_planted_bias() {
     }
     let none = moment_matched_bias(&rows, &theta, &b_cell, &[0.0, 0.0], -9.0);
     assert_eq!(none, vec![-9.0, -9.0]);
+}
+
+#[test]
+fn status_round_trips_through_its_wire_spelling() {
+    for s in [
+        GeneStatus::Matched,
+        GeneStatus::Missing,
+        GeneStatus::Initialized,
+        GeneStatus::Dropped,
+    ] {
+        assert_eq!(GeneStatus::parse(s.as_str()), Some(s));
+    }
+    assert_eq!(GeneStatus::parse("other"), None);
+}
+
+#[test]
+fn module_table_paths_strip_every_dictionary_slot() {
+    for dict in [
+        "run.feature_loading.parquet",
+        "run.dictionary.parquet",
+        "run.feature_embedding.parquet",
+        "run.parquet",
+    ] {
+        let (pi, mu) = module_table_paths(dict);
+        assert_eq!(pi, "run.module_membership.parquet", "{dict}");
+        assert_eq!(mu, "run.module_dictionary.parquet", "{dict}");
+    }
+}
+
+#[test]
+fn log_rates_is_the_bilinear_score_plus_both_biases() {
+    let theta = DMatrix::<f32>::from_row_slice(2, 2, &[1.0, 0.0, 0.5, 0.5]);
+    let rows = DMatrix::<f32>::from_row_slice(1, 2, &[2.0, 4.0]);
+    let s = log_rates(&theta, &rows, &[0.1], &[1.0, -1.0]);
+    assert!((s[(0, 0)] - (2.0 + 0.1 + 1.0)).abs() < 1e-6);
+    assert!((s[(1, 0)] - (3.0 + 0.1 - 1.0)).abs() < 1e-6);
 }

--- a/graph-embedding-util/src/transfer/tests.rs
+++ b/graph-embedding-util/src/transfer/tests.rs
@@ -1,0 +1,217 @@
+use super::*;
+
+const H: usize = 3;
+const M: usize = 2;
+const S: usize = 4;
+
+/// Two modules, four training genes: 0,1 in module 0; 2,3 in module 1 (gene 3
+/// mixed 0.25/0.75). Rows are `π μ + r` with a nonzero residual so the trained row
+/// differs from the pure module composition.
+fn trained() -> (DMatrix<f32>, DMatrix<f32>, DMatrix<f32>, Vec<f32>) {
+    let mu = DMatrix::<f32>::from_row_slice(M, H, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+    let pi = DMatrix::<f32>::from_row_slice(4, M, &[1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.25, 0.75]);
+    let r = DMatrix::<f32>::from_row_slice(
+        4,
+        H,
+        &[
+            0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.05, 0.05, 0.05,
+        ],
+    );
+    let rho = &pi * &mu + r;
+    let b = vec![-1.0, -2.0, -3.0, -4.0];
+    (rho, pi, mu, b)
+}
+
+/// New-data profiles: genes 0..3 of the new axis match training rows 1, 3, 0 (in
+/// that order, exercising a permutation); training gene 2 is MISSING. New genes 3
+/// and 4 are unseen: 3 has exactly gene 0's profile, 4 resembles nothing.
+fn new_data() -> (Vec<Option<usize>>, DMatrix<f32>) {
+    let new_to_train = vec![Some(1), Some(3), Some(0), None, None];
+    let p = DMatrix::<f32>::from_row_slice(
+        5,
+        S,
+        &[
+            10.0, 0.0, 10.0, 0.0, // new 0 = train 1
+            0.0, 10.0, 0.0, 10.0, // new 1 = train 3
+            10.0, 0.0, 10.0, 0.0, // new 2 = train 0
+            10.0, 0.0, 10.0, 0.0, // new 3: identical to train 0's profile
+            5.0, 5.0, 5.0, 5.0, // new 4: flat, resembles nothing after centring
+        ],
+    );
+    (new_to_train, p)
+}
+
+fn align(k: usize, floor: f32) -> GeneAlignment {
+    let (rho, pi, mu, b) = trained();
+    let (n2t, p) = new_data();
+    align_gene_axis(&AlignInputs {
+        rho: &rho,
+        b_feat: &b,
+        modules: Some(ModuleTables { pi: &pi, mu: &mu }),
+        new_to_train: &n2t,
+        profiles_new: Some(&p),
+        k,
+        similarity_floor: floor,
+    })
+}
+
+#[test]
+fn union_axis_is_training_genes_then_new_only_genes() {
+    let a = align(1, 0.5);
+    assert_eq!(a.n_union(), 4 + 2);
+    assert_eq!(a.union_to_train[..4], [Some(0), Some(1), Some(2), Some(3)]);
+    assert_eq!(a.union_to_train[4..], [None, None]);
+    assert_eq!(
+        a.union_to_new,
+        vec![Some(2), Some(0), None, Some(1), Some(3), Some(4)]
+    );
+}
+
+#[test]
+fn matched_genes_keep_row_bias_and_membership_verbatim() {
+    let (rho, pi, _, b) = trained();
+    let a = align(1, 0.5);
+    for g in [0usize, 1, 3] {
+        assert_eq!(a.status[g], GeneStatus::Matched);
+        assert_eq!(a.rows.row(g), rho.row(g));
+        assert_eq!(a.bias[g], b[g]);
+        assert_eq!(a.membership.as_ref().unwrap().row(g), pi.row(g));
+        assert!(a.provenance[g].is_none());
+    }
+}
+
+#[test]
+fn missing_gene_keeps_its_row_and_is_flagged() {
+    let (rho, _, _, b) = trained();
+    let a = align(1, 0.5);
+    assert_eq!(a.status[2], GeneStatus::Missing);
+    assert_eq!(a.rows.row(2), rho.row(2));
+    assert_eq!(a.bias[2], b[2]);
+}
+
+#[test]
+fn identical_profile_inherits_the_neighbours_membership_without_its_residual() {
+    let (_, pi, mu, _) = trained();
+    let a = align(1, 0.5);
+    let g = 4; // union index of new gene 3
+    assert_eq!(a.status[g], GeneStatus::Initialized);
+    let pm = a.membership.as_ref().unwrap();
+    // Nearest matched gene by profile is train 0 (or train 1, identical profile and
+    // identical membership), so π̂ = (1, 0) and ρ̂ = μ_0 exactly — no residual.
+    assert_eq!(pm.row(g), pi.row(0));
+    let want = pi.row(0) * &mu;
+    for j in 0..H {
+        assert!((a.rows[(g, j)] - want[j]).abs() < 1e-6, "ρ̂ must be π̂ μ");
+    }
+    let prov = a.provenance[g].as_ref().unwrap();
+    assert!(!prov.diffuse);
+    assert!(prov.best_similarity > 0.99);
+    assert!(prov.neighbours[0] == 0 || prov.neighbours[0] == 1);
+}
+
+#[test]
+fn k_neighbours_average_memberships_by_similarity() {
+    let (_, pi, _, _) = trained();
+    let a = align(3, 0.0);
+    let g = 4;
+    let pm = a.membership.as_ref().unwrap();
+    // Neighbours of the flat-free profile (10,0,10,0): train 0 and 1 (sim 1), train 3
+    // (sim −1, weight clipped to 0). So still (1, 0).
+    assert_eq!(pm.row(g), pi.row(0));
+    let row: Vec<f32> = pm.row(g).iter().copied().collect();
+    assert!(
+        (row.iter().sum::<f32>() - 1.0).abs() < 1e-6,
+        "π̂ stays on the simplex"
+    );
+}
+
+#[test]
+fn a_gene_resembling_nothing_gets_the_module_average_and_is_marked_diffuse() {
+    let (_, pi, mu, _) = trained();
+    let a = align(2, 0.5);
+    let g = 5; // union index of new gene 4 (flat profile → zero after centring)
+    assert_eq!(a.status[g], GeneStatus::Initialized);
+    let prov = a.provenance[g].as_ref().unwrap();
+    assert!(prov.diffuse);
+    assert!(prov.neighbours.is_empty());
+    let pm = a.membership.as_ref().unwrap();
+    let avg: Vec<f32> = (0..M)
+        .map(|m| pi.column(m).iter().sum::<f32>() / 4.0)
+        .collect();
+    for m in 0..M {
+        assert!((pm[(g, m)] - avg[m]).abs() < 1e-6);
+    }
+    let want = DMatrix::<f32>::from_row_slice(1, M, &avg) * &mu;
+    for j in 0..H {
+        assert!((a.rows[(g, j)] - want[(0, j)]).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn without_profiles_unseen_genes_are_dropped() {
+    let (rho, pi, mu, b) = trained();
+    let (n2t, _) = new_data();
+    let a = align_gene_axis(&AlignInputs {
+        rho: &rho,
+        b_feat: &b,
+        modules: Some(ModuleTables { pi: &pi, mu: &mu }),
+        new_to_train: &n2t,
+        profiles_new: None,
+        k: 3,
+        similarity_floor: 0.5,
+    });
+    assert_eq!(a.status[4], GeneStatus::Dropped);
+    assert_eq!(a.status[5], GeneStatus::Dropped);
+    assert!(a.rows.row(4).iter().all(|&v| v == 0.0));
+    assert_eq!(a.with_status(GeneStatus::Matched).len(), 3);
+}
+
+#[test]
+fn without_modules_an_unseen_gene_takes_its_neighbours_row() {
+    let (rho, _, _, b) = trained();
+    let (n2t, p) = new_data();
+    let a = align_gene_axis(&AlignInputs {
+        rho: &rho,
+        b_feat: &b,
+        modules: None,
+        new_to_train: &n2t,
+        profiles_new: Some(&p),
+        k: 1,
+        similarity_floor: 0.5,
+    });
+    assert!(a.membership.is_none());
+    let g = 4;
+    assert_eq!(a.status[g], GeneStatus::Initialized);
+    let n = a.provenance[g].as_ref().unwrap().neighbours[0];
+    assert_eq!(a.rows.row(g), rho.row(n));
+}
+
+/// Planted bias: counts are the exact expected rates, so the moment-matched bias
+/// must recover the planted `a_g` to float precision.
+#[test]
+fn moment_matching_recovers_a_planted_bias() {
+    let rows = DMatrix::<f32>::from_row_slice(2, H, &[0.5, -0.2, 0.1, -0.3, 0.4, 0.2]);
+    let theta =
+        DMatrix::<f32>::from_row_slice(3, H, &[1.0, 0.0, 0.5, -0.5, 1.0, 0.0, 0.2, 0.2, 0.2]);
+    let b_cell = [0.1f32, -0.4, 0.3];
+    let planted = [-1.5f32, 0.7];
+    let mut total = vec![0f32; 2];
+    for g in 0..2 {
+        for c in 0..3 {
+            let s: f32 =
+                (0..H).map(|j| rows[(g, j)] * theta[(c, j)]).sum::<f32>() + planted[g] + b_cell[c];
+            total[g] += s.exp();
+        }
+    }
+    let got = moment_matched_bias(&rows, &theta, &b_cell, &total, 0.0);
+    for g in 0..2 {
+        assert!(
+            (got[g] - planted[g]).abs() < 1e-4,
+            "gene {g}: {} vs {}",
+            got[g],
+            planted[g]
+        );
+    }
+    let none = moment_matched_bias(&rows, &theta, &b_cell, &[0.0, 0.0], -9.0);
+    assert_eq!(none, vec![-9.0, -9.0]);
+}

--- a/graph-embedding-util/src/transfer/tests.rs
+++ b/graph-embedding-util/src/transfer/tests.rs
@@ -24,7 +24,8 @@ fn trained() -> (DMatrix<f32>, DMatrix<f32>, DMatrix<f32>, Vec<f32>) {
 
 /// New-data profiles: genes 0..3 of the new axis match training rows 1, 3, 0 (in
 /// that order, exercising a permutation); training gene 2 is MISSING. New genes 3
-/// and 4 are unseen: 3 has exactly gene 0's profile, 4 resembles nothing.
+/// and 4 are unseen: 3 has exactly gene 0's profile, 4 has no shape once the
+/// pseudobulk depths are equalized.
 fn new_data() -> (Vec<Option<usize>>, DMatrix<f32>) {
     let new_to_train = vec![Some(1), Some(3), Some(0), None, None];
     let p = DMatrix::<f32>::from_row_slice(
@@ -35,7 +36,9 @@ fn new_data() -> (Vec<Option<usize>>, DMatrix<f32>) {
             0.0, 10.0, 0.0, 10.0, // new 1 = train 3
             10.0, 0.0, 10.0, 0.0, // new 2 = train 0
             10.0, 0.0, 10.0, 0.0, // new 3: identical to train 0's profile
-            5.0, 5.0, 5.0, 5.0, // new 4: flat, resembles nothing after centring
+            // new 4: proportional to the COLUMN TOTALS (45, 15, 45, 15), so it is
+            // flat after depth normalization and resembles nothing after centring.
+            15.0, 5.0, 15.0, 5.0,
         ],
     );
     (new_to_train, p)

--- a/graph-embedding-util/tests/module_gradient_contract.rs
+++ b/graph-embedding-util/tests/module_gradient_contract.rs
@@ -1,0 +1,252 @@
+//! The gradient-flow contract of the module parameterization, checked against the
+//! real loss functions rather than described: which Var each term reaches, and
+//! the analytic gradient of the exact term.
+
+use candle_util::candle_core::{DType, Device, Tensor, Var};
+use candle_util::candle_nn::VarMap;
+use candle_util::nn::sparsemax;
+use graph_embedding_util::loss::{
+    gather_feature_rows, module_balance_prior, module_softmax_loss, nce_loss_identity, EdgeBatch,
+    NceObjective,
+};
+use graph_embedding_util::model::{
+    FeatureGateSpec, JointEmbedModel, ModuleInit, MODULE_BIAS_VAR_NAME, MODULE_LOGITS_VAR_NAME,
+    MODULE_MU_VAR_NAME, MODULE_RESIDUAL_VAR_NAME,
+};
+
+const D: usize = 8;
+const M: usize = 3;
+const H: usize = 4;
+const N: usize = 5;
+
+fn dev() -> Device {
+    Device::Cpu
+}
+
+/// A module model with a hard (one-hot) warm start unless `own_mass < 1`.
+fn model(own_mass: f32, vm: &VarMap) -> JointEmbedModel {
+    let labels: Vec<u32> = (0..D as u32).map(|g| g % M as u32).collect();
+    JointEmbedModel::new_with_modules(
+        ModuleInit {
+            n_features: D,
+            n_cells: N,
+            embedding_dim: H,
+            n_modules: M,
+            init_labels: Some(&labels),
+            init_own_mass: own_mass,
+            b_feat: &[0f32; D],
+            b_cell: &[0f32; N],
+            seed: 1,
+        },
+        vm,
+        &dev(),
+    )
+    .unwrap()
+}
+
+fn var(vm: &VarMap, name: &str) -> Var {
+    vm.data().lock().unwrap().get(name).unwrap().clone()
+}
+
+fn grad_norm(grads: &candle_util::candle_core::backprop::GradStore, v: &Var) -> Option<f32> {
+    grads.get(v.as_tensor()).map(|g| {
+        g.sqr()
+            .unwrap()
+            .sum_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap()
+            .sqrt()
+    })
+}
+
+/// Within-module NCE, hard membership: negatives share the positive's module, so
+/// μ cancels and receives no gradient; r, a_g, e_c, b_c do; the logits do not
+/// (a one-hot sparsemax row has a zero Jacobian).
+#[test]
+fn within_module_nce_reaches_residual_and_cells_but_not_mu() {
+    let vm = VarMap::new();
+    let m = model(1.0, &vm);
+    // Feature 0 (module 0) positive; negatives 3 and 6 are the other module-0 members.
+    let batch = EdgeBatch {
+        coarse_cells: vec![2],
+        fine_feats: vec![0],
+        neg_feats: vec![3, 6],
+        n_negatives: 2,
+        n_module_fallback: 0,
+    };
+    // Perturb the residual so rows differ (zero-init would make the loss flat).
+    let r = var(&vm, MODULE_RESIDUAL_VAR_NAME);
+    r.set(&Tensor::rand(-0.5f32, 0.5, (D, H), &dev()).unwrap())
+        .unwrap();
+    let loss = nce_loss_identity(&m, batch, NceObjective::Softmax, &dev()).unwrap();
+    let grads = loss.backward().unwrap();
+    let mu = grad_norm(&grads, &var(&vm, MODULE_MU_VAR_NAME)).unwrap_or(0.0);
+    assert!(
+        mu < 1e-5,
+        "μ must cancel within a hard module, got ‖∇μ‖ = {mu}"
+    );
+    assert!(grad_norm(&grads, &var(&vm, MODULE_RESIDUAL_VAR_NAME)).unwrap() > 1e-4);
+    assert!(grad_norm(&grads, &var(&vm, "b_feat")).unwrap() > 1e-4);
+    assert!(grad_norm(&grads, &var(&vm, "e_cell")).unwrap() > 1e-4);
+    // b_cell is shared by the positive and its negatives, so the softmax NCE is
+    // invariant to it: its gradient is exactly zero even though it is in the graph.
+    assert!(grad_norm(&grads, &var(&vm, "b_cell")).unwrap_or(0.0) < 1e-6);
+    // One-hot rows have a zero sparsemax Jacobian EXCEPT at an exact support tie
+    // (the warm start puts the other logits at 0 = τ), where candle's clamp
+    // backward passes a boundary gradient. Small, and gone once anything moves.
+    let lg = grad_norm(&grads, &var(&vm, MODULE_LOGITS_VAR_NAME)).unwrap_or(0.0);
+    assert!(
+        lg < 1e-2,
+        "hard rows: only a boundary-tie gradient is expected, got {lg}"
+    );
+}
+
+/// Mixed membership with negatives whose membership rows EQUAL the positive's
+/// still cancels μ exactly: the module vector drops out of every score difference.
+#[test]
+fn identical_membership_rows_cancel_mu_even_when_mixed() {
+    let vm = VarMap::new();
+    let m = model(0.7, &vm);
+    // 0, 3, 6 all carry the same warm-start row (0.7, 0.15, 0.15).
+    let batch = EdgeBatch {
+        coarse_cells: vec![2],
+        fine_feats: vec![0],
+        neg_feats: vec![3, 6],
+        n_negatives: 2,
+        n_module_fallback: 0,
+    };
+    let loss = nce_loss_identity(&m, batch, NceObjective::Softmax, &dev()).unwrap();
+    let grads = loss.backward().unwrap();
+    let mu = grad_norm(&grads, &var(&vm, MODULE_MU_VAR_NAME)).unwrap_or(0.0);
+    assert!(mu < 1e-5, "identical rows must cancel μ, got {mu}");
+}
+
+/// Mixed membership with negatives whose rows DIFFER from the positive's (module
+/// 0 also holds genes whose main module is 1 or 2, at weight 0.15): the NCE now
+/// reaches μ and the logits.
+#[test]
+fn within_module_nce_reaches_mu_and_logits_under_mixed_membership() {
+    let vm = VarMap::new();
+    let m = model(0.7, &vm);
+    let batch = EdgeBatch {
+        coarse_cells: vec![2],
+        fine_feats: vec![0],
+        neg_feats: vec![1, 2],
+        n_negatives: 2,
+        n_module_fallback: 0,
+    };
+    let loss = nce_loss_identity(&m, batch, NceObjective::Softmax, &dev()).unwrap();
+    let grads = loss.backward().unwrap();
+    assert!(grad_norm(&grads, &var(&vm, MODULE_MU_VAR_NAME)).unwrap() > 1e-4);
+    assert!(grad_norm(&grads, &var(&vm, MODULE_LOGITS_VAR_NAME)).unwrap() > 1e-4);
+    // Frozen: the logits drop out of the graph, μ still trains.
+    m.modules.as_ref().unwrap().set_frozen(true);
+    let batch = EdgeBatch {
+        coarse_cells: vec![2],
+        fine_feats: vec![0],
+        neg_feats: vec![1, 2],
+        n_negatives: 2,
+        n_module_fallback: 0,
+    };
+    let loss = nce_loss_identity(&m, batch, NceObjective::Softmax, &dev()).unwrap();
+    let grads = loss.backward().unwrap();
+    assert!(grads
+        .get(var(&vm, MODULE_LOGITS_VAR_NAME).as_tensor())
+        .is_none());
+    assert!(grad_norm(&grads, &var(&vm, MODULE_MU_VAR_NAME)).unwrap() > 1e-4);
+}
+
+/// Exact module term: reaches μ, b_m and e_c; never the logits, r, a_g, b_c. Its
+/// gradient on the module bias is exactly mean_c (q_cm − p_cm).
+#[test]
+fn exact_term_reaches_mu_bias_cells_with_q_minus_p_and_nothing_else() {
+    let vm = VarMap::new();
+    let m = model(0.7, &vm);
+    let modules = m.modules.as_ref().unwrap();
+    let u = 3usize;
+    let x = Tensor::rand(0f32, 5.0, (u, D), &dev()).unwrap();
+    let pi = modules.membership().unwrap();
+    let x_cm = x.matmul(&pi).unwrap();
+    let e_units = m.e_cell.narrow(0, 0, u).unwrap();
+    let loss = module_softmax_loss(&e_units, &modules.mu, &modules.b_module, &x_cm).unwrap();
+    let grads = loss.backward().unwrap();
+    assert!(grad_norm(&grads, &var(&vm, MODULE_MU_VAR_NAME)).unwrap() > 1e-5);
+    assert!(grad_norm(&grads, &var(&vm, "e_cell")).unwrap() > 1e-5);
+    for absent in [
+        MODULE_LOGITS_VAR_NAME,
+        MODULE_RESIDUAL_VAR_NAME,
+        "b_feat",
+        "b_cell",
+    ] {
+        assert!(
+            grads.get(var(&vm, absent).as_tensor()).is_none(),
+            "{absent} must not be reached by the exact term"
+        );
+    }
+    // Analytic check on b_m: ∂L/∂b_m = mean_c (q_cm − p_cm).
+    let s = e_units
+        .matmul(&modules.mu.t().unwrap())
+        .unwrap()
+        .broadcast_add(&modules.b_module)
+        .unwrap();
+    let q = candle_util::candle_nn::ops::softmax(&s, 1).unwrap();
+    let p = x_cm.broadcast_div(&x_cm.sum_keepdim(1).unwrap()).unwrap();
+    let want: Vec<f32> = (q - p).unwrap().mean(0).unwrap().to_vec1().unwrap();
+    let got: Vec<f32> = grads
+        .get(var(&vm, MODULE_BIAS_VAR_NAME).as_tensor())
+        .unwrap()
+        .to_vec1()
+        .unwrap();
+    for (a, b) in want.iter().zip(&got) {
+        assert!(
+            (a - b).abs() < 1e-5,
+            "∂L/∂b_m: analytic {a} vs autograd {b}"
+        );
+    }
+}
+
+/// Balance prior reaches only the logits; the ridge only the residual; the gate
+/// KL reaches the gate tables and, through the live composition, μ.
+#[test]
+fn priors_reach_their_own_tables() {
+    let vm = VarMap::new();
+    let mut m = model(0.7, &vm);
+    let pi = m.modules.as_ref().unwrap().membership().unwrap();
+    let grads = module_balance_prior(&pi).unwrap().backward().unwrap();
+    assert!(grad_norm(&grads, &var(&vm, MODULE_LOGITS_VAR_NAME)).unwrap() > 1e-6);
+    assert!(grads
+        .get(var(&vm, MODULE_MU_VAR_NAME).as_tensor())
+        .is_none());
+
+    var(&vm, MODULE_RESIDUAL_VAR_NAME)
+        .set(&Tensor::ones((D, H), DType::F32, &dev()).unwrap())
+        .unwrap();
+    let grads = m.feature_ridge(0.1).unwrap().unwrap().backward().unwrap();
+    assert!(grad_norm(&grads, &var(&vm, MODULE_RESIDUAL_VAR_NAME)).unwrap() > 1e-6);
+    assert!(grads
+        .get(var(&vm, MODULE_MU_VAR_NAME).as_tensor())
+        .is_none());
+    assert!(grads
+        .get(var(&vm, MODULE_LOGITS_VAR_NAME).as_tensor())
+        .is_none());
+
+    m.enable_feature_gate(
+        FeatureGateSpec {
+            temperature: 1.0,
+            ibp_alpha: None,
+        },
+        &vm,
+        &dev(),
+    )
+    .unwrap();
+    let grads = m.gate_kl().unwrap().unwrap().backward().unwrap();
+    assert!(grad_norm(&grads, &var(&vm, "s_feat")).unwrap() > 1e-8);
+    assert!(grad_norm(&grads, &var(&vm, "e_feat_logstd")).unwrap() > 1e-8);
+    assert!(grad_norm(&grads, &var(&vm, MODULE_MU_VAR_NAME)).unwrap() > 1e-8);
+    // And the gated gather still composes the live row.
+    let idx = Tensor::from_vec(vec![1u32], 1, &dev()).unwrap();
+    let rows = gather_feature_rows(&m, &idx).unwrap();
+    assert_eq!(rows.dims(), &[1, H]);
+    let _ = sparsemax(&m.modules.as_ref().unwrap().logits).unwrap();
+}

--- a/graph-embedding-util/tests/module_gradient_contract.rs
+++ b/graph-embedding-util/tests/module_gradient_contract.rs
@@ -34,6 +34,8 @@ fn model(own_mass: f32, vm: &VarMap) -> JointEmbedModel {
             n_modules: M,
             init_labels: Some(&labels),
             init_own_mass: own_mass,
+            init_logits: None,
+            init_mu: None,
             b_feat: &[0f32; D],
             b_cell: &[0f32; N],
             seed: 1,

--- a/graph-embedding-util/tests/module_gradient_contract.rs
+++ b/graph-embedding-util/tests/module_gradient_contract.rs
@@ -10,8 +10,8 @@ use graph_embedding_util::loss::{
     NceObjective,
 };
 use graph_embedding_util::model::{
-    FeatureGateSpec, JointEmbedModel, ModuleInit, MODULE_BIAS_VAR_NAME, MODULE_LOGITS_VAR_NAME,
-    MODULE_MU_VAR_NAME, MODULE_RESIDUAL_VAR_NAME,
+    FeatureGateSpec, JointEmbedModel, ModuleInit, ModuleWarmStart, MODULE_BIAS_VAR_NAME,
+    MODULE_LOGITS_VAR_NAME, MODULE_MU_VAR_NAME, MODULE_RESIDUAL_VAR_NAME,
 };
 
 const D: usize = 8;
@@ -32,10 +32,10 @@ fn model(own_mass: f32, vm: &VarMap) -> JointEmbedModel {
             n_cells: N,
             embedding_dim: H,
             n_modules: M,
-            init_labels: Some(&labels),
-            init_own_mass: own_mass,
-            init_logits: None,
-            init_mu: None,
+            warm: ModuleWarmStart::Labels {
+                labels: &labels,
+                own_mass,
+            },
             b_feat: &[0f32; D],
             b_cell: &[0f32; N],
             seed: 1,
@@ -75,7 +75,6 @@ fn within_module_nce_reaches_residual_and_cells_but_not_mu() {
         fine_feats: vec![0],
         neg_feats: vec![3, 6],
         n_negatives: 2,
-        n_module_fallback: 0,
     };
     // Perturb the residual so rows differ (zero-init would make the loss flat).
     let r = var(&vm, MODULE_RESIDUAL_VAR_NAME);
@@ -116,7 +115,6 @@ fn identical_membership_rows_cancel_mu_even_when_mixed() {
         fine_feats: vec![0],
         neg_feats: vec![3, 6],
         n_negatives: 2,
-        n_module_fallback: 0,
     };
     let loss = nce_loss_identity(&m, batch, NceObjective::Softmax, &dev()).unwrap();
     let grads = loss.backward().unwrap();
@@ -136,7 +134,6 @@ fn within_module_nce_reaches_mu_and_logits_under_mixed_membership() {
         fine_feats: vec![0],
         neg_feats: vec![1, 2],
         n_negatives: 2,
-        n_module_fallback: 0,
     };
     let loss = nce_loss_identity(&m, batch, NceObjective::Softmax, &dev()).unwrap();
     let grads = loss.backward().unwrap();
@@ -149,7 +146,6 @@ fn within_module_nce_reaches_mu_and_logits_under_mixed_membership() {
         fine_feats: vec![0],
         neg_feats: vec![1, 2],
         n_negatives: 2,
-        n_module_fallback: 0,
     };
     let loss = nce_loss_identity(&m, batch, NceObjective::Softmax, &dev()).unwrap();
     let grads = loss.backward().unwrap();

--- a/pinto/Cargo.toml
+++ b/pinto/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.9.1"
+version = "0.9.2"
 
 [[bin]]
 name = "pinto"

--- a/pinto/Cargo.toml
+++ b/pinto/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.9.0"
+version = "0.9.1"
 
 [[bin]]
 name = "pinto"

--- a/pinto/src/cell_activity_graph_embedding/args.rs
+++ b/pinto/src/cell_activity_graph_embedding/args.rs
@@ -712,6 +712,14 @@ pub struct CellActivityGraphEmbeddingArgs {
                 on top of the shared map"
     )]
     pub gene_adapter_residual: bool,
+
+    /// The `--gene-modules` flag group (see `graph_embedding_util::GeneModuleArgs`).
+    /// Cage has no gene-negative NCE, so the within-module negatives do not apply
+    /// here; the composition, the exact pseudobulk–module term, the gene dropout
+    /// and the warm start do. The residual takes `--embedding-l2` like every other
+    /// gene-side table in cage.
+    #[command(flatten)]
+    pub modules: graph_embedding_util::GeneModuleArgs,
 }
 
 /// What training may do to a pre-trained gene embedding.

--- a/pinto/src/cell_activity_graph_embedding/args.rs
+++ b/pinto/src/cell_activity_graph_embedding/args.rs
@@ -713,6 +713,45 @@ pub struct CellActivityGraphEmbeddingArgs {
     )]
     pub gene_adapter_residual: bool,
 
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = GeneInitMode::Membership,
+        requires = "gene_embedding",
+        help = "How a gene with no dictionary row starts",
+        long_help = "How a gene with no row in --gene-embedding starts.\n\
+                     \n\
+                     membership places it through the dictionary's learned modules:\n\
+                     its membership is the similarity-weighted mean of the closest\n\
+                     matched genes' memberships (by count profile), and its row is\n\
+                     that membership times the module dictionary, with no residual.\n\
+                     Needs {stem}.module_membership.parquet and\n\
+                     {stem}.module_dictionary.parquet beside the dictionary; without\n\
+                     them it falls back to neighbor and says so in\n\
+                     {out}.gene_embedding_init.parquet.\n\
+                     \n\
+                     neighbor copies the row of the single closest matched gene."
+    )]
+    pub gene_init_mode: GeneInitMode,
+
+    #[arg(
+        long,
+        default_value_t = 10,
+        value_name = "K",
+        requires = "gene_embedding",
+        help = "membership init: matched genes whose memberships are averaged"
+    )]
+    pub gene_init_neighbours: usize,
+
+    #[arg(
+        long,
+        default_value_t = 0.2,
+        value_name = "S",
+        requires = "gene_embedding",
+        help = "membership init: below this best profile similarity a gene takes the diffuse prior"
+    )]
+    pub gene_init_similarity_floor: f32,
+
     /// The `--gene-modules` flag group (see `graph_embedding_util::GeneModuleArgs`).
     /// Cage has no gene-negative NCE, so the within-module negatives do not apply
     /// here; the composition, the exact pseudobulk–module term, the gene dropout
@@ -720,6 +759,16 @@ pub struct CellActivityGraphEmbeddingArgs {
     /// gene-side table in cage.
     #[command(flatten)]
     pub modules: graph_embedding_util::GeneModuleArgs,
+}
+
+/// How a gene with no dictionary row is initialized.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum GeneInitMode {
+    /// Through the dictionary's learned modules (falls back to `Neighbor`
+    /// without module tables).
+    Membership,
+    /// The closest matched gene's row.
+    Neighbor,
 }
 
 /// What training may do to a pre-trained gene embedding.

--- a/pinto/src/cell_activity_graph_embedding/args.rs
+++ b/pinto/src/cell_activity_graph_embedding/args.rs
@@ -736,7 +736,7 @@ pub struct CellActivityGraphEmbeddingArgs {
 
     #[arg(
         long,
-        default_value_t = 10,
+        default_value_t = graph_embedding_util::transfer::DEFAULT_INIT_NEIGHBOURS,
         value_name = "K",
         requires = "gene_embedding",
         help = "membership init: matched genes whose memberships are averaged"
@@ -745,7 +745,7 @@ pub struct CellActivityGraphEmbeddingArgs {
 
     #[arg(
         long,
-        default_value_t = 0.2,
+        default_value_t = graph_embedding_util::transfer::DEFAULT_SIMILARITY_FLOOR,
         value_name = "S",
         requires = "gene_embedding",
         help = "membership init: below this best profile similarity a gene takes the diffuse prior"

--- a/pinto/src/cell_activity_graph_embedding/fit.rs
+++ b/pinto/src/cell_activity_graph_embedding/fit.rs
@@ -273,7 +273,8 @@ pub fn fit_cell_activity_graph_embedding(
             );
         }
     }
-    let module_cfg = args.modules.to_config()?;
+    // Opt-in on cage: the default sampled gate anchors on a free per-gene table.
+    let module_cfg = args.modules.resolve(None)?;
     anyhow::ensure!(
         !(module_cfg.is_some() && args.gene_embedding.is_some()),
         "--gene-modules learns the gene side through a module layer and --gene-embedding \

--- a/pinto/src/cell_activity_graph_embedding/fit.rs
+++ b/pinto/src/cell_activity_graph_embedding/fit.rs
@@ -969,6 +969,8 @@ pub fn fit_cell_activity_graph_embedding(
                         n_modules: gm.n_modules,
                         init_labels: Some(&labels),
                         init_own_mass: gm.init_own_mass,
+                        init_logits: None,
+                        init_mu: None,
                         b_feat: &b_feat_init,
                         b_cell: &b_pb_init,
                         seed: c.seed,

--- a/pinto/src/cell_activity_graph_embedding/fit.rs
+++ b/pinto/src/cell_activity_graph_embedding/fit.rs
@@ -119,12 +119,13 @@ use data_beans_alg::hvg::select_hvg_streaming;
 use data_beans_alg::random_projection::RandProjOps;
 use graph_embedding_util::embedding_col_names;
 use graph_embedding_util::loss::{
-    build_per_batch_unit_samplers, draw_gene_keep_mask, embedding_ridge, masked_membership,
-    membership_diagnostics, module_balance_prior, module_row_entropy, module_softmax_loss,
-    pool_module_counts, ChainGroupFilter,
+    build_per_batch_unit_samplers, draw_gene_keep_mask, embedding_ridge,
+    log_membership_diagnostics, masked_membership, module_priors, module_step_loss,
+    ChainGroupFilter,
 };
 use graph_embedding_util::model::{
     AdapterInit, FeatureGateSpec, GateKind, JointEmbedModel, ModelArgs, ModelInit, ModuleInit,
+    ModuleWarmStart,
 };
 use graph_embedding_util::stop::setup_stop_handler;
 use matrix_util::common_io::mkdir_parent;
@@ -872,7 +873,7 @@ pub fn fit_cell_activity_graph_embedding(
                 name_kind: feature_kind.clone(),
                 gene_profiles: &build_profiles,
                 membership_init: match args.gene_init_mode {
-                    GeneInitMode::Membership => Some(pretrained::MembershipInit {
+                    GeneInitMode::Membership => Some(graph_embedding_util::transfer::AlignKnobs {
                         k: args.gene_init_neighbours,
                         similarity_floor: args.gene_init_similarity_floor,
                     }),
@@ -967,10 +968,10 @@ pub fn fit_cell_activity_graph_embedding(
                         n_cells: n_pb,
                         embedding_dim: args.embedding_dim,
                         n_modules: gm.n_modules,
-                        init_labels: Some(&labels),
-                        init_own_mass: gm.init_own_mass,
-                        init_logits: None,
-                        init_mu: None,
+                        warm: ModuleWarmStart::Labels {
+                            labels: &labels,
+                            own_mass: gm.init_own_mass,
+                        },
                         b_feat: &b_feat_init,
                         b_cell: &b_pb_init,
                         seed: c.seed,
@@ -1177,30 +1178,29 @@ pub fn fit_cell_activity_graph_embedding(
     let stop = setup_stop_handler();
 
     // Module warm-up: hold the k-means membership for the first epochs, release
-    // it afterwards (same schedule as geu's composite trainer).
-    let module_warmup = module_cfg.as_ref().map(|gm| {
-        gm.warmup_epochs
-            .unwrap_or_else(|| ((args.epochs as f64) * 0.25).ceil() as usize)
-            .clamp(usize::from(args.epochs > 0), args.epochs)
-    });
-    if let (Some(m), Some(wu)) = (&model.modules, module_warmup) {
-        m.set_frozen(wu > 0);
-        info!(
-            "gene modules: membership held for {wu} of {} epochs, then trained",
-            args.epochs
-        );
-    }
-    // The profile columns the module term pools, as row-major `[n_pb][G]` so a
-    // drawn pseudobulk's count row is one contiguous copy.
-    let module_rows: Option<Vec<Vec<f32>>> = module_profiles.as_ref().map(|p| {
-        (0..p.ncols())
-            .map(|j| p.column(j).iter().copied().collect())
-            .collect()
-    });
+    // it afterwards (geu's schedule). The profile matrix the exact term pools sits
+    // on the device as `[n_pb × G]`, so a step is one `index_select`.
+    let module_run: Option<(usize, Tensor)> = match (&module_cfg, &module_profiles) {
+        (Some(gm), Some(p)) => {
+            let wu = gm.warmup_epochs_for(args.epochs);
+            if let Some(m) = &model.modules {
+                m.set_frozen(wu > 0);
+            }
+            info!(
+                "gene modules: membership held for {wu} of {} epochs, then trained",
+                args.epochs
+            );
+            let rows: Vec<f32> = (0..p.ncols())
+                .flat_map(|j| p.column(j).iter().copied().collect::<Vec<f32>>())
+                .collect();
+            Some((wu, Tensor::from_vec(rows, (p.ncols(), p.nrows()), &dev)?))
+        }
+        _ => None,
+    };
 
     'epochs: for epoch in 0..args.epochs {
-        if let (Some(m), Some(wu)) = (&model.modules, module_warmup) {
-            if epoch == wu && m.is_frozen() {
+        if let (Some(m), Some((wu, _))) = (&model.modules, &module_run) {
+            if epoch == *wu && m.is_frozen() {
                 m.set_frozen(false);
                 info!("epoch {epoch}: module membership released — π now trains");
             }
@@ -1444,51 +1444,33 @@ pub fn fit_cell_activity_graph_embedding(
                 total = (total + (kl * (chunk_mass / epoch_mass))?)?;
             }
             // Exact pseudobulk–module term + membership priors, once per optimizer
-            // step like geu's composite trainer: draw `units_per_step` pseudobulks
-            // uniformly, pool their count rows through the (dropout-masked)
-            // membership, and score every module with a full softmax against the
+            // step, through the same functions geu's composite trainer uses: draw
+            // `units_per_step` pseudobulks uniformly, pool their count rows through
+            // the (dropout-masked) membership, and score every module against the
             // trained PB table.
-            if let (Some(m), Some(gm), Some(rows)) =
-                (&model.modules, module_cfg.as_ref(), module_rows.as_ref())
+            if let (Some(m), Some(gm), Some((_, profile_t))) =
+                (&model.modules, module_cfg.as_ref(), module_run.as_ref())
             {
                 let u = gm.units_per_step.min(n_pb);
                 if u > 0 && gm.lambda_module > 0.0 {
-                    let mut rng = SmallRng::seed_from_u64(
-                        c.seed
-                            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
-                            .wrapping_add((epoch as u64).wrapping_mul(7_919))
-                            .wrapping_add(chunk_count as u64),
-                    );
-                    let picks: Vec<u32> =
-                        (0..u).map(|_| rng.random_range(0..n_pb) as u32).collect();
-                    let mut flat: Vec<f32> = Vec::with_capacity(u * n_genes);
-                    for &p in &picks {
-                        flat.extend_from_slice(&rows[p as usize]);
-                    }
-                    let x = Tensor::from_vec(flat, (u, n_genes), &dev)?;
+                    let picks: Vec<u32> = (0..u)
+                        .map(|_| rng_master.random_range(0..n_pb) as u32)
+                        .collect();
+                    let idx = Tensor::from_vec(picks, u, &dev)?;
+                    let x = profile_t.index_select(&idx, 0)?;
                     let pi = m.membership()?;
                     let pi_masked = if gm.gene_dropout > 0.0 {
-                        let keep = draw_gene_keep_mask(n_genes, gm.gene_dropout, &mut rng, &dev)?;
+                        let keep =
+                            draw_gene_keep_mask(n_genes, gm.gene_dropout, &mut rng_master, &dev)?;
                         masked_membership(&pi, &keep)?
                     } else {
-                        pi.clone()
+                        pi.detach()
                     };
-                    let x_cm = pool_module_counts(&x, &pi_masked)?;
-                    let idx = Tensor::from_vec(picks, u, &dev)?;
                     let e_units = model.e_cell.index_select(&idx, 0)?;
-                    let term = module_softmax_loss(&e_units, &m.mu, &m.b_module, &x_cm)?;
-                    total = (total + term.affine(f64::from(gm.lambda_module), 0.0)?)?;
-                    if !m.is_frozen() {
-                        if gm.lambda_balance > 0.0 {
-                            let bal = module_balance_prior(&pi)?
-                                .affine(f64::from(gm.lambda_balance), 0.0)?;
-                            total = (total + bal)?;
-                        }
-                        if gm.lambda_entropy > 0.0 {
-                            let ent = module_row_entropy(&pi)?
-                                .affine(f64::from(gm.lambda_entropy), 0.0)?;
-                            total = (total + ent)?;
-                        }
+                    total =
+                        (total + module_step_loss(m, &pi_masked, &x, &e_units, gm.lambda_module)?)?;
+                    if let Some(prior) = module_priors(m, &pi, gm.lambda_balance)? {
+                        total = (total + prior)?;
                     }
                 }
             }
@@ -1567,17 +1549,8 @@ pub fn fit_cell_activity_graph_embedding(
         );
         if let Some(m) = &model.modules {
             let pi_host: Vec<f32> = m.membership()?.detach().flatten_all()?.to_vec1()?;
-            let dg = membership_diagnostics(&pi_host, n_genes, m.n_modules, 5);
-            info!(
-                "epoch {epoch} modules{}: max occupancy {:.2}x uniform, {} of {} modules below 5 \
-                 genes, row entropy {:.3} nats, {:.2} modules/gene",
-                if m.is_frozen() { " (frozen)" } else { "" },
-                dg.max_occupancy_ratio,
-                dg.n_small_modules,
-                m.n_modules,
-                dg.mean_row_entropy,
-                dg.mean_row_support,
-            );
+            // cage draws its negatives over pseudobulks, so no within-module fallback.
+            log_membership_diagnostics(m, &pi_host, epoch, args.epochs, 0)?;
         }
 
         // Pair-term magnitude: the collapse detector. If this decays toward

--- a/pinto/src/cell_activity_graph_embedding/fit.rs
+++ b/pinto/src/cell_activity_graph_embedding/fit.rs
@@ -82,7 +82,7 @@
 //! because a dropout keep-rate is not a coefficient.
 
 use crate::cell_activity_graph_embedding::args::{
-    CellActivityGraphEmbeddingArgs, GateMode, GeneEmbeddingMode,
+    CellActivityGraphEmbeddingArgs, GateMode, GeneEmbeddingMode, GeneInitMode,
 };
 use crate::cell_activity_graph_embedding::gene_chain_sampler::{
     build_gene_exp_batch_cache, GeneGatedChainSampler,
@@ -871,6 +871,13 @@ pub fn fit_cell_activity_graph_embedding(
                 gene_names: &gene_names,
                 name_kind: feature_kind.clone(),
                 gene_profiles: &build_profiles,
+                membership_init: match args.gene_init_mode {
+                    GeneInitMode::Membership => Some(pretrained::MembershipInit {
+                        k: args.gene_init_neighbours,
+                        similarity_floor: args.gene_init_similarity_floor,
+                    }),
+                    GeneInitMode::Neighbor => None,
+                },
             })?;
             // adapt decouples the two widths; freeze/free install rows verbatim
             // and so need them equal.

--- a/pinto/src/cell_activity_graph_embedding/fit.rs
+++ b/pinto/src/cell_activity_graph_embedding/fit.rs
@@ -119,15 +119,18 @@ use data_beans_alg::hvg::select_hvg_streaming;
 use data_beans_alg::random_projection::RandProjOps;
 use graph_embedding_util::embedding_col_names;
 use graph_embedding_util::loss::{
-    build_per_batch_unit_samplers, embedding_ridge, ChainGroupFilter,
+    build_per_batch_unit_samplers, draw_gene_keep_mask, embedding_ridge, masked_membership,
+    membership_diagnostics, module_balance_prior, module_row_entropy, module_softmax_loss,
+    pool_module_counts, ChainGroupFilter,
 };
 use graph_embedding_util::model::{
-    AdapterInit, FeatureGateSpec, GateKind, JointEmbedModel, ModelArgs, ModelInit,
+    AdapterInit, FeatureGateSpec, GateKind, JointEmbedModel, ModelArgs, ModelInit, ModuleInit,
 };
 use graph_embedding_util::stop::setup_stop_handler;
 use matrix_util::common_io::mkdir_parent;
 use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
+use rand::RngExt;
 use rand::SeedableRng;
 use std::sync::atomic::Ordering;
 
@@ -270,6 +273,18 @@ pub fn fit_cell_activity_graph_embedding(
             );
         }
     }
+    let module_cfg = args.modules.to_config()?;
+    anyhow::ensure!(
+        !(module_cfg.is_some() && args.gene_embedding.is_some()),
+        "--gene-modules learns the gene side through a module layer and --gene-embedding \
+         installs a pre-trained one; the two parameterizations are exclusive. Drop one."
+    );
+    anyhow::ensure!(
+        !(module_cfg.is_some() && args.gate_mode == GateMode::Sampled),
+        "--gene-modules cannot combine with --gate-mode sampled: the Gibbs selection \
+         anchors on a free per-gene table, which the module model composes rather than \
+         trains. Pass --gate-mode learned."
+    );
     anyhow::ensure!(
         !(args.gene_adapter_residual && args.gene_embedding_mode != GeneEmbeddingMode::Adapt),
         "--gene-adapter-residual is the adapter's per-gene correction and only \
@@ -826,22 +841,29 @@ pub fn fit_cell_activity_graph_embedding(
     // axis is final and the coarsening exists (its finest level pools the
     // per-gene profiles that seed unmatched genes), and before the model so
     // the init below can consume it.
+    // Per-gene profiles over the finest pseudobulks `[G × n_pb]`: the seed for
+    // unmatched pre-trained genes, and the count rows the module term pools.
+    // Lazy for the pre-trained path (a full pass over the data that runs only if
+    // the loader finds a gene with no dictionary row); materialized once for the
+    // module path, which reads it every step.
+    let build_profiles = || -> anyhow::Result<Mat> {
+        let finest = ml
+            .all_cell_labels
+            .last()
+            .expect("coarsening produced no levels");
+        let n_pb = finest.iter().copied().max().map_or(0, |m| m + 1);
+        let row_profiles = coarsen_cell_expression_dense(&data_vec, finest, n_pb)?;
+        Ok(gene_axis
+            .pool_rows_opt(&row_profiles)
+            .unwrap_or(row_profiles))
+    };
+    let module_profiles: Option<Mat> = match &module_cfg {
+        Some(_) => Some(build_profiles()?),
+        None => None,
+    };
     let pretrained_gene = match args.gene_embedding.as_deref() {
         None => None,
         Some(dict_path) => {
-            // Lazy: this full pass over the data runs only if the loader
-            // actually finds a gene with no dictionary row.
-            let build_profiles = || -> anyhow::Result<Mat> {
-                let finest = ml
-                    .all_cell_labels
-                    .last()
-                    .expect("coarsening produced no levels");
-                let n_pb = finest.iter().copied().max().map_or(0, |m| m + 1);
-                let row_profiles = coarsen_cell_expression_dense(&data_vec, finest, n_pb)?;
-                Ok(gene_axis
-                    .pool_rows_opt(&row_profiles)
-                    .unwrap_or(row_profiles))
-            };
             let pre = pretrained::load_pretrained_gene_embedding(pretrained::PretrainedArgs {
                 dictionary_path: dict_path,
                 bias_path: args.gene_embedding_bias.as_deref(),
@@ -909,6 +931,46 @@ pub fn fit_cell_activity_graph_embedding(
         (None, _) => info!("PB table starts from seeded random init (no collapse SVD)"),
     }
     let (mut model, frozen_gene) = match (&pretrained_gene, args.gene_embedding_mode) {
+        // Learned gene modules: every gene row is `Σ_m π_gm μ_m + r_g`, warm-started
+        // from a k-means over the pseudobulk profiles. Same detached-snapshot
+        // contract as the adapter arm.
+        _ if module_cfg.is_some() => {
+            let gm = module_cfg.as_ref().expect("checked above");
+            let profiles = module_profiles.as_ref().expect("built with the config");
+            anyhow::ensure!(
+                profiles.nrows() == n_genes && profiles.ncols() == n_pb,
+                "module profiles [{} x {}] do not match {} genes x {} pseudobulks",
+                profiles.nrows(),
+                profiles.ncols(),
+                n_genes,
+                n_pb
+            );
+            let labels =
+                graph_embedding_util::warm_start_module_labels(profiles, gm.n_modules, c.seed);
+            info!(
+                "learned gene modules: {} genes → {} modules (mixed membership), gene dropout {}, \
+                 exact module term λ={}, balance λ={}",
+                n_genes, gm.n_modules, gm.gene_dropout, gm.lambda_module, gm.lambda_balance
+            );
+            (
+                JointEmbedModel::new_with_modules(
+                    ModuleInit {
+                        n_features: n_genes,
+                        n_cells: n_pb,
+                        embedding_dim: args.embedding_dim,
+                        n_modules: gm.n_modules,
+                        init_labels: Some(&labels),
+                        init_own_mass: gm.init_own_mass,
+                        b_feat: &b_feat_init,
+                        b_cell: &b_pb_init,
+                        seed: c.seed,
+                    },
+                    &varmap,
+                    &dev,
+                )?,
+                None,
+            )
+        }
         // Adapter: the dictionary is a fixed constant and the gene side trains
         // one shared [h_src x H] map (plus the optional per-gene residual), so
         // every gene's gradient moves the same few parameters.
@@ -1104,7 +1166,35 @@ pub fn fit_cell_activity_graph_embedding(
     // second ^C = hard abort. See graph_embedding_util::stop.
     let stop = setup_stop_handler();
 
+    // Module warm-up: hold the k-means membership for the first epochs, release
+    // it afterwards (same schedule as geu's composite trainer).
+    let module_warmup = module_cfg.as_ref().map(|gm| {
+        gm.warmup_epochs
+            .unwrap_or_else(|| ((args.epochs as f64) * 0.25).ceil() as usize)
+            .clamp(usize::from(args.epochs > 0), args.epochs)
+    });
+    if let (Some(m), Some(wu)) = (&model.modules, module_warmup) {
+        m.set_frozen(wu > 0);
+        info!(
+            "gene modules: membership held for {wu} of {} epochs, then trained",
+            args.epochs
+        );
+    }
+    // The profile columns the module term pools, as row-major `[n_pb][G]` so a
+    // drawn pseudobulk's count row is one contiguous copy.
+    let module_rows: Option<Vec<Vec<f32>>> = module_profiles.as_ref().map(|p| {
+        (0..p.ncols())
+            .map(|j| p.column(j).iter().copied().collect())
+            .collect()
+    });
+
     'epochs: for epoch in 0..args.epochs {
+        if let (Some(m), Some(wu)) = (&model.modules, module_warmup) {
+            if epoch == wu && m.is_frozen() {
+                m.set_frozen(false);
+                info!("epoch {epoch}: module membership released — π now trains");
+            }
+        }
         let mut perm: Vec<usize> = trainable_genes.clone();
         // ONE `z ~ Bern(pip)` draw for the whole epoch. Per-EPOCH, not
         // per-chunk: `z` is a latent for the DATASET, so a per-chunk draw would
@@ -1343,6 +1433,55 @@ pub fn fit_cell_activity_graph_embedding(
             if let Some(kl) = model.gate_kl()? {
                 total = (total + (kl * (chunk_mass / epoch_mass))?)?;
             }
+            // Exact pseudobulk–module term + membership priors, once per optimizer
+            // step like geu's composite trainer: draw `units_per_step` pseudobulks
+            // uniformly, pool their count rows through the (dropout-masked)
+            // membership, and score every module with a full softmax against the
+            // trained PB table.
+            if let (Some(m), Some(gm), Some(rows)) =
+                (&model.modules, module_cfg.as_ref(), module_rows.as_ref())
+            {
+                let u = gm.units_per_step.min(n_pb);
+                if u > 0 && gm.lambda_module > 0.0 {
+                    let mut rng = SmallRng::seed_from_u64(
+                        c.seed
+                            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                            .wrapping_add((epoch as u64).wrapping_mul(7_919))
+                            .wrapping_add(chunk_count as u64),
+                    );
+                    let picks: Vec<u32> =
+                        (0..u).map(|_| rng.random_range(0..n_pb) as u32).collect();
+                    let mut flat: Vec<f32> = Vec::with_capacity(u * n_genes);
+                    for &p in &picks {
+                        flat.extend_from_slice(&rows[p as usize]);
+                    }
+                    let x = Tensor::from_vec(flat, (u, n_genes), &dev)?;
+                    let pi = m.membership()?;
+                    let pi_masked = if gm.gene_dropout > 0.0 {
+                        let keep = draw_gene_keep_mask(n_genes, gm.gene_dropout, &mut rng, &dev)?;
+                        masked_membership(&pi, &keep)?
+                    } else {
+                        pi.clone()
+                    };
+                    let x_cm = pool_module_counts(&x, &pi_masked)?;
+                    let idx = Tensor::from_vec(picks, u, &dev)?;
+                    let e_units = model.e_cell.index_select(&idx, 0)?;
+                    let term = module_softmax_loss(&e_units, &m.mu, &m.b_module, &x_cm)?;
+                    total = (total + term.affine(f64::from(gm.lambda_module), 0.0)?)?;
+                    if !m.is_frozen() {
+                        if gm.lambda_balance > 0.0 {
+                            let bal = module_balance_prior(&pi)?
+                                .affine(f64::from(gm.lambda_balance), 0.0)?;
+                            total = (total + bal)?;
+                        }
+                        if gm.lambda_entropy > 0.0 {
+                            let ent = module_row_entropy(&pi)?
+                                .affine(f64::from(gm.lambda_entropy), 0.0)?;
+                            total = (total + ent)?;
+                        }
+                    }
+                }
+            }
             // Global-norm clip before the step. The NCE loss spikes when a
             // chunk draws a gene whose active edges are nearly all positives,
             // and an unbounded step there inflates the embedding norms every
@@ -1416,6 +1555,20 @@ pub fn fit_cell_activity_graph_embedding(
             "epoch {}: mean loss = {:.4e} (per-level: {:?}), samples = {}, skipped pairs = {}",
             epoch, mean_loss, mean_per_level, sample_count, skip_count
         );
+        if let Some(m) = &model.modules {
+            let pi_host: Vec<f32> = m.membership()?.detach().flatten_all()?.to_vec1()?;
+            let dg = membership_diagnostics(&pi_host, n_genes, m.n_modules, 5);
+            info!(
+                "epoch {epoch} modules{}: max occupancy {:.2}x uniform, {} of {} modules below 5 \
+                 genes, row entropy {:.3} nats, {:.2} modules/gene",
+                if m.is_frozen() { " (frozen)" } else { "" },
+                dg.max_occupancy_ratio,
+                dg.n_small_modules,
+                m.n_modules,
+                dg.mean_row_entropy,
+                dg.mean_row_support,
+            );
+        }
 
         // Pair-term magnitude: the collapse detector. If this decays toward
         // zero while the loss still falls, the ungated cell biases have taken
@@ -1590,6 +1743,9 @@ pub fn fit_cell_activity_graph_embedding(
         (Some(&gene_names), Some("feature")),
         Some(&embedding_col_names(args.embedding_dim)),
     )?;
+    // Learned-module tables (no-op without modules); the feature embedding above
+    // already holds the composed row.
+    graph_embedding_util::write_module_tables(&c.out, &model, &gene_names)?;
 
     // The adapter map itself, so the spatial refinement can be applied OUTSIDE
     // this run: any gene with a row in the source dictionary, panel or not,

--- a/pinto/src/cell_activity_graph_embedding/pair_projection.rs
+++ b/pinto/src/cell_activity_graph_embedding/pair_projection.rs
@@ -74,7 +74,7 @@
 //! are:
 //!
 //! - Its entry point is `pub(crate)`, and its batch divisor is wired to bge /
-//!   gem's pseudobulk hierarchy (`μ_residual` indexed by `cell_to_pb`), which a
+//!   gem's pseudobulk hierarchy (the per-batch gene fold `δ` indexed by each cell's batch), which a
 //!   spatial pair — batch-divided per endpoint, before pooling — does not have.
 //!   Reaching it means widening another crate's API and generalizing that
 //!   abstraction for one caller.
@@ -176,7 +176,7 @@ impl Default for PairProjectionArgs {
 }
 
 /// Per-endpoint batch division, applied to each cell's counts *before* they are
-/// pooled — the same `μ_residual` divide `senna bge` applies in phase 2, so a
+/// pooled — the same per-batch fold divide `senna bge` applies in phase 2, so a
 /// pair's latent reflects de-batched composition. Without it a multi-batch run
 /// clusters edges by batch, since every edge is within-batch by construction.
 #[derive(Copy, Clone)]

--- a/pinto/src/cell_activity_graph_embedding/pretrained.rs
+++ b/pinto/src/cell_activity_graph_embedding/pretrained.rs
@@ -19,7 +19,6 @@ use auxiliary_data::feature_rows::parse_feature_row;
 use auxiliary_data::frozen_features::{load_frozen_feature_host, FrozenLoadArgs};
 use candle_util::candle_core::{Tensor, Var};
 use log::{info, warn};
-use matrix_util::traits::IoOps;
 use rayon::prelude::*;
 
 /// Where a gene's initial embedding row came from.
@@ -119,15 +118,7 @@ pub struct PretrainedArgs<'a> {
     /// `π̂` = similarity-weighted mean membership of the `k` closest matched
     /// genes, row = `π̂ μ`. Falls back to the neighbour rule when the tables are
     /// absent. `None` = the neighbour rule.
-    pub membership_init: Option<MembershipInit>,
-}
-
-/// Knobs of the membership initialization (see
-/// [`graph_embedding_util::transfer::align_gene_axis`]).
-#[derive(Clone, Copy, Debug)]
-pub struct MembershipInit {
-    pub k: usize,
-    pub similarity_floor: f32,
+    pub membership_init: Option<graph_embedding_util::transfer::AlignKnobs>,
 }
 
 /// Load, align, and fill. See the module doc for the contract; every path
@@ -187,8 +178,21 @@ pub fn load_pretrained_gene_embedding(
     // Membership initialization through the dictionary's modules, when asked
     // for and the tables exist. Returns early with the alignment's rows for the
     // unmatched genes; otherwise the neighbour rule below runs.
-    if let (Some(mi), false) = (args.membership_init, unmatched_idx.is_empty()) {
-        if let Some((pi, mu)) = read_module_tables(args.dictionary_path, &dict_names)? {
+    if let (Some(knobs), false) = (args.membership_init, unmatched_idx.is_empty()) {
+        let (pi_path, mu_path) =
+            graph_embedding_util::transfer::module_table_paths(args.dictionary_path);
+        let tables =
+            if std::path::Path::new(&pi_path).exists() && std::path::Path::new(&mu_path).exists() {
+                Some(graph_embedding_util::transfer::read_module_tables(
+                    &pi_path,
+                    &mu_path,
+                    &host.src_names,
+                    h,
+                )?)
+            } else {
+                None
+            };
+        if let Some((pi, mu)) = tables {
             let prof = (args.gene_profiles)()?;
             anyhow::ensure!(
                 prof.nrows() == n_genes,
@@ -196,8 +200,6 @@ pub fn load_pretrained_gene_embedding(
                 prof.nrows(),
                 n_genes
             );
-            let dict = <Mat as IoOps>::from_parquet(args.dictionary_path)?;
-            let n_src = dict.mat.nrows();
             // Run gene → dictionary row, for the matched genes.
             let mut new_to_train: Vec<Option<usize>> = vec![None; n_genes];
             for (&g, &src) in host
@@ -207,59 +209,58 @@ pub fn load_pretrained_gene_embedding(
             {
                 new_to_train[g] = Some(src);
             }
-            let zeros = vec![0f32; n_src];
             let al = graph_embedding_util::transfer::align_gene_axis(
                 &graph_embedding_util::transfer::AlignInputs {
-                    rho: &dict.mat,
-                    b_feat: &zeros,
+                    rho: &host.src_e_feat,
+                    b_feat: None,
                     modules: Some(graph_embedding_util::transfer::ModuleTables {
                         pi: &pi,
                         mu: &mu,
                     }),
                     new_to_train: &new_to_train,
                     profiles_new: Some(&prof),
-                    k: mi.k,
-                    similarity_floor: mi.similarity_floor,
+                    knobs,
                 },
             );
-            // The alignment lists the unmatched genes after the dictionary's rows,
-            // in run order — the same order as `unmatched_idx`.
             let mut diffuse = 0usize;
-            let mut records: Vec<InitRecord> = Vec::with_capacity(n_genes);
-            let mut u = 0usize;
-            for (g, gene) in args.gene_names.iter().enumerate() {
-                if matched[g] {
-                    records.push(InitRecord {
+            let records: Vec<InitRecord> = args
+                .gene_names
+                .iter()
+                .enumerate()
+                .map(|(g, gene)| {
+                    if matched[g] {
+                        return InitRecord {
+                            gene: gene.clone(),
+                            init: InitKind::Matched,
+                            neighbor_gene: None,
+                            cosine: f32::NAN,
+                        };
+                    }
+                    let union = al.new_to_union[g].expect("an unmatched gene is initialized");
+                    for c in 0..h {
+                        e_gene[(g, c)] = al.rows[(union, c)];
+                    }
+                    let prov = al.provenance[union]
+                        .as_ref()
+                        .expect("an initialized gene has provenance");
+                    if prov.diffuse {
+                        diffuse += 1;
+                    }
+                    InitRecord {
                         gene: gene.clone(),
-                        init: InitKind::Matched,
-                        neighbor_gene: None,
-                        cosine: f32::NAN,
-                    });
-                    continue;
-                }
-                let union = n_src + u;
-                u += 1;
-                debug_assert_eq!(al.union_to_new[union], Some(g));
-                for c in 0..h {
-                    e_gene[(g, c)] = al.rows[(union, c)];
-                }
-                let prov = al.provenance[union]
-                    .as_ref()
-                    .expect("an unmatched gene is initialized");
-                if prov.diffuse {
-                    diffuse += 1;
-                }
-                records.push(InitRecord {
-                    gene: gene.clone(),
-                    init: InitKind::Membership,
-                    neighbor_gene: prov.neighbours.first().map(|&src| dict_names[src].clone()),
-                    cosine: if prov.diffuse {
-                        f32::NAN
-                    } else {
-                        prov.best_similarity
-                    },
-                });
-            }
+                        init: InitKind::Membership,
+                        neighbor_gene: prov
+                            .neighbours
+                            .first()
+                            .map(|&src| host.src_names[src].clone()),
+                        cosine: if prov.diffuse {
+                            f32::NAN
+                        } else {
+                            prov.best_similarity
+                        },
+                    }
+                })
+                .collect();
             info!(
                 "Pre-trained gene embedding: {} matched, {} membership-initialized through {} \
                  modules ({} on the diffuse prior), {} dictionary rows unused",
@@ -392,38 +393,6 @@ pub fn load_pretrained_gene_embedding(
         b_gene,
         records,
     })
-}
-
-/// The dictionary's module tables, `(π [D_src × M], μ [M × H])`, when both sit
-/// beside it under the run's stem; `None` when either is absent. π's rows must
-/// be the dictionary's genes in the dictionary's order.
-fn read_module_tables(
-    dictionary_path: &str,
-    dict_names: &[Box<str>],
-) -> anyhow::Result<Option<(Mat, Mat)>> {
-    let stem = ["feature_loading", "dictionary"]
-        .iter()
-        .find_map(|slot| dictionary_path.strip_suffix(&format!(".{slot}.parquet")))
-        .or_else(|| dictionary_path.strip_suffix(".parquet"))
-        .unwrap_or(dictionary_path);
-    let pi_path = format!("{stem}.module_membership.parquet");
-    let mu_path = format!("{stem}.module_dictionary.parquet");
-    if !(std::path::Path::new(&pi_path).exists() && std::path::Path::new(&mu_path).exists()) {
-        return Ok(None);
-    }
-    let pi = <Mat as IoOps>::from_parquet(&pi_path)?;
-    let mu = <Mat as IoOps>::from_parquet(&mu_path)?;
-    anyhow::ensure!(
-        pi.rows.len() == dict_names.len() && pi.rows.iter().zip(dict_names).all(|(a, b)| a == b),
-        "{pi_path}: rows are not the dictionary's genes in the dictionary's order"
-    );
-    anyhow::ensure!(
-        mu.mat.nrows() == pi.mat.ncols(),
-        "{mu_path}: {} modules but {pi_path} has {}",
-        mu.mat.nrows(),
-        pi.mat.ncols()
-    );
-    Ok(Some((pi.mat, mu.mat)))
 }
 
 /// Write the audit table: one row per gene, in gene-axis order.

--- a/pinto/src/cell_activity_graph_embedding/pretrained.rs
+++ b/pinto/src/cell_activity_graph_embedding/pretrained.rs
@@ -19,6 +19,7 @@ use auxiliary_data::feature_rows::parse_feature_row;
 use auxiliary_data::frozen_features::{load_frozen_feature_host, FrozenLoadArgs};
 use candle_util::candle_core::{Tensor, Var};
 use log::{info, warn};
+use matrix_util::traits::IoOps;
 use rayon::prelude::*;
 
 /// Where a gene's initial embedding row came from.
@@ -183,6 +184,104 @@ pub fn load_pretrained_gene_embedding(
     let matched_idx: Vec<usize> = (0..n_genes).filter(|&g| matched[g]).collect();
     let unmatched_idx: Vec<usize> = (0..n_genes).filter(|&g| !matched[g]).collect();
 
+    // Membership initialization through the dictionary's modules, when asked
+    // for and the tables exist. Returns early with the alignment's rows for the
+    // unmatched genes; otherwise the neighbour rule below runs.
+    if let (Some(mi), false) = (args.membership_init, unmatched_idx.is_empty()) {
+        if let Some((pi, mu)) = read_module_tables(args.dictionary_path, &dict_names)? {
+            let prof = (args.gene_profiles)()?;
+            anyhow::ensure!(
+                prof.nrows() == n_genes,
+                "gene_profiles rows ({}) != gene axis ({})",
+                prof.nrows(),
+                n_genes
+            );
+            let dict = <Mat as IoOps>::from_parquet(args.dictionary_path)?;
+            let n_src = dict.mat.nrows();
+            // Run gene → dictionary row, for the matched genes.
+            let mut new_to_train: Vec<Option<usize>> = vec![None; n_genes];
+            for (&g, &src) in host
+                .keep_target_indices
+                .iter()
+                .zip(host.keep_src_indices.iter())
+            {
+                new_to_train[g] = Some(src);
+            }
+            let zeros = vec![0f32; n_src];
+            let al = graph_embedding_util::transfer::align_gene_axis(
+                &graph_embedding_util::transfer::AlignInputs {
+                    rho: &dict.mat,
+                    b_feat: &zeros,
+                    modules: Some(graph_embedding_util::transfer::ModuleTables {
+                        pi: &pi,
+                        mu: &mu,
+                    }),
+                    new_to_train: &new_to_train,
+                    profiles_new: Some(&prof),
+                    k: mi.k,
+                    similarity_floor: mi.similarity_floor,
+                },
+            );
+            // The alignment lists the unmatched genes after the dictionary's rows,
+            // in run order — the same order as `unmatched_idx`.
+            let mut diffuse = 0usize;
+            let mut records: Vec<InitRecord> = Vec::with_capacity(n_genes);
+            let mut u = 0usize;
+            for (g, gene) in args.gene_names.iter().enumerate() {
+                if matched[g] {
+                    records.push(InitRecord {
+                        gene: gene.clone(),
+                        init: InitKind::Matched,
+                        neighbor_gene: None,
+                        cosine: f32::NAN,
+                    });
+                    continue;
+                }
+                let union = n_src + u;
+                u += 1;
+                debug_assert_eq!(al.union_to_new[union], Some(g));
+                for c in 0..h {
+                    e_gene[(g, c)] = al.rows[(union, c)];
+                }
+                let prov = al.provenance[union]
+                    .as_ref()
+                    .expect("an unmatched gene is initialized");
+                if prov.diffuse {
+                    diffuse += 1;
+                }
+                records.push(InitRecord {
+                    gene: gene.clone(),
+                    init: InitKind::Membership,
+                    neighbor_gene: prov.neighbours.first().map(|&src| dict_names[src].clone()),
+                    cosine: if prov.diffuse {
+                        f32::NAN
+                    } else {
+                        prov.best_similarity
+                    },
+                });
+            }
+            info!(
+                "Pre-trained gene embedding: {} matched, {} membership-initialized through {} \
+                 modules ({} on the diffuse prior), {} dictionary rows unused",
+                n_matched,
+                unmatched_idx.len(),
+                pi.ncols(),
+                diffuse,
+                dict_names.len().saturating_sub(n_matched)
+            );
+            return Ok(PretrainedGeneEmbedding {
+                e_gene,
+                b_gene,
+                records,
+            });
+        }
+        info!(
+            "membership initialization requested but {} has no module tables beside it; \
+             falling back to the neighbour rule",
+            args.dictionary_path
+        );
+    }
+
     // Closest matched gene by profile cosine, per unmatched gene. The
     // profiles (a full pass over the data at the caller) are built only when
     // this branch is reached at all.
@@ -293,6 +392,38 @@ pub fn load_pretrained_gene_embedding(
         b_gene,
         records,
     })
+}
+
+/// The dictionary's module tables, `(π [D_src × M], μ [M × H])`, when both sit
+/// beside it under the run's stem; `None` when either is absent. π's rows must
+/// be the dictionary's genes in the dictionary's order.
+fn read_module_tables(
+    dictionary_path: &str,
+    dict_names: &[Box<str>],
+) -> anyhow::Result<Option<(Mat, Mat)>> {
+    let stem = ["feature_loading", "dictionary"]
+        .iter()
+        .find_map(|slot| dictionary_path.strip_suffix(&format!(".{slot}.parquet")))
+        .or_else(|| dictionary_path.strip_suffix(".parquet"))
+        .unwrap_or(dictionary_path);
+    let pi_path = format!("{stem}.module_membership.parquet");
+    let mu_path = format!("{stem}.module_dictionary.parquet");
+    if !(std::path::Path::new(&pi_path).exists() && std::path::Path::new(&mu_path).exists()) {
+        return Ok(None);
+    }
+    let pi = <Mat as IoOps>::from_parquet(&pi_path)?;
+    let mu = <Mat as IoOps>::from_parquet(&mu_path)?;
+    anyhow::ensure!(
+        pi.rows.len() == dict_names.len() && pi.rows.iter().zip(dict_names).all(|(a, b)| a == b),
+        "{pi_path}: rows are not the dictionary's genes in the dictionary's order"
+    );
+    anyhow::ensure!(
+        mu.mat.nrows() == pi.mat.ncols(),
+        "{mu_path}: {} modules but {pi_path} has {}",
+        mu.mat.nrows(),
+        pi.mat.ncols()
+    );
+    Ok(Some((pi.mat, mu.mat)))
 }
 
 /// Write the audit table: one row per gene, in gene-axis order.

--- a/pinto/src/cell_activity_graph_embedding/pretrained.rs
+++ b/pinto/src/cell_activity_graph_embedding/pretrained.rs
@@ -30,6 +30,11 @@ pub enum InitKind {
     /// (or from the matched-row mean when the gene's profile is all zero,
     /// in which case `neighbor_gene` is `None`).
     Neighbor,
+    /// No dictionary row; placed through the dictionary's learned modules as
+    /// `π̂ μ`, with `π̂` averaged over the closest matched genes' memberships
+    /// (`neighbor_gene` is the best of them; `None` when the diffuse prior was
+    /// used because no neighbour reached the similarity floor).
+    Membership,
 }
 
 impl InitKind {
@@ -37,6 +42,7 @@ impl InitKind {
         match self {
             InitKind::Matched => "matched",
             InitKind::Neighbor => "neighbor",
+            InitKind::Membership => "membership",
         }
     }
 }
@@ -105,6 +111,22 @@ pub struct PretrainedArgs<'a> {
     /// row directions matter). Called at most once, and only when some gene
     /// has no dictionary row — an all-matched dictionary never pays for it.
     pub gene_profiles: &'a dyn Fn() -> anyhow::Result<Mat>,
+    /// Place unmatched genes through the dictionary's learned modules when
+    /// `{stem}.module_membership.parquet` and `{stem}.module_dictionary.parquet`
+    /// sit beside it (`stem` = the dictionary path without its
+    /// `.feature_loading.parquet` / `.dictionary.parquet` / `.parquet` suffix):
+    /// `π̂` = similarity-weighted mean membership of the `k` closest matched
+    /// genes, row = `π̂ μ`. Falls back to the neighbour rule when the tables are
+    /// absent. `None` = the neighbour rule.
+    pub membership_init: Option<MembershipInit>,
+}
+
+/// Knobs of the membership initialization (see
+/// [`graph_embedding_util::transfer::align_gene_axis`]).
+#[derive(Clone, Copy, Debug)]
+pub struct MembershipInit {
+    pub k: usize,
+    pub similarity_floor: f32,
 }
 
 /// Load, align, and fill. See the module doc for the contract; every path

--- a/pinto/src/cell_activity_graph_embedding/pretrained_tests.rs
+++ b/pinto/src/cell_activity_graph_embedding/pretrained_tests.rs
@@ -264,7 +264,7 @@ fn restore_puts_frozen_rows_back_and_leaves_trainable_rows_alone() -> anyhow::Re
 /// initialized row equals its neighbour's row exactly, and the record says how.
 #[test]
 fn unmatched_gene_is_initialized_through_the_modules_when_tables_exist() -> anyhow::Result<()> {
-    use super::pretrained::MembershipInit;
+    use graph_embedding_util::transfer::AlignKnobs;
     let dir = tempfile::tempdir()?;
     let dict_genes = names(&["G1", "G2"]);
     // π: G1 → module 0, G2 → module 1; μ: two distinct rows; ρ = π μ.
@@ -312,7 +312,7 @@ fn unmatched_gene_is_initialized_through_the_modules_when_tables_exist() -> anyh
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
-        membership_init: Some(MembershipInit {
+        membership_init: Some(AlignKnobs {
             k: 1,
             similarity_floor: 0.5,
         }),
@@ -336,7 +336,7 @@ fn unmatched_gene_is_initialized_through_the_modules_when_tables_exist() -> anyh
 /// beside it: fall back to the neighbour rule and say so in the record.
 #[test]
 fn membership_init_without_tables_falls_back_to_the_neighbour_rule() -> anyhow::Result<()> {
-    use super::pretrained::MembershipInit;
+    use graph_embedding_util::transfer::AlignKnobs;
     let dir = tempfile::tempdir()?;
     let dict_genes = names(&["G1", "G2"]);
     let path = write_dictionary(&dir, "dict", &dict_genes, 3, 0.0)?;
@@ -348,7 +348,7 @@ fn membership_init_without_tables_falls_back_to_the_neighbour_rule() -> anyhow::
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
-        membership_init: Some(MembershipInit {
+        membership_init: Some(AlignKnobs {
             k: 3,
             similarity_floor: 0.5,
         }),

--- a/pinto/src/cell_activity_graph_embedding/pretrained_tests.rs
+++ b/pinto/src/cell_activity_graph_embedding/pretrained_tests.rs
@@ -55,6 +55,7 @@ fn rows_follow_the_runs_gene_axis_not_the_dictionarys() -> anyhow::Result<()> {
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: None,
     })?;
 
     assert_eq!(out.h(), 4);
@@ -99,6 +100,7 @@ fn unmatched_gene_takes_the_closest_matched_profile_neighbor() -> anyhow::Result
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: None,
     })?;
 
     assert_eq!(out.frozen_row_mask(), vec![1.0, 1.0, 0.0]);
@@ -132,6 +134,7 @@ fn track_suffixed_rows_are_rejected_with_the_offending_name() -> anyhow::Result<
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: None,
     })
     .err()
     .expect("a co-embed table must be rejected")
@@ -159,6 +162,7 @@ fn zero_profile_gene_takes_the_matched_mean() -> anyhow::Result<()> {
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: None,
     })?;
 
     // Mean of rows (0,1) and (10,11) is (5,6).
@@ -199,6 +203,7 @@ fn bias_loads_for_matched_genes_and_zeros_elsewhere() -> anyhow::Result<()> {
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: None,
     })?;
 
     assert_eq!(out.b_gene, vec![8.0, 0.0]);
@@ -220,6 +225,7 @@ fn zero_matched_genes_is_a_hard_error() -> anyhow::Result<()> {
         gene_names: &run_genes,
         name_kind: FeatureNameKind::Exact,
         gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: None,
     })
     .is_err());
     Ok(())
@@ -249,5 +255,105 @@ fn restore_puts_frozen_rows_back_and_leaves_trainable_rows_alone() -> anyhow::Re
     assert_eq!(got[0], vec![1.0, 2.0], "frozen row 0 restored");
     assert_eq!(got[2], vec![5.0, 6.0], "frozen row 2 restored");
     assert_eq!(got[1], vec![13.0, 14.0], "trainable row 1 keeps its step");
+    Ok(())
+}
+
+/// With the dictionary's module tables beside it, an unmatched gene is placed
+/// through the membership of its profile neighbours: `π̂ μ`, without the
+/// neighbour's residual. Here the dictionary IS `π μ` (zero residual), so the
+/// initialized row equals its neighbour's row exactly, and the record says how.
+#[test]
+fn unmatched_gene_is_initialized_through_the_modules_when_tables_exist() -> anyhow::Result<()> {
+    use super::pretrained::MembershipInit;
+    let dir = tempfile::tempdir()?;
+    let dict_genes = names(&["G1", "G2"]);
+    // π: G1 → module 0, G2 → module 1; μ: two distinct rows; ρ = π μ.
+    let pi = Mat::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]);
+    let mu = Mat::from_row_slice(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rho = &pi * &mu;
+    let cols: Vec<Box<str>> = (0..3).map(|c| format!("h{c}").into()).collect();
+    let dict_path = dir
+        .path()
+        .join("run.feature_loading.parquet")
+        .to_string_lossy()
+        .into_owned();
+    rho.to_parquet_with_names(&dict_path, (Some(&dict_genes), Some("gene")), Some(&cols))?;
+    let mcols: Vec<Box<str>> = (0..2).map(|c| format!("m{c}").into()).collect();
+    let mnames = names(&["m0", "m1"]);
+    pi.to_parquet_with_names(
+        &dir.path()
+            .join("run.module_membership.parquet")
+            .to_string_lossy(),
+        (Some(&dict_genes), Some("feature")),
+        Some(&mcols),
+    )?;
+    mu.to_parquet_with_names(
+        &dir.path()
+            .join("run.module_dictionary.parquet")
+            .to_string_lossy(),
+        (Some(&mnames), Some("module")),
+        Some(&cols),
+    )?;
+
+    let run_genes = names(&["G1", "G2", "G9"]);
+    // Depth-equal pseudobulks; G9's profile is G2's shape.
+    let profiles = Mat::from_row_slice(
+        3,
+        4,
+        &[
+            9.0, 1.0, 9.0, 1.0, // G1
+            1.0, 9.0, 1.0, 9.0, // G2
+            2.0, 18.0, 2.0, 18.0, // G9 ~ G2
+        ],
+    );
+    let out = load_pretrained_gene_embedding(PretrainedArgs {
+        dictionary_path: &dict_path,
+        bias_path: None,
+        gene_names: &run_genes,
+        name_kind: FeatureNameKind::Exact,
+        gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: Some(MembershipInit {
+            k: 1,
+            similarity_floor: 0.5,
+        }),
+    })?;
+    assert_eq!(out.frozen_row_mask(), vec![1.0, 1.0, 0.0]);
+    for c in 0..3 {
+        assert!(
+            (out.e_gene[(2, c)] - rho[(1, c)]).abs() < 1e-6,
+            "G9 col {c}"
+        );
+    }
+    let rec = &out.records[2];
+    assert_eq!(rec.init, InitKind::Membership);
+    assert_eq!(rec.neighbor_gene.as_deref(), Some("G2"));
+    assert!(rec.cosine > 0.99, "cosine {}", rec.cosine);
+    assert_eq!(out.records[0].init, InitKind::Matched);
+    Ok(())
+}
+
+/// Membership initialization asked for, but the dictionary has no module tables
+/// beside it: fall back to the neighbour rule and say so in the record.
+#[test]
+fn membership_init_without_tables_falls_back_to_the_neighbour_rule() -> anyhow::Result<()> {
+    use super::pretrained::MembershipInit;
+    let dir = tempfile::tempdir()?;
+    let dict_genes = names(&["G1", "G2"]);
+    let path = write_dictionary(&dir, "dict", &dict_genes, 3, 0.0)?;
+    let run_genes = names(&["G1", "G2", "G9"]);
+    let profiles = Mat::from_row_slice(3, 2, &[1.0, 0.0, 0.0, 1.0, 0.0, 2.0]);
+    let out = load_pretrained_gene_embedding(PretrainedArgs {
+        dictionary_path: &path,
+        bias_path: None,
+        gene_names: &run_genes,
+        name_kind: FeatureNameKind::Exact,
+        gene_profiles: &|| Ok(profiles.clone()),
+        membership_init: Some(MembershipInit {
+            k: 3,
+            similarity_floor: 0.5,
+        }),
+    })?;
+    assert_eq!(out.records[2].init, InitKind::Neighbor);
+    assert_eq!(out.records[2].neighbor_gene.as_deref(), Some("G2"));
     Ok(())
 }

--- a/pinto/src/predict.rs
+++ b/pinto/src/predict.rs
@@ -91,27 +91,20 @@ pub struct PredictArgs {
 
     #[arg(
         long,
-        value_enum,
-        default_value_t = crate::cell_activity_graph_embedding::args::GeneInitMode::Membership,
-        help = "How a gene the model never saw is placed: through its modules, or dropped",
-        long_help = "How a gene of this sample that the model never saw is handled.\n\
-                     \n\
-                     membership places it through the model's learned modules (needs\n\
-                     {model}.module_membership.parquet and {model}.module_dictionary.parquet):\n\
-                     its membership is the similarity-weighted mean of the closest matched\n\
-                     genes' memberships by count profile over pseudobulks of this sample,\n\
-                     and its row is that membership times the module dictionary. The gene\n\
-                     then sits on the partition axis with its own counts. Written to\n\
-                     {out}.gene_embedding_init.parquet with its provenance.\n\
-                     \n\
-                     neighbor drops it: no row, not on the partition axis — the historical\n\
-                     behaviour, kept because an invented row pulls on every pair's latent."
+        help = "Drop genes the model never saw instead of initializing them through its modules",
+        long_help = "Genes of this sample that the model never saw are placed through the model's\n\
+                     learned modules (needs {model}.module_membership.parquet and\n\
+                     {model}.module_dictionary.parquet): membership averaged over the closest\n\
+                     matched genes by count profile over pseudobulks of this sample, row =\n\
+                     membership times the module dictionary, with their own counts on the\n\
+                     partition axis and provenance in {out}.gene_embedding_init.parquet.\n\
+                     This flag restores the historical drop: no row, not on the axis."
     )]
-    pub gene_init_mode: crate::cell_activity_graph_embedding::args::GeneInitMode,
+    pub no_init_genes: bool,
 
     #[arg(
         long,
-        default_value_t = 10,
+        default_value_t = graph_embedding_util::transfer::DEFAULT_INIT_NEIGHBOURS,
         value_name = "K",
         help = "membership init: matched genes whose memberships are averaged"
     )]
@@ -119,7 +112,7 @@ pub struct PredictArgs {
 
     #[arg(
         long,
-        default_value_t = 0.2,
+        default_value_t = graph_embedding_util::transfer::DEFAULT_SIMILARITY_FLOOR,
         value_name = "S",
         help = "membership init: below this best profile similarity a gene takes the diffuse prior"
     )]
@@ -390,14 +383,14 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
     for (i, &g) in host.keep_target_indices.iter().enumerate() {
         e_full.row_mut(g).copy_from(&host.e_feat.row(i));
     }
-    // Genes the model never saw: placed through its modules when asked and the
-    // tables exist (the same loader cage trains from), else left off the axis.
-    let mut initialized_genes: Vec<bool> = vec![false; n_genes];
-    if matches!(
-        args.gene_init_mode,
-        crate::cell_activity_graph_embedding::args::GeneInitMode::Membership
-    ) && n_matched < n_genes
-    {
+    // Which genes are on the partition axis: every matched gene, plus — unless
+    // `--no-init-genes` — the genes the model never saw, placed through its
+    // modules by the same loader cage trains from.
+    let mut on_axis: Vec<bool> = vec![false; n_genes];
+    for &g in &host.keep_target_indices {
+        on_axis[g] = true;
+    }
+    if !args.no_init_genes && n_matched < n_genes {
         use crate::cell_activity_graph_embedding::pretrained;
         // Profiles over pseudobulks of THIS sample: k-means on its random
         // projection, then per-gene sums per cluster.
@@ -406,7 +399,7 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("predict: no cell projection to cluster on"))?;
             let cells_by_dim = proj.proj.transpose(); // [n_cells × k]
-            let n_pb = (n_cells / 50).clamp(8, 256).min(n_cells.max(1));
+            let n_pb = graph_embedding_util::transfer::pseudobulk_count(n_cells);
             let (_, labels) =
                 matrix_util::principal_graph::kmeans_centroids_seeded(&cells_by_dim, n_pb, 20, 0);
             let row_profiles = crate::link_community::profiles::coarsen_cell_expression_dense(
@@ -422,23 +415,20 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
             gene_names: &gene_names,
             name_kind: feature_kind.clone(),
             gene_profiles: &build_profiles,
-            membership_init: Some(pretrained::MembershipInit {
+            membership_init: Some(graph_embedding_util::transfer::AlignKnobs {
                 k: args.gene_init_neighbours,
                 similarity_floor: args.gene_init_similarity_floor,
             }),
         })?;
-        let n_init = pre
-            .records
-            .iter()
-            .filter(|r| r.init == pretrained::InitKind::Membership)
-            .count();
-        if n_init > 0 {
-            for (g, r) in pre.records.iter().enumerate() {
-                if r.init == pretrained::InitKind::Membership {
-                    e_full.row_mut(g).copy_from(&pre.e_gene.row(g));
-                    initialized_genes[g] = true;
-                }
+        let mut n_init = 0usize;
+        for (g, r) in pre.records.iter().enumerate() {
+            if r.init == pretrained::InitKind::Membership {
+                e_full.row_mut(g).copy_from(&pre.e_gene.row(g));
+                on_axis[g] = true;
+                n_init += 1;
             }
+        }
+        if n_init > 0 {
             pretrained::write_init_report(&c.out, &pre.records)?;
             info!(
                 "{n_init} genes the model never saw were initialized through its modules and \
@@ -453,9 +443,6 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
             );
         }
     }
-    // Per-gene totals: from the TRAINING half when given, else from the query.
-    // Substituted here rather than later so the model-dictionary mask below still
-    // applies to whichever source was used.
     let mut gene_totals = match args.null_from.as_deref() {
         Some(files) => training_gene_totals(files, c, &feature_kind, &gene_names)?,
         None => {
@@ -473,15 +460,9 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
             gene_axis.pool_totals(&row_totals)
         }
     };
-    {
-        let mut matched = vec![false; n_genes];
-        for &g in &host.keep_target_indices {
-            matched[g] = true;
-        }
-        for (g, t) in gene_totals.iter_mut().enumerate() {
-            if !matched[g] && !initialized_genes[g] {
-                *t = 0.0;
-            }
+    for (g, t) in gene_totals.iter_mut().enumerate() {
+        if !on_axis[g] {
+            *t = 0.0;
         }
     }
 

--- a/pinto/src/predict.rs
+++ b/pinto/src/predict.rs
@@ -91,6 +91,42 @@ pub struct PredictArgs {
 
     #[arg(
         long,
+        value_enum,
+        default_value_t = crate::cell_activity_graph_embedding::args::GeneInitMode::Membership,
+        help = "How a gene the model never saw is placed: through its modules, or dropped",
+        long_help = "How a gene of this sample that the model never saw is handled.\n\
+                     \n\
+                     membership places it through the model's learned modules (needs\n\
+                     {model}.module_membership.parquet and {model}.module_dictionary.parquet):\n\
+                     its membership is the similarity-weighted mean of the closest matched\n\
+                     genes' memberships by count profile over pseudobulks of this sample,\n\
+                     and its row is that membership times the module dictionary. The gene\n\
+                     then sits on the partition axis with its own counts. Written to\n\
+                     {out}.gene_embedding_init.parquet with its provenance.\n\
+                     \n\
+                     neighbor drops it: no row, not on the partition axis — the historical\n\
+                     behaviour, kept because an invented row pulls on every pair's latent."
+    )]
+    pub gene_init_mode: crate::cell_activity_graph_embedding::args::GeneInitMode,
+
+    #[arg(
+        long,
+        default_value_t = 10,
+        value_name = "K",
+        help = "membership init: matched genes whose memberships are averaged"
+    )]
+    pub gene_init_neighbours: usize,
+
+    #[arg(
+        long,
+        default_value_t = 0.2,
+        value_name = "S",
+        help = "membership init: below this best profile similarity a gene takes the diffuse prior"
+    )]
+    pub gene_init_similarity_floor: f32,
+
+    #[arg(
+        long,
         default_value_t = 1.0,
         help = "Ridge on the pair latent (as in cage)",
         hide = true
@@ -299,6 +335,7 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
         gene_weights,
         n_cells,
         n_rows: _,
+        cell_proj,
         ..
     } = preprocess_srt(SrtPreprocessConfig {
         common: c,
@@ -353,6 +390,69 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
     for (i, &g) in host.keep_target_indices.iter().enumerate() {
         e_full.row_mut(g).copy_from(&host.e_feat.row(i));
     }
+    // Genes the model never saw: placed through its modules when asked and the
+    // tables exist (the same loader cage trains from), else left off the axis.
+    let mut initialized_genes: Vec<bool> = vec![false; n_genes];
+    if matches!(
+        args.gene_init_mode,
+        crate::cell_activity_graph_embedding::args::GeneInitMode::Membership
+    ) && n_matched < n_genes
+    {
+        use crate::cell_activity_graph_embedding::pretrained;
+        // Profiles over pseudobulks of THIS sample: k-means on its random
+        // projection, then per-gene sums per cluster.
+        let build_profiles = || -> anyhow::Result<Mat> {
+            let proj = cell_proj
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("predict: no cell projection to cluster on"))?;
+            let cells_by_dim = proj.proj.transpose(); // [n_cells × k]
+            let n_pb = (n_cells / 50).clamp(8, 256).min(n_cells.max(1));
+            let (_, labels) =
+                matrix_util::principal_graph::kmeans_centroids_seeded(&cells_by_dim, n_pb, 20, 0);
+            let row_profiles = crate::link_community::profiles::coarsen_cell_expression_dense(
+                &data_vec, &labels, n_pb,
+            )?;
+            Ok(gene_axis
+                .pool_rows_opt(&row_profiles)
+                .unwrap_or(row_profiles))
+        };
+        let pre = pretrained::load_pretrained_gene_embedding(pretrained::PretrainedArgs {
+            dictionary_path: &format!("{}.feature_embedding.parquet", args.model),
+            bias_path: None,
+            gene_names: &gene_names,
+            name_kind: feature_kind.clone(),
+            gene_profiles: &build_profiles,
+            membership_init: Some(pretrained::MembershipInit {
+                k: args.gene_init_neighbours,
+                similarity_floor: args.gene_init_similarity_floor,
+            }),
+        })?;
+        let n_init = pre
+            .records
+            .iter()
+            .filter(|r| r.init == pretrained::InitKind::Membership)
+            .count();
+        if n_init > 0 {
+            for (g, r) in pre.records.iter().enumerate() {
+                if r.init == pretrained::InitKind::Membership {
+                    e_full.row_mut(g).copy_from(&pre.e_gene.row(g));
+                    initialized_genes[g] = true;
+                }
+            }
+            pretrained::write_init_report(&c.out, &pre.records)?;
+            info!(
+                "{n_init} genes the model never saw were initialized through its modules and \
+                 join the partition axis (see {}.gene_embedding_init.parquet)",
+                c.out
+            );
+        } else {
+            info!(
+                "no module tables beside {}.feature_embedding.parquet: genes the model never \
+                 saw stay off the partition axis",
+                args.model
+            );
+        }
+    }
     // Per-gene totals: from the TRAINING half when given, else from the query.
     // Substituted here rather than later so the model-dictionary mask below still
     // applies to whichever source was used.
@@ -379,7 +479,7 @@ pub fn predict_cage(args: &PredictArgs) -> anyhow::Result<(Mat, Vec<Box<str>>)> 
             matched[g] = true;
         }
         for (g, t) in gene_totals.iter_mut().enumerate() {
-            if !matched[g] {
+            if !matched[g] && !initialized_genes[g] {
                 *t = 0.0;
             }
         }

--- a/pinto/src/util/batch_effects.rs
+++ b/pinto/src/util/batch_effects.rs
@@ -24,12 +24,15 @@
 //!    "what would this group look like in another batch?" estimate.
 //!    - `imputed_sum[g,s]` = weighted average of matched neighbors'
 //!      per-cell gene expression, scaled by cell count
-//!    - `residual_sum[g,s]` = observed / imputed ratio
+//!    - `matched_bs[b,s]` = how much of that counterfactual came from
+//!      each source batch
 //!
-//! 5. **EM-style optimization**: iteratively refine four Gamma
-//!    parameters (μ, μ_resid, γ, δ) to decompose observed expression
-//!    into true signal (μ), batch effect (δ), and cross-batch
-//!    correction terms (γ, μ_resid).
+//! 5. **EM-style optimization**: one batch-free rate μ per (gene, group)
+//!    with both the observed and the counterfactual side Poisson at that
+//!    rate, and a per-(gene, batch) fold δ identified by the counterfactual
+//!    side and pinned to geometric mean 1 over the frame batches. The
+//!    per-group readouts μ_resid (own fold) and γ (source fold) are derived
+//!    from μ afterwards.
 //!
 //! 6. **Multilevel refinement**: repeat steps 1-5 at each level with
 //!    increasing `sort_dim` (coarse → fine). Coarser levels capture

--- a/senna/Cargo.toml
+++ b/senna/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.11.2"
+version = "0.12.0"
 
 [lib]
 name = "senna"

--- a/senna/Cargo.toml
+++ b/senna/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
-version = "0.11.1"
+version = "0.11.2"
 
 [lib]
 name = "senna"

--- a/senna/src/bge/args.rs
+++ b/senna/src/bge/args.rs
@@ -395,7 +395,8 @@ pub struct BgeArgs {
     #[command(flatten)]
     pub(crate) posterior: ge::posterior::PosteriorArgs,
 
-    /// The `--gene-modules` flag group (see `ge::GeneModuleArgs`).
+    /// The `--gene-modules` flag group (see `ge::GeneModuleArgs`); on by default
+    /// here, resolved in `build_config`.
     #[command(flatten)]
     pub(crate) modules: ge::GeneModuleArgs,
 

--- a/senna/src/bge/args.rs
+++ b/senna/src/bge/args.rs
@@ -44,10 +44,10 @@ pub struct BgeArgs {
     #[serde(skip)]
     pub(crate) pb_reference: Option<crate::pb_reference::ReferenceInput>,
 
-    /// The parent run this one continues, set by `senna update`. Like `svd`,
-    /// bge has no weights to warm-start (its ETM is re-derived by archetypal
-    /// analysis each run), so this only chains the emitted reference's
-    /// generation counter.
+    /// The parent run this one continues, set by `senna update`. bge carries
+    /// the parent's learned gene modules as its warm start (see
+    /// `parent_modules`); the ETM is re-derived by archetypal analysis each run,
+    /// and the emitted reference's generation counter is chained through here.
     #[arg(skip)]
     #[serde(skip)]
     pub(crate) init_from: Option<Box<str>>,
@@ -420,10 +420,9 @@ impl crate::update::Updatable for BgeArgs {
         self.batch_files = r.batch_files;
         self.out = r.out;
         self.pb_reference = r.reference;
-        // Like `svd`, bge has no weights to warm-start: `update` re-fits on
-        // the union with the recorded configuration, and the carried
-        // reference (when used) is what keeps that O(new). `init_from` only
-        // chains the emitted reference's generation counter.
+        // `update` re-fits on the union with the recorded configuration; the
+        // carried reference (when used) keeps that O(new), and `init_from` is
+        // where `build_config` finds the parent's modules to warm-start from.
         self.init_from = Some(r.init_from);
         if let Some(e) = r.epochs {
             self.epochs = e;

--- a/senna/src/bge/args.rs
+++ b/senna/src/bge/args.rs
@@ -395,6 +395,10 @@ pub struct BgeArgs {
     #[command(flatten)]
     pub(crate) posterior: ge::posterior::PosteriorArgs,
 
+    /// The `--gene-modules` flag group (see `ge::GeneModuleArgs`).
+    #[command(flatten)]
+    pub(crate) modules: ge::GeneModuleArgs,
+
     #[arg(
         long,
         short,

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -363,6 +363,8 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
             pb_posterior_nested_delta: true,
             pb_posterior: posterior_plan.map(|plan| plan.pb_gibbs_config()),
             nce_objective: args.nce_objective.to_ge(),
+            // `--gene-modules M`: learned mixed-membership modules in front of ρ.
+            gene_modules: args.modules.to_config()?,
             // Per-(gene, dim) Bernoulli spike-and-slab feature gate, ALWAYS ON for bge
             // (inclusion KL against a learned π_h + Gaussian effect KL, at the fixed
             // internal weight). There is no null absorber and no simplex — that was the
@@ -521,6 +523,8 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
                 qc_keep_idx.as_deref(),
                 &cell_labels,
             )?;
+            // The --skip-etm branch writes these inside `save_outputs_named`.
+            ge::write_module_tables(&args.out, &out.model, &unified.feature_names)?;
         } else {
             ge::save_outputs_named(
                 &out.model,
@@ -544,6 +548,7 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
         .as_ref()
         .map(|v| v.iter().map(std::string::ToString::to_string).collect())
         .unwrap_or_default();
+    let has_modules = out.model.modules.is_some();
     crate::run_manifest::write_run_manifest(&crate::run_manifest::RunDescription {
         train_args: Some(crate::run_manifest::record_train_args(args)?),
         kind: crate::run_manifest::RunKind::Bge,
@@ -570,6 +575,10 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
         // dictionary and ignores the co-embed file on disk).
         feature_embedding_suffix: Some("feature_embedding.parquet"),
         feature_loading_suffix: Some("feature_loading.parquet"),
+        // Learned gene modules, when the run trained them; the composed row still
+        // lives in `feature_loading`, so these are additive.
+        module_membership_suffix: has_modules.then_some("module_membership.parquet"),
+        module_dictionary_suffix: has_modules.then_some("module_dictionary.parquet"),
         // ETM resolved => `dictionary` holds the log-simplex β; --skip-etm => it is ρ.
         softmax_dictionary_suffix: resolve_etm.then_some("dictionary.parquet"),
         // Z always lands in cell_embedding.parquet — on BOTH the ETM and

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -368,7 +368,14 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
             // (`--no-gene-modules` opts out): on held-out marrow cells they turned the
             // gain over the training-marginal null from negative to zero, raised the
             // per-cell rank agreement, and lost less under gene ablation.
-            gene_modules: args.modules.resolve(Some(ge::DEFAULT_GENE_MODULES))?,
+            // Under `senna update` the parent's modules are carried as the warm start.
+            gene_modules: match args.modules.resolve(Some(ge::DEFAULT_GENE_MODULES))? {
+                Some(mut gm) => {
+                    gm.parent = parent_modules(args.init_from.as_deref(), &unified.feature_names)?;
+                    Some(gm)
+                }
+                None => None,
+            },
             // Per-(gene, dim) Bernoulli spike-and-slab feature gate, ALWAYS ON for bge
             // (inclusion KL against a learned π_h + Gaussian effect KL, at the fixed
             // internal weight). There is no null absorber and no simplex — that was the
@@ -669,4 +676,51 @@ fn median_of(v: &[f64]) -> f64 {
     let mut s = v.to_vec();
     s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     s[s.len() / 2]
+}
+
+/// The parent run's module tables for `senna update`'s warm start, matched to
+/// this fit's feature axis by exact name. `None` when there is no parent, or the
+/// parent trained no modules (the fit then warm-starts from its own k-means, as a
+/// fresh run would).
+fn parent_modules(
+    init_from: Option<&str>,
+    feature_names: &[Box<str>],
+) -> anyhow::Result<Option<ge::ParentModulesOwned>> {
+    let Some(prefix) = init_from else {
+        return Ok(None);
+    };
+    let parent = crate::bge::score::BgeEmbedding::open(prefix)?;
+    let Some((pi, mu)) = parent.modules else {
+        info!(
+            "update: parent {prefix} trained no gene modules; warm-starting from this fit's own \
+             profiles"
+        );
+        return Ok(None);
+    };
+    let by_name: std::collections::HashMap<&str, usize> = parent
+        .gene_names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.as_ref(), i))
+        .collect();
+    let row_to_parent: Vec<Option<usize>> = feature_names
+        .iter()
+        .map(|n| by_name.get(n.as_ref()).copied())
+        .collect();
+    let n_matched = row_to_parent.iter().filter(|r| r.is_some()).count();
+    info!(
+        "update: carrying {} gene modules from {prefix}; {} of {} features match the parent by name",
+        mu.nrows(),
+        n_matched,
+        feature_names.len()
+    );
+    let rho = Mat::from_row_slice(parent.gene_names.len(), parent.h, &parent.rho);
+    Ok(Some(ge::ParentModulesOwned {
+        rho,
+        pi,
+        mu,
+        row_to_parent,
+        k: 10,
+        similarity_floor: 0.2,
+    }))
 }

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -611,6 +611,9 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
     // separates by batch, this table says whether the separation was already
     // there before phase 2.
     write_pb_embeddings(&args.out, &out.pb_embeddings, &unified.batch_names)?;
+    if let Some(fold) = &out.batch_gene_fold {
+        write_batch_gene_fold(&args.out, fold, &unified.feature_names)?;
+    }
 
     // The posterior no longer runs here. It is phase-1's own sampler now
     // (`FitConfig::pb_posterior`), so it happens INSIDE `fit` — before phase 2,
@@ -732,6 +735,25 @@ fn parent_modules(
 /// command's, so it lives here rather than in the shared flag group.
 const DEFAULT_GENE_MODULES: usize = 128;
 
+/// `{out}.batch_gene_fold.parquet`: the per-batch gene fold phase 2 divided each
+/// batch's cell counts by, as `log δ_gb`, `[features × batches]`.
+fn write_batch_gene_fold(
+    out: &str,
+    fold: &ge::fit::BatchGeneFold,
+    feature_names: &[Box<str>],
+) -> anyhow::Result<()> {
+    let table = Mat::from_row_slice(fold.n_batches(), fold.n_features, &fold.delta)
+        .map(f32::ln)
+        .transpose();
+    table.to_parquet_with_names(
+        &format!("{out}.batch_gene_fold.parquet"),
+        (Some(feature_names), Some("feature")),
+        Some(&fold.batch_names),
+    )?;
+    info!("Wrote {out}.batch_gene_fold.parquet");
+    Ok(())
+}
+
 /// `{out}.pb_embedding.parquet` (rows `l{level}:pb{i}`, columns `h0..`) and
 /// `{out}.pb_batch.parquet` (level and batch name per row), every level stacked.
 fn write_pb_embeddings(
@@ -739,27 +761,25 @@ fn write_pb_embeddings(
     levels: &[ge::fit::PbLevelEmbedding],
     batch_names: &[Box<str>],
 ) -> anyhow::Result<()> {
+    use matrix_util::dmatrix_util::concatenate_vertical;
     use matrix_util::parquet::{write_named_table, Column};
     if levels.is_empty() {
         return Ok(());
     }
     let h = levels[0].e_pb.ncols();
-    let n: usize = levels.iter().map(|l| l.e_pb.nrows()).sum();
-    let mut table = Mat::zeros(n, h);
+    let table = concatenate_vertical(&levels.iter().map(|l| l.e_pb.clone()).collect::<Vec<_>>())?;
+    let n = table.nrows();
     let mut rows: Vec<Box<str>> = Vec::with_capacity(n);
     let mut level_col: Vec<i32> = Vec::with_capacity(n);
     let mut batch_col: Vec<Box<str>> = Vec::with_capacity(n);
-    let mut r = 0usize;
     for (level, l) in levels.iter().enumerate() {
         for i in 0..l.e_pb.nrows() {
-            table.set_row(r, &l.e_pb.row(i));
             rows.push(format!("l{level}:pb{i}").into_boxed_str());
             level_col.push(level as i32);
             batch_col.push(match l.batch[i] {
                 u32::MAX => Box::from(""),
                 b => batch_names[b as usize].clone(),
             });
-            r += 1;
         }
     }
     table.to_parquet_with_names(

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -22,6 +22,7 @@ use graph_embedding_util as ge;
 
 pub(crate) mod args;
 mod resolve_etm;
+pub(crate) mod transfer;
 pub(crate) mod score;
 
 pub use args::BgeArgs;

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -369,7 +369,7 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
             // gain over the training-marginal null from negative to zero, raised the
             // per-cell rank agreement, and lost less under gene ablation.
             // Under `senna update` the parent's modules are carried as the warm start.
-            gene_modules: match args.modules.resolve(Some(ge::DEFAULT_GENE_MODULES))? {
+            gene_modules: match args.modules.resolve(Some(DEFAULT_GENE_MODULES))? {
                 Some(mut gm) => {
                     gm.parent = parent_modules(args.init_from.as_deref(), &unified.feature_names)?;
                     Some(gm)
@@ -534,8 +534,6 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
                 qc_keep_idx.as_deref(),
                 &cell_labels,
             )?;
-            // The --skip-etm branch writes these inside `save_outputs_named`.
-            ge::write_module_tables(&args.out, &out.model, &unified.feature_names)?;
         } else {
             ge::save_outputs_named(
                 &out.model,
@@ -548,6 +546,9 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
                 ge::EmbeddingFileNames::SENNA_EMBEDDING,
             )?;
         }
+        // The learned-module tables, on both paths; the composed ρ above already
+        // carries them for every reader that does not care.
+        ge::write_module_tables(&args.out, &out.model, &unified.feature_names)?;
     }
 
     let input: Vec<String> = data_files
@@ -588,8 +589,8 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
         feature_loading_suffix: Some("feature_loading.parquet"),
         // Learned gene modules, when the run trained them; the composed row still
         // lives in `feature_loading`, so these are additive.
-        module_membership_suffix: has_modules.then_some("module_membership.parquet"),
-        module_dictionary_suffix: has_modules.then_some("module_dictionary.parquet"),
+        module_membership_suffix: has_modules.then_some(ge::transfer::MODULE_MEMBERSHIP_SUFFIX),
+        module_dictionary_suffix: has_modules.then_some(ge::transfer::MODULE_DICTIONARY_SUFFIX),
         // ETM resolved => `dictionary` holds the log-simplex β; --skip-etm => it is ρ.
         softmax_dictionary_suffix: resolve_etm.then_some("dictionary.parquet"),
         // Z always lands in cell_embedding.parquet — on BOTH the ETM and
@@ -690,6 +691,7 @@ fn parent_modules(
         return Ok(None);
     };
     let parent = crate::bge::score::BgeEmbedding::open(prefix)?;
+    let rho = parent.rho_matrix();
     let Some((pi, mu)) = parent.modules else {
         info!(
             "update: parent {prefix} trained no gene modules; warm-starting from this fit's own \
@@ -697,30 +699,29 @@ fn parent_modules(
         );
         return Ok(None);
     };
-    let by_name: std::collections::HashMap<&str, usize> = parent
-        .gene_names
-        .iter()
-        .enumerate()
-        .map(|(i, n)| (n.as_ref(), i))
-        .collect();
-    let row_to_parent: Vec<Option<usize>> = feature_names
-        .iter()
-        .map(|n| by_name.get(n.as_ref()).copied())
-        .collect();
-    let n_matched = row_to_parent.iter().filter(|r| r.is_some()).count();
+    // The same flexible matcher `predict` aligns a query with, so a parent whose
+    // names differ by case or suffix still matches.
+    let remap = crate::topic::eval::build_gene_remap_with(
+        &parent.gene_names,
+        feature_names,
+        &crate::topic::eval::QueryNameOpts::default(),
+    );
+    let n_matched = remap.new_to_train.iter().filter(|r| r.is_some()).count();
     info!(
-        "update: carrying {} gene modules from {prefix}; {} of {} features match the parent by name",
+        "update: carrying {} gene modules from {prefix}; {} of {} features match the parent",
         mu.nrows(),
         n_matched,
         feature_names.len()
     );
-    let rho = Mat::from_row_slice(parent.gene_names.len(), parent.h, &parent.rho);
     Ok(Some(ge::ParentModulesOwned {
         rho,
         pi,
         mu,
-        row_to_parent,
-        k: 10,
-        similarity_floor: 0.2,
+        row_to_parent: remap.new_to_train,
+        knobs: ge::transfer::AlignKnobs::default(),
     }))
 }
+
+/// Module count `senna bge` trains unless told otherwise — the policy is this
+/// command's, so it lives here rather than in the shared flag group.
+const DEFAULT_GENE_MODULES: usize = 128;

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -22,8 +22,8 @@ use graph_embedding_util as ge;
 
 pub(crate) mod args;
 mod resolve_etm;
-pub(crate) mod transfer;
 pub(crate) mod score;
+pub(crate) mod transfer;
 
 pub use args::BgeArgs;
 use args::MultiomeFile;

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -606,6 +606,12 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
         has_cell_to_pb: false,
     })?;
 
+    // The phase-1 pseudobulk embeddings, with each pseudobulk's batch: the
+    // geometry the dictionary was trained against. When the per-cell embedding
+    // separates by batch, this table says whether the separation was already
+    // there before phase 2.
+    write_pb_embeddings(&args.out, &out.pb_embeddings, &unified.batch_names)?;
+
     // The posterior no longer runs here. It is phase-1's own sampler now
     // (`FitConfig::pb_posterior`), so it happens INSIDE `fit` — before phase 2,
     // before the co-embedding, and against the pseudobulk side rather than a
@@ -725,3 +731,54 @@ fn parent_modules(
 /// Module count `senna bge` trains unless told otherwise — the policy is this
 /// command's, so it lives here rather than in the shared flag group.
 const DEFAULT_GENE_MODULES: usize = 128;
+
+/// `{out}.pb_embedding.parquet` (rows `l{level}:pb{i}`, columns `h0..`) and
+/// `{out}.pb_batch.parquet` (level and batch name per row), every level stacked.
+fn write_pb_embeddings(
+    out: &str,
+    levels: &[ge::fit::PbLevelEmbedding],
+    batch_names: &[Box<str>],
+) -> anyhow::Result<()> {
+    use matrix_util::parquet::{write_named_table, Column};
+    if levels.is_empty() {
+        return Ok(());
+    }
+    let h = levels[0].e_pb.ncols();
+    let n: usize = levels.iter().map(|l| l.e_pb.nrows()).sum();
+    let mut table = Mat::zeros(n, h);
+    let mut rows: Vec<Box<str>> = Vec::with_capacity(n);
+    let mut level_col: Vec<i32> = Vec::with_capacity(n);
+    let mut batch_col: Vec<Box<str>> = Vec::with_capacity(n);
+    let mut r = 0usize;
+    for (level, l) in levels.iter().enumerate() {
+        for i in 0..l.e_pb.nrows() {
+            table.set_row(r, &l.e_pb.row(i));
+            rows.push(format!("l{level}:pb{i}").into_boxed_str());
+            level_col.push(level as i32);
+            batch_col.push(match l.batch[i] {
+                u32::MAX => Box::from(""),
+                b => batch_names[b as usize].clone(),
+            });
+            r += 1;
+        }
+    }
+    table.to_parquet_with_names(
+        &format!("{out}.pb_embedding.parquet"),
+        (Some(&rows), Some("pb")),
+        Some(&axis_id_names("h", h)),
+    )?;
+    write_named_table(
+        &format!("{out}.pb_batch.parquet"),
+        "pb",
+        &rows,
+        &[
+            (Box::from("level"), Column::I32(&level_col)),
+            (Box::from("batch"), Column::Str(&batch_col)),
+        ],
+    )?;
+    info!(
+        "Wrote {out}.pb_embedding.parquet / pb_batch.parquet ({n} pseudobulks over {} levels)",
+        levels.len()
+    );
+    Ok(())
+}

--- a/senna/src/bge/mod.rs
+++ b/senna/src/bge/mod.rs
@@ -363,8 +363,11 @@ pub fn fit_bge(args: &BgeArgs) -> anyhow::Result<()> {
             pb_posterior_nested_delta: true,
             pb_posterior: posterior_plan.map(|plan| plan.pb_gibbs_config()),
             nce_objective: args.nce_objective.to_ge(),
-            // `--gene-modules M`: learned mixed-membership modules in front of ρ.
-            gene_modules: args.modules.to_config()?,
+            // Learned mixed-membership modules in front of ρ — ON by default for bge
+            // (`--no-gene-modules` opts out): on held-out marrow cells they turned the
+            // gain over the training-marginal null from negative to zero, raised the
+            // per-cell rank agreement, and lost less under gene ablation.
+            gene_modules: args.modules.resolve(Some(ge::DEFAULT_GENE_MODULES))?,
             // Per-(gene, dim) Bernoulli spike-and-slab feature gate, ALWAYS ON for bge
             // (inclusion KL against a learned π_h + Gaussian effect KL, at the fixed
             // internal weight). There is no null absorber and no simplex — that was the

--- a/senna/src/bge/score.rs
+++ b/senna/src/bge/score.rs
@@ -56,12 +56,9 @@ pub struct BgeEmbedding {
 /// How `predict` treats the new data's genes the model never saw.
 #[derive(Clone, Copy, Debug)]
 pub struct InitOpts {
-    /// `false` drops unseen genes, the pre-alignment behaviour.
-    pub enabled: bool,
-    /// Neighbours whose membership is averaged for an unseen gene.
-    pub k: usize,
-    /// Below this best cosine similarity an unseen gene takes the diffuse prior.
-    pub similarity_floor: f32,
+    /// `None` drops unseen genes, the pre-alignment behaviour; `Some` places
+    /// them through the modules with this neighbourhood.
+    pub align: Option<graph_embedding_util::transfer::AlignKnobs>,
     /// Re-project every cell with the initialized genes as observations (pass 2).
     /// Off, they are scored from the pass-1 latent and never move it.
     pub in_fit: bool,
@@ -69,9 +66,7 @@ pub struct InitOpts {
 
 impl InitOpts {
     pub const OFF: Self = Self {
-        enabled: false,
-        k: 10,
-        similarity_floor: 0.2,
+        align: None,
         in_fit: false,
     };
 }
@@ -79,10 +74,6 @@ impl InitOpts {
 /// What the alignment produced, for the writers.
 pub struct InitOutcome {
     pub alignment: graph_embedding_util::transfer::GeneAlignment,
-    /// Row names of the NEW data (the alignment's `union_to_new` indexes these).
-    pub new_gene_names: Vec<Box<str>>,
-    /// New-data rows that were initialized, in alignment order.
-    pub unseen_rows: Vec<usize>,
     /// Per-cell score on the initialized genes.
     pub scores: Vec<super::transfer::InitScore>,
     /// Pseudobulks the profiles were formed over.
@@ -110,6 +101,11 @@ pub struct BgeFit {
 }
 
 impl BgeEmbedding {
+    /// ρ as a `[D, H]` matrix (the row-major buffer read back as columns).
+    pub fn rho_matrix(&self) -> DMatrix<f32> {
+        DMatrix::from_row_slice(self.gene_names.len(), self.h, &self.rho)
+    }
+
     /// Open from a run prefix or a `{run}.senna.json` path.
     ///
     /// Both, because the two callers disagree: `probe --model` is documented as a run
@@ -166,38 +162,20 @@ impl BgeEmbedding {
         let rho_rm = rho.mat.transpose().as_slice().to_vec();
         info!("bge model: {d} genes, H={h} (ρ {rho_path})");
 
-        // Module tables, when the run trained them. Rows must be the dictionary's genes
-        // in the dictionary's order: the alignment indexes π by training row.
+        // Module tables, when the run trained them.
         let modules = match (
             manifest.outputs.module_membership.as_deref(),
             manifest.outputs.module_dictionary.as_deref(),
         ) {
             (Some(pi_rel), Some(mu_rel)) => {
-                let pi_path = run_manifest::resolve(&dir, pi_rel)
-                    .to_string_lossy()
-                    .into_owned();
-                let mu_path = run_manifest::resolve(&dir, mu_rel)
-                    .to_string_lossy()
-                    .into_owned();
-                let pi = DMatrix::<f32>::from_parquet(&pi_path)
-                    .with_context(|| format!("reading module membership {pi_path}"))?;
-                let mu = DMatrix::<f32>::from_parquet(&mu_path)
-                    .with_context(|| format!("reading module dictionary {mu_path}"))?;
-                anyhow::ensure!(
-                    pi.rows == rho.rows,
-                    "module membership genes disagree with the dictionary ({} vs {} rows)",
-                    pi.rows.len(),
-                    rho.rows.len()
-                );
-                anyhow::ensure!(
-                    mu.mat.ncols() == h && mu.mat.nrows() == pi.mat.ncols(),
-                    "module dictionary is {}×{} but π has {} modules and H={h}",
-                    mu.mat.nrows(),
-                    mu.mat.ncols(),
-                    pi.mat.ncols()
-                );
-                info!("bge model carries {} learned gene modules", pi.mat.ncols());
-                Some((pi.mat, mu.mat))
+                let (pi, mu) = graph_embedding_util::transfer::read_module_tables(
+                    &run_manifest::resolve(&dir, pi_rel).to_string_lossy(),
+                    &run_manifest::resolve(&dir, mu_rel).to_string_lossy(),
+                    &rho.rows,
+                    h,
+                )?;
+                info!("bge model carries {} learned gene modules", pi.ncols());
+                Some((pi, mu))
             }
             _ => None,
         };
@@ -252,9 +230,10 @@ impl BgeEmbedding {
         init: InitOpts,
         dev: &Device,
     ) -> anyhow::Result<BgeFit> {
-        use super::transfer::{profiles_by_cluster, score_initialized, union_remap, unseen_rows};
+        use super::transfer::{profiles_by_cluster, score_initialized, union_remap};
         use graph_embedding_util::transfer::{
-            align_gene_axis, moment_matched_bias, AlignInputs, GeneStatus, ModuleTables,
+            align_gene_axis, moment_matched_bias, pseudobulk_count, AlignInputs, GeneStatus,
+            ModuleTables,
         };
 
         let loaded = read_data_on_shared_rows(ReadSharedRowsArgs {
@@ -277,7 +256,8 @@ impl BgeEmbedding {
         // be dropped here along with every `--feature-name-*` flag.
         crate::topic::eval::ensure_gene_coverage(&remap, qopts.min_overlap, "--feature-name-kind")?;
         // The remap BEFORE the hide pass: the alignment must see a withheld model gene as
-        // matched (its row is kept, its counts are not), never as unseen.
+        // matched (its row is kept, its counts are not), never as unseen. The unseen
+        // genes are exactly the rows that matched nothing here.
         let before_hide = remap.new_to_train.clone();
         // After the coverage gate, not before: the hidden genes are deliberately
         // withheld, so counting them as missing coverage would refuse every
@@ -286,17 +266,13 @@ impl BgeEmbedding {
         if let Some(hide) = qopts.hide.as_deref() {
             crate::topic::eval::hide_features(&mut remap, &new_genes, hide)?;
         }
-        let hidden_rows: std::collections::HashSet<usize> = (0..new_genes.len())
-            .filter(|&r| before_hide[r].is_some() && remap.new_to_train[r].is_none())
-            .collect();
-        let unseen: Vec<usize> = if init.enabled {
-            unseen_rows(&before_hide, &hidden_rows)
-        } else {
-            Vec::new()
+        let unseen: Vec<usize> = match init.align {
+            Some(_) => (0..new_genes.len())
+                .filter(|&r| before_hide[r].is_none())
+                .collect(),
+            None => Vec::new(),
         };
 
-        // The exact normalizer: every model gene, so `partition_scale = 1`.
-        let partition: Vec<u32> = (0..n_model as u32).collect();
         let side = FrozenSide {
             e: &self.rho,
             b: &self.b_feat,
@@ -320,19 +296,17 @@ impl BgeEmbedding {
             remap: &remap.new_to_train,
             projector: &projector,
             side: &side,
-            partition: &partition,
             n_model,
             block,
-            h: self.h,
         })?;
 
         let mut init_out: Option<InitOutcome> = None;
-        if !unseen.is_empty() {
+        if let (Some(knobs), false) = (init.align, unseen.is_empty()) {
             let n_cells = pass.latent.nrows();
             let n_new = new_genes.len();
             // Pseudobulks for the profiles: a clustering of the pass-1 latents, so a
             // profile is a gene's expression across the cell states this model sees.
-            let n_clusters = (n_cells / 50).clamp(8, 256).min(n_cells.max(1));
+            let n_clusters = pseudobulk_count(n_cells);
             let (_, labels) = matrix_util::principal_graph::kmeans_centroids_seeded(
                 &pass.latent,
                 n_clusters,
@@ -346,7 +320,6 @@ impl BgeEmbedding {
                 unseen_local[r] = i as u32;
             }
             let mut obs: Vec<Vec<(u32, f32)>> = vec![Vec::new(); n_cells];
-            let mut totals = vec![0f32; unseen.len()];
             let mut profiles = DMatrix::<f32>::zeros(n_new, n_clusters);
             let mut lb = 0usize;
             while lb < n_cells {
@@ -355,51 +328,45 @@ impl BgeEmbedding {
                 // Raw CSC arrays sliced by offset: a column view would borrow a local.
                 let (offsets, rows_all, vals_all) =
                     (csc.col_offsets(), csc.row_indices(), csc.values());
-                profiles_by_cluster(
-                    &mut profiles,
-                    &labels,
-                    (0..csc.ncols()).map(|j| {
-                        let (s0, s1) = (offsets[j], offsets[j + 1]);
-                        (lb + j, &rows_all[s0..s1], &vals_all[s0..s1])
-                    }),
-                );
                 for j in 0..csc.ncols() {
-                    let c = lb + j;
-                    let col = csc.col(j);
-                    for (&row, &v) in col.row_indices().iter().zip(col.values()) {
+                    let (s0, s1) = (offsets[j], offsets[j + 1]);
+                    let (rows, vals) = (&rows_all[s0..s1], &vals_all[s0..s1]);
+                    profiles_by_cluster(
+                        &mut profiles,
+                        &labels,
+                        std::iter::once((lb + j, rows, vals)),
+                    );
+                    for (&row, &v) in rows.iter().zip(vals) {
                         let li = unseen_local[row];
                         if li != u32::MAX {
-                            obs[c].push((li, v));
-                            totals[li as usize] += v;
+                            obs[lb + j].push((li, v));
                         }
                     }
                 }
                 lb = ub;
             }
+            let totals: Vec<f32> = unseen
+                .iter()
+                .map(|&r| profiles.row(r).iter().sum::<f32>())
+                .collect();
 
-            let rho_dm = DMatrix::<f32>::from_row_slice(n_model, self.h, &self.rho);
+            let rho_dm = self.rho_matrix();
             let modules = self
                 .modules
                 .as_ref()
                 .map(|(pi, mu)| ModuleTables { pi, mu });
             let mut alignment = align_gene_axis(&AlignInputs {
                 rho: &rho_dm,
-                b_feat: &self.b_feat,
+                b_feat: Some(&self.b_feat),
                 modules,
                 new_to_train: &before_hide,
                 profiles_new: Some(&profiles),
-                k: init.k,
-                similarity_floor: init.similarity_floor,
+                knobs,
             });
-            let init_idx = alignment.with_status(GeneStatus::Initialized);
-            anyhow::ensure!(
-                init_idx.len() == unseen.len()
-                    && init_idx
-                        .iter()
-                        .zip(&unseen)
-                        .all(|(&g, &r)| alignment.union_to_new[g] == Some(r)),
-                "alignment and unseen-row bookkeeping disagree"
-            );
+            let init_idx: Vec<usize> = unseen
+                .iter()
+                .map(|&r| alignment.new_to_union[r].expect("an unseen gene is initialized"))
+                .collect();
             let init_rows = alignment.rows.select_rows(init_idx.iter());
             // A gene the query never expresses has no scale to match; give it the
             // smallest trained bias rather than 0, which would make it the most
@@ -421,8 +388,8 @@ impl BgeEmbedding {
                 alignment.with_status(GeneStatus::Missing).len(),
                 init_idx.len(),
                 n_diffuse,
-                init.k,
-                init.similarity_floor
+                knobs.k,
+                knobs.similarity_floor
             );
 
             // Pass 2: the initialized genes become observations. The comparable score
@@ -446,10 +413,8 @@ impl BgeEmbedding {
                     remap: &remap2,
                     projector: &projector2,
                     side: &side,
-                    partition: &partition,
                     n_model,
                     block,
-                    h: self.h,
                 })?;
             }
 
@@ -467,8 +432,6 @@ impl BgeEmbedding {
             );
             init_out = Some(InitOutcome {
                 alignment,
-                new_gene_names: new_genes.clone(),
-                unseen_rows: unseen,
                 scores,
                 n_clusters,
                 in_fit: init.in_fit,
@@ -494,13 +457,11 @@ struct ProjectAll<'a> {
     remap: &'a [Option<usize>],
     projector: &'a FrozenProjector<'a>,
     side: &'a FrozenSide<'a>,
-    partition: &'a [u32],
     /// Rows below this belong to the model's own genes and enter the score;
     /// rows at or above it are initialized genes, observed by the projector but
     /// not scored here.
     n_model: usize,
     block: usize,
-    h: usize,
 }
 
 struct ProjectAllOut {
@@ -512,10 +473,13 @@ struct ProjectAllOut {
 
 fn project_all(a: ProjectAll<'_>) -> anyhow::Result<ProjectAllOut> {
     let ntot = a.data_vec.num_columns();
+    let h = a.side.h;
+    // The exact normalizer: every model gene, so `partition_scale = 1`.
+    let partition: Vec<u32> = (0..a.n_model as u32).collect();
     let mut llik = Vec::with_capacity(ntot);
     let mut total = Vec::with_capacity(ntot);
     let mut b_cell = Vec::with_capacity(ntot);
-    let mut latent = Mat::zeros(ntot, a.h);
+    let mut latent = Mat::zeros(ntot, h);
     // ONE bar for the query. The projector advances it as its blocks step, so this
     // side never increments it: nesting a second bar under it (one per projection
     // call) is what the group loop used to do.
@@ -589,14 +553,14 @@ fn project_all(a: ProjectAll<'_>) -> anyhow::Result<ProjectAllOut> {
                 .zip(count.iter().copied())
                 .filter(|&(f, _)| f < n_model)
                 .collect();
-            let node = NodeTerm::new(&pos, a.partition, 1.0);
-            multinomial_ll(&e_cell[c * a.h..(c + 1) * a.h], &node, a.side)
+            let node = NodeTerm::new(&pos, &partition, 1.0);
+            multinomial_ll(&e_cell[c * h..(c + 1) * h], &node, a.side)
         }));
         // `e_cell` is row-major `[n_group, H]`; `Mat` is column-major, so this is a
         // transposing copy rather than a memcpy.
         for c in 0..n_group {
-            for j in 0..a.h {
-                latent[(group_lb + c, j)] = e_cell[c * a.h + j];
+            for j in 0..h {
+                latent[(group_lb + c, j)] = e_cell[c * h + j];
             }
         }
         group.clear();

--- a/senna/src/bge/score.rs
+++ b/senna/src/bge/score.rs
@@ -46,6 +46,49 @@ pub struct BgeEmbedding {
     pub b_feat: Vec<f32>,
     pub gene_names: Vec<Box<str>>,
     pub h: usize,
+    /// The learned-module tables `(π [D × M], μ [M × H])` when the run trained them —
+    /// what lets an unseen gene be initialized through its co-expression rather than
+    /// dropped. `None` for a plain run, where an unseen gene falls back to its
+    /// neighbours' row average.
+    pub modules: Option<(DMatrix<f32>, DMatrix<f32>)>,
+}
+
+/// How `predict` treats the new data's genes the model never saw.
+#[derive(Clone, Copy, Debug)]
+pub struct InitOpts {
+    /// `false` drops unseen genes, the pre-alignment behaviour.
+    pub enabled: bool,
+    /// Neighbours whose membership is averaged for an unseen gene.
+    pub k: usize,
+    /// Below this best cosine similarity an unseen gene takes the diffuse prior.
+    pub similarity_floor: f32,
+    /// Re-project every cell with the initialized genes as observations (pass 2).
+    /// Off, they are scored from the pass-1 latent and never move it.
+    pub in_fit: bool,
+}
+
+impl InitOpts {
+    pub const OFF: Self = Self {
+        enabled: false,
+        k: 10,
+        similarity_floor: 0.2,
+        in_fit: false,
+    };
+}
+
+/// What the alignment produced, for the writers.
+pub struct InitOutcome {
+    pub alignment: graph_embedding_util::transfer::GeneAlignment,
+    /// Row names of the NEW data (the alignment's `union_to_new` indexes these).
+    pub new_gene_names: Vec<Box<str>>,
+    /// New-data rows that were initialized, in alignment order.
+    pub unseen_rows: Vec<usize>,
+    /// Per-cell score on the initialized genes.
+    pub scores: Vec<super::transfer::InitScore>,
+    /// Pseudobulks the profiles were formed over.
+    pub n_clusters: usize,
+    /// Whether pass 2 ran, i.e. whether `latent` saw the initialized genes.
+    pub in_fit: bool,
 }
 
 pub struct BgeFit {
@@ -59,6 +102,11 @@ pub struct BgeFit {
     /// wanting held-out coordinates had to re-run the whole projection itself. It is the
     /// same object `{prefix}.cell_embedding.parquet` holds for the training cells.
     pub latent: Mat,
+    /// `[N]` per-cell intercept fitted alongside the latent.
+    pub b_cell: Vec<f32>,
+    /// The gene-axis alignment, when the query carried genes the model never saw
+    /// and initialization was on.
+    pub init: Option<InitOutcome>,
 }
 
 impl BgeEmbedding {
@@ -118,11 +166,48 @@ impl BgeEmbedding {
         let rho_rm = rho.mat.transpose().as_slice().to_vec();
         info!("bge model: {d} genes, H={h} (ρ {rho_path})");
 
+        // Module tables, when the run trained them. Rows must be the dictionary's genes
+        // in the dictionary's order: the alignment indexes π by training row.
+        let modules = match (
+            manifest.outputs.module_membership.as_deref(),
+            manifest.outputs.module_dictionary.as_deref(),
+        ) {
+            (Some(pi_rel), Some(mu_rel)) => {
+                let pi_path = run_manifest::resolve(&dir, pi_rel)
+                    .to_string_lossy()
+                    .into_owned();
+                let mu_path = run_manifest::resolve(&dir, mu_rel)
+                    .to_string_lossy()
+                    .into_owned();
+                let pi = DMatrix::<f32>::from_parquet(&pi_path)
+                    .with_context(|| format!("reading module membership {pi_path}"))?;
+                let mu = DMatrix::<f32>::from_parquet(&mu_path)
+                    .with_context(|| format!("reading module dictionary {mu_path}"))?;
+                anyhow::ensure!(
+                    pi.rows == rho.rows,
+                    "module membership genes disagree with the dictionary ({} vs {} rows)",
+                    pi.rows.len(),
+                    rho.rows.len()
+                );
+                anyhow::ensure!(
+                    mu.mat.ncols() == h && mu.mat.nrows() == pi.mat.ncols(),
+                    "module dictionary is {}×{} but π has {} modules and H={h}",
+                    mu.mat.nrows(),
+                    mu.mat.ncols(),
+                    pi.mat.ncols()
+                );
+                info!("bge model carries {} learned gene modules", pi.mat.ncols());
+                Some((pi.mat, mu.mat))
+            }
+            _ => None,
+        };
+
         Ok(Self {
             rho: rho_rm,
             b_feat: bias.mat.column(0).iter().copied().collect(),
             gene_names: rho.rows,
             h,
+            modules,
         })
     }
 
@@ -151,6 +236,27 @@ impl BgeEmbedding {
         qopts: &QueryNameOpts,
         dev: &Device,
     ) -> anyhow::Result<BgeFit> {
+        self.score_with_init(files, preload, block, qopts, InitOpts::OFF, dev)
+    }
+
+    /// [`Self::score`] with the gene-axis alignment: genes the model never saw are
+    /// initialized through the modules (see `super::transfer`) instead of dropped.
+    /// With `init.enabled == false`, or a query with no unseen genes, this is
+    /// byte-identical to [`Self::score`].
+    pub fn score_with_init(
+        &self,
+        files: &[Box<str>],
+        preload: bool,
+        block: usize,
+        qopts: &QueryNameOpts,
+        init: InitOpts,
+        dev: &Device,
+    ) -> anyhow::Result<BgeFit> {
+        use super::transfer::{profiles_by_cluster, score_initialized, union_remap, unseen_rows};
+        use graph_embedding_util::transfer::{
+            align_gene_axis, moment_matched_bias, AlignInputs, GeneStatus, ModuleTables,
+        };
+
         let loaded = read_data_on_shared_rows(ReadSharedRowsArgs {
             data_files: files.to_vec(),
             preload,
@@ -170,6 +276,9 @@ impl BgeEmbedding {
         // it exists to score — while `predict` passes `--min-gene-overlap`, which used to
         // be dropped here along with every `--feature-name-*` flag.
         crate::topic::eval::ensure_gene_coverage(&remap, qopts.min_overlap, "--feature-name-kind")?;
+        // The remap BEFORE the hide pass: the alignment must see a withheld model gene as
+        // matched (its row is kept, its counts are not), never as unseen.
+        let before_hide = remap.new_to_train.clone();
         // After the coverage gate, not before: the hidden genes are deliberately
         // withheld, so counting them as missing coverage would refuse every
         // ablated run. Driven from `qopts` rather than a separate parameter, so
@@ -177,6 +286,14 @@ impl BgeEmbedding {
         if let Some(hide) = qopts.hide.as_deref() {
             crate::topic::eval::hide_features(&mut remap, &new_genes, hide)?;
         }
+        let hidden_rows: std::collections::HashSet<usize> = (0..new_genes.len())
+            .filter(|&r| before_hide[r].is_some() && remap.new_to_train[r].is_none())
+            .collect();
+        let unseen: Vec<usize> = if init.enabled {
+            unseen_rows(&before_hide, &hidden_rows)
+        } else {
+            Vec::new()
+        };
 
         // The exact normalizer: every model gene, so `partition_scale = 1`.
         let partition: Vec<u32> = (0..n_model as u32).collect();
@@ -197,116 +314,315 @@ impl BgeEmbedding {
             dev,
         })?;
 
-        let ntot = data_vec.num_columns();
-        let mut llik = Vec::with_capacity(ntot);
-        let mut total = Vec::with_capacity(ntot);
-        let mut latent = Mat::zeros(ntot, self.h);
-        // ONE bar for the query. The projector advances it as its blocks step, so this
-        // side never increments it: nesting a second bar under it (one per projection
-        // call) is what the group loop used to do.
-        let bar = new_progress_bar(ntot as u64).with_message("scoring");
+        // Pass 1: every cell on the matched genes.
+        let mut pass = project_all(ProjectAll {
+            data_vec: &data_vec,
+            remap: &remap.new_to_train,
+            projector: &projector,
+            side: &side,
+            partition: &partition,
+            n_model,
+            block,
+            h: self.h,
+        })?;
 
-        // Columns are READ in `block`-sized slabs — that bound is the reader's — but they
-        // are PROJECTED in groups the engine sizes.
-        //
-        // The two are not the same thing and used to be conflated. `block` is
-        // `--minibatch-size`, default 500; the projection engine sizes its internal blocks
-        // from an activation budget of its own and takes thousands of cells at a time.
-        // Handing it 500 gave it exactly one under-sized block per call, so its per-step
-        // matmul ran on a short `M`. The fix used to be a byte budget guessed here, in
-        // nonzeros — a currency the engine never sees, aimed at a block size this crate
-        // cannot read. [`FrozenProjector::group_nodes`] is that number in the engine's own
-        // terms, and cutting the group EXACTLY there is what keeps every block full.
-        let group_nodes = projector.group_nodes();
-        let mut group = EdgeGroup::default();
-
-        let mut lb = 0usize;
-        while lb < ntot {
-            let group_lb = lb;
-            // Accumulate slabs until the group is full. The inner loop's exit condition
-            // IS the flush condition, so a part-group at the end needs no special case.
-            while lb < ntot && group.len() < group_nodes {
-                let ub = (lb + block).min(group_lb + group_nodes).min(ntot);
+        let mut init_out: Option<InitOutcome> = None;
+        if !unseen.is_empty() {
+            let n_cells = pass.latent.nrows();
+            let n_new = new_genes.len();
+            // Pseudobulks for the profiles: a clustering of the pass-1 latents, so a
+            // profile is a gene's expression across the cell states this model sees.
+            let n_clusters = (n_cells / 50).clamp(8, 256).min(n_cells.max(1));
+            let (_, labels) = matrix_util::principal_graph::kmeans_centroids_seeded(
+                &pass.latent,
+                n_clusters,
+                20,
+                0,
+            );
+            // One more pass over the columns: profiles over ALL new rows, plus each
+            // cell's counts on the unseen genes for the bias and the score.
+            let mut unseen_local = vec![u32::MAX; n_new];
+            for (i, &r) in unseen.iter().enumerate() {
+                unseen_local[r] = i as u32;
+            }
+            let mut obs: Vec<Vec<(u32, f32)>> = vec![Vec::new(); n_cells];
+            let mut totals = vec![0f32; unseen.len()];
+            let mut profiles = DMatrix::<f32>::zeros(n_new, n_clusters);
+            let mut lb = 0usize;
+            while lb < n_cells {
+                let ub = (lb + block).min(n_cells);
                 let csc = data_vec.read_columns_csc(lb..ub)?;
-                // One walk per cell yields both the remapped entries and the cell's
-                // total; the total used to be a third pass over the same nonzeros.
-                // Parallel per cell, matching the `multinomial_ll` pass below — the
-                // walks are independent, and an indexed range keeps them in cell order.
-                let (per_cell, totals): (Vec<Vec<(u32, f32)>>, Vec<f32>) = (0..csc.ncols())
-                    .into_par_iter()
-                    .map(|j| {
-                        let col = csc.col(j);
-                        let pos: Vec<(u32, f32)> = col
-                            .row_indices()
-                            .iter()
-                            .zip(col.values())
-                            .filter_map(|(&i, &v)| remap.new_to_train[i].map(|t| (t as u32, v)))
-                            .collect();
-                        let tot = pos.iter().map(|&(_, v)| v).sum::<f32>();
-                        (pos, tot)
-                    })
-                    .unzip();
-                drop(csc);
-
-                group.extend(&per_cell);
-                total.extend(totals);
+                // Raw CSC arrays sliced by offset: a column view would borrow a local.
+                let (offsets, rows_all, vals_all) =
+                    (csc.col_offsets(), csc.row_indices(), csc.values());
+                profiles_by_cluster(
+                    &mut profiles,
+                    &labels,
+                    (0..csc.ncols()).map(|j| {
+                        let (s0, s1) = (offsets[j], offsets[j + 1]);
+                        (lb + j, &rows_all[s0..s1], &vals_all[s0..s1])
+                    }),
+                );
+                for j in 0..csc.ncols() {
+                    let c = lb + j;
+                    let col = csc.col(j);
+                    for (&row, &v) in col.row_indices().iter().zip(col.values()) {
+                        let li = unseen_local[row];
+                        if li != u32::MAX {
+                            obs[c].push((li, v));
+                            totals[li as usize] += v;
+                        }
+                    }
+                }
                 lb = ub;
             }
 
-            let n_group = group.len();
-            let e_cell = project_group(&projector, &group, &bar)?;
-            // `multinomial_ll` walks the whole gene axis twice per cell for the
-            // normalizer, which makes it the dominant cost here — and it sat serial
-            // directly below `project_cells`, which is already rayon-parallel. Everything
-            // it reads is shared and immutable, so the map parallelizes as-is and stays in
-            // order. `NodeTerm` borrows an interleaved slice, so the split arrays are
-            // re-zipped into a per-cell temporary — a few thousand entries against a
-            // normalizer that touches the whole gene axis twice.
-            llik.par_extend((0..n_group).into_par_iter().map(|c| {
-                let (feat, count) = group.cell(c);
-                let pos: Vec<(u32, f32)> =
-                    feat.iter().copied().zip(count.iter().copied()).collect();
-                let node = NodeTerm::new(&pos, &partition, 1.0);
-                multinomial_ll(&e_cell[c * self.h..(c + 1) * self.h], &node, &side)
-            }));
-            // `e_cell` is row-major `[n_group, H]`; `Mat` is column-major, so this is a
-            // transposing copy rather than a memcpy.
-            for c in 0..n_group {
-                for j in 0..self.h {
-                    latent[(group_lb + c, j)] = e_cell[c * self.h + j];
-                }
+            let rho_dm = DMatrix::<f32>::from_row_slice(n_model, self.h, &self.rho);
+            let modules = self
+                .modules
+                .as_ref()
+                .map(|(pi, mu)| ModuleTables { pi, mu });
+            let mut alignment = align_gene_axis(&AlignInputs {
+                rho: &rho_dm,
+                b_feat: &self.b_feat,
+                modules,
+                new_to_train: &before_hide,
+                profiles_new: Some(&profiles),
+                k: init.k,
+                similarity_floor: init.similarity_floor,
+            });
+            let init_idx = alignment.with_status(GeneStatus::Initialized);
+            anyhow::ensure!(
+                init_idx.len() == unseen.len()
+                    && init_idx
+                        .iter()
+                        .zip(&unseen)
+                        .all(|(&g, &r)| alignment.union_to_new[g] == Some(r)),
+                "alignment and unseen-row bookkeeping disagree"
+            );
+            let init_rows = alignment.rows.select_rows(init_idx.iter());
+            // A gene the query never expresses has no scale to match; give it the
+            // smallest trained bias rather than 0, which would make it the most
+            // abundant gene in the partition.
+            let fallback = self.b_feat.iter().copied().fold(f32::INFINITY, f32::min);
+            let init_bias =
+                moment_matched_bias(&init_rows, &pass.latent, &pass.b_cell, &totals, fallback);
+            for (i, &g) in init_idx.iter().enumerate() {
+                alignment.bias[g] = init_bias[i];
             }
-            group.clear();
+            let n_diffuse = init_idx
+                .iter()
+                .filter(|&&g| alignment.provenance[g].as_ref().is_some_and(|p| p.diffuse))
+                .count();
+            info!(
+                "gene-axis alignment: {} matched, {} missing, {} initialized ({} diffuse) over \
+                 {n_clusters} pseudobulks, k={} floor={}",
+                alignment.with_status(GeneStatus::Matched).len(),
+                alignment.with_status(GeneStatus::Missing).len(),
+                init_idx.len(),
+                n_diffuse,
+                init.k,
+                init.similarity_floor
+            );
+
+            // Pass 2: the initialized genes become observations. The comparable score
+            // still normalizes over the model's genes only.
+            if init.in_fit {
+                let union_rm = alignment.rows.transpose().as_slice().to_vec();
+                let projector2 = FrozenProjector::new(&FrozenProjectionArgs {
+                    feat: &union_rm,
+                    b_feat: &alignment.bias,
+                    h: self.h,
+                    lambda: f64::from(PROJECTION_RIDGE_SGD),
+                    dev,
+                })?;
+                let remap2 = union_remap(&remap.new_to_train, &unseen, n_model);
+                info!(
+                    "pass 2: re-projecting every cell with the {} initialized genes observed",
+                    unseen.len()
+                );
+                pass = project_all(ProjectAll {
+                    data_vec: &data_vec,
+                    remap: &remap2,
+                    projector: &projector2,
+                    side: &side,
+                    partition: &partition,
+                    n_model,
+                    block,
+                    h: self.h,
+                })?;
+            }
+
+            // The null for the initialized genes is the query's own composition over
+            // them: there is no training marginal for a gene the model never saw.
+            let tot: f32 = totals.iter().sum::<f32>().max(1e-12);
+            let null_comp: Vec<f32> = totals.iter().map(|&t| t / tot).collect();
+            let scores = score_initialized(
+                &init_rows,
+                &init_bias,
+                &pass.latent,
+                &pass.b_cell,
+                &obs,
+                &null_comp,
+            );
+            init_out = Some(InitOutcome {
+                alignment,
+                new_gene_names: new_genes.clone(),
+                unseen_rows: unseen,
+                scores,
+                n_clusters,
+                in_fit: init.in_fit,
+            });
         }
-        bar.finish_and_clear();
 
         Ok(BgeFit {
             data_vec,
-            llik,
-            total,
-            latent,
+            llik: pass.llik,
+            total: pass.total,
+            latent: pass.latent,
+            b_cell: pass.b_cell,
+            init: init_out,
         })
     }
 }
 
-/// Project one group of cells onto the frozen side, returning `θ` row-major `[n, H]`.
-///
-/// The SAME block SGD the training run used for its own phase 2. The Newton/IRLS
-/// alternative fits a cell's observed features only and lets a ridge stand in for the
-/// log-partition, so it lands in a different space — and a train/test comparison whose
-/// two halves were projected differently measures the estimator gap as much as the model.
+/// One projection sweep over the query: every cell placed against `projector`
+/// through `remap`, scored by [`multinomial_ll`] on the model's own genes.
+struct ProjectAll<'a> {
+    data_vec: &'a SparseIoVec,
+    /// New-data row → row of `projector`'s dictionary.
+    remap: &'a [Option<usize>],
+    projector: &'a FrozenProjector<'a>,
+    side: &'a FrozenSide<'a>,
+    partition: &'a [u32],
+    /// Rows below this belong to the model's own genes and enter the score;
+    /// rows at or above it are initialized genes, observed by the projector but
+    /// not scored here.
+    n_model: usize,
+    block: usize,
+    h: usize,
+}
+
+struct ProjectAllOut {
+    latent: Mat,
+    b_cell: Vec<f32>,
+    llik: Vec<f32>,
+    total: Vec<f32>,
+}
+
+fn project_all(a: ProjectAll<'_>) -> anyhow::Result<ProjectAllOut> {
+    let ntot = a.data_vec.num_columns();
+    let mut llik = Vec::with_capacity(ntot);
+    let mut total = Vec::with_capacity(ntot);
+    let mut b_cell = Vec::with_capacity(ntot);
+    let mut latent = Mat::zeros(ntot, a.h);
+    // ONE bar for the query. The projector advances it as its blocks step, so this
+    // side never increments it: nesting a second bar under it (one per projection
+    // call) is what the group loop used to do.
+    let bar = new_progress_bar(ntot as u64).with_message("scoring");
+
+    // Columns are READ in `block`-sized slabs — that bound is the reader's — but they
+    // are PROJECTED in groups the engine sizes.
+    //
+    // The two are not the same thing and used to be conflated. `block` is
+    // `--minibatch-size`, default 500; the projection engine sizes its internal blocks
+    // from an activation budget of its own and takes thousands of cells at a time.
+    // Handing it 500 gave it exactly one under-sized block per call, so its per-step
+    // matmul ran on a short `M`. The fix used to be a byte budget guessed here, in
+    // nonzeros — a currency the engine never sees, aimed at a block size this crate
+    // cannot read. [`FrozenProjector::group_nodes`] is that number in the engine's own
+    // terms, and cutting the group EXACTLY there is what keeps every block full.
+    let group_nodes = a.projector.group_nodes();
+    let mut group = EdgeGroup::default();
+
+    let mut lb = 0usize;
+    while lb < ntot {
+        let group_lb = lb;
+        // Accumulate slabs until the group is full. The inner loop's exit condition
+        // IS the flush condition, so a part-group at the end needs no special case.
+        while lb < ntot && group.len() < group_nodes {
+            let ub = (lb + a.block).min(group_lb + group_nodes).min(ntot);
+            let csc = a.data_vec.read_columns_csc(lb..ub)?;
+            // One walk per cell yields both the remapped entries and the cell's
+            // total; the total used to be a third pass over the same nonzeros.
+            // Parallel per cell, matching the `multinomial_ll` pass below — the
+            // walks are independent, and an indexed range keeps them in cell order.
+            let (per_cell, totals): (Vec<Vec<(u32, f32)>>, Vec<f32>) = (0..csc.ncols())
+                .into_par_iter()
+                .map(|j| {
+                    let col = csc.col(j);
+                    let pos: Vec<(u32, f32)> = col
+                        .row_indices()
+                        .iter()
+                        .zip(col.values())
+                        .filter_map(|(&i, &v)| a.remap[i].map(|t| (t as u32, v)))
+                        .collect();
+                    let tot = pos.iter().map(|&(_, v)| v).sum::<f32>();
+                    (pos, tot)
+                })
+                .unzip();
+            drop(csc);
+
+            group.extend(&per_cell);
+            total.extend(totals);
+            lb = ub;
+        }
+
+        let n_group = group.len();
+        let proj = project_group(a.projector, &group, &bar)?;
+        let e_cell = proj.theta;
+        b_cell.extend_from_slice(&proj.b_node);
+        // `multinomial_ll` walks the whole gene axis twice per cell for the
+        // normalizer, which makes it the dominant cost here — and it sat serial
+        // directly below `project_cells`, which is already rayon-parallel. Everything
+        // it reads is shared and immutable, so the map parallelizes as-is and stays in
+        // order. `NodeTerm` borrows an interleaved slice, so the split arrays are
+        // re-zipped into a per-cell temporary — a few thousand entries against a
+        // normalizer that touches the whole gene axis twice. Initialized genes (rows at
+        // or past `n_model`) are left out of the score: it stays over the model's genes.
+        let n_model = a.n_model as u32;
+        llik.par_extend((0..n_group).into_par_iter().map(|c| {
+            let (feat, count) = group.cell(c);
+            let pos: Vec<(u32, f32)> = feat
+                .iter()
+                .copied()
+                .zip(count.iter().copied())
+                .filter(|&(f, _)| f < n_model)
+                .collect();
+            let node = NodeTerm::new(&pos, a.partition, 1.0);
+            multinomial_ll(&e_cell[c * a.h..(c + 1) * a.h], &node, a.side)
+        }));
+        // `e_cell` is row-major `[n_group, H]`; `Mat` is column-major, so this is a
+        // transposing copy rather than a memcpy.
+        for c in 0..n_group {
+            for j in 0..a.h {
+                latent[(group_lb + c, j)] = e_cell[c * a.h + j];
+            }
+        }
+        group.clear();
+    }
+    bar.finish_and_clear();
+
+    Ok(ProjectAllOut {
+        latent,
+        b_cell,
+        llik,
+        total,
+    })
+}
+
 fn project_group(
     projector: &FrozenProjector,
     group: &EdgeGroup,
     bar: &indicatif::ProgressBar,
-) -> anyhow::Result<Vec<f32>> {
+) -> anyhow::Result<graph_embedding_util::fit::FrozenProjection> {
     let nodes: Vec<(u32, &[u32], &[f32])> = (0..group.len())
         .map(|j| {
             let (feat, count) = group.cell(j);
             (j as u32, feat, count)
         })
         .collect();
-    Ok(projector.project(&nodes, group.len(), bar)?.theta)
+    projector.project(&nodes, group.len(), bar)
 }
 
 /// One projection group's remapped edges, flat and split.

--- a/senna/src/bge/transfer.rs
+++ b/senna/src/bge/transfer.rs
@@ -1,0 +1,83 @@
+//! Gene-axis alignment for `senna predict` on a bge model: the pure pieces
+//! between the projector and the writer, so each is testable without a backend.
+//!
+//! The flow in `BgeEmbedding::score`:
+//! 1. pass 1 — project every cell on the MATCHED genes (as before);
+//! 2. cluster the pass-1 latents into pseudobulks and accumulate the new data's
+//!    per-gene profiles over them ([`profiles_by_cluster`]);
+//! 3. align the gene axes ([`graph_embedding_util::transfer::align_gene_axis`]):
+//!    unseen genes get a membership-initialized row, then a moment-matched bias;
+//! 4. optional pass 2 — re-project with the initialized genes as observations
+//!    ([`union_remap`] maps the new rows onto the union axis);
+//! 5. score the initialized genes on their OWN column ([`score_initialized`]):
+//!    a prior's score is never mixed into the comparable per-gene score.
+
+use crate::embed_common::Mat;
+use nalgebra::DMatrix;
+use std::collections::HashSet;
+
+/// Rows of the NEW data that matched no training gene by name, excluding the
+/// rows deliberately withheld by `--ablate-features` — those are model genes
+/// being tested, not unseen ones. `new_to_train` must be the remap BEFORE the
+/// hide pass zeroed the hidden rows.
+pub(crate) fn unseen_rows(new_to_train: &[Option<usize>], hidden_rows: &HashSet<usize>) -> Vec<usize> {
+    let _ = (new_to_train, hidden_rows);
+    todo!("unseen_rows")
+}
+
+/// Per-gene count profiles over pseudobulks defined by a cell clustering:
+/// `profiles[g, s] = Σ_{c: labels[c] = s} x_cg`, `[n_genes × n_clusters]`.
+/// `cells` yields `(cell, feature rows, counts)` on the NEW data's row axis.
+pub(crate) fn profiles_by_cluster<'a>(
+    n_genes: usize,
+    n_clusters: usize,
+    labels: &[usize],
+    cells: impl Iterator<Item = (usize, &'a [u32], &'a [f32])>,
+) -> DMatrix<f32> {
+    let _ = (n_genes, n_clusters, labels, cells);
+    todo!("profiles_by_cluster")
+}
+
+/// New-data row → union-axis index: a matched row keeps its training position,
+/// an unseen row `unseen[i]` becomes `n_train + i`, and any other row (hidden,
+/// or dropped) maps to `None`.
+pub(crate) fn union_remap(
+    new_to_train: &[Option<usize>],
+    unseen: &[usize],
+    n_train: usize,
+) -> Vec<Option<usize>> {
+    let _ = (new_to_train, unseen, n_train);
+    todo!("union_remap")
+}
+
+/// Per-cell score of the INITIALIZED genes, in the same multinomial-per-count
+/// form as the comparable score, kept in its own column.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct InitScore {
+    /// Observed counts on the initialized genes.
+    pub count: f32,
+    /// `Σ_g x_g log p_g / Σ_g x_g` with `p` the model's composition over the
+    /// initialized genes; `NaN` when the cell has no counts on them.
+    pub llik_per_count: f32,
+    /// The same under `null_comp`.
+    pub null_llik_per_count: f32,
+}
+
+/// `rows` / `bias` are the initialized genes' `[U × H]` / `[U]`; `theta` `[N × H]`
+/// and `b_cell` `[N]` are the latents the rates are evaluated at; `obs[c]` lists
+/// `(local initialized index, count)` for cell `c`; `null_comp` is a composition
+/// over the `U` genes.
+pub(crate) fn score_initialized(
+    rows: &DMatrix<f32>,
+    bias: &[f32],
+    theta: &Mat,
+    b_cell: &[f32],
+    obs: &[Vec<(u32, f32)>],
+    null_comp: &[f32],
+) -> Vec<InitScore> {
+    let _ = (rows, bias, theta, b_cell, obs, null_comp);
+    todo!("score_initialized")
+}
+
+#[cfg(test)]
+mod tests;

--- a/senna/src/bge/transfer.rs
+++ b/senna/src/bge/transfer.rs
@@ -20,9 +20,16 @@ use std::collections::HashSet;
 /// rows deliberately withheld by `--ablate-features` — those are model genes
 /// being tested, not unseen ones. `new_to_train` must be the remap BEFORE the
 /// hide pass zeroed the hidden rows.
-pub(crate) fn unseen_rows(new_to_train: &[Option<usize>], hidden_rows: &HashSet<usize>) -> Vec<usize> {
-    let _ = (new_to_train, hidden_rows);
-    todo!("unseen_rows")
+pub(crate) fn unseen_rows(
+    new_to_train: &[Option<usize>],
+    hidden_rows: &HashSet<usize>,
+) -> Vec<usize> {
+    new_to_train
+        .iter()
+        .enumerate()
+        .filter(|(n, t)| t.is_none() && !hidden_rows.contains(n))
+        .map(|(n, _)| n)
+        .collect()
 }
 
 /// Per-gene count profiles over pseudobulks defined by a cell clustering:
@@ -34,8 +41,14 @@ pub(crate) fn profiles_by_cluster<'a>(
     labels: &[usize],
     cells: impl Iterator<Item = (usize, &'a [u32], &'a [f32])>,
 ) -> DMatrix<f32> {
-    let _ = (n_genes, n_clusters, labels, cells);
-    todo!("profiles_by_cluster")
+    let mut p = DMatrix::<f32>::zeros(n_genes, n_clusters);
+    for (c, feats, counts) in cells {
+        let s = labels[c];
+        for (&f, &x) in feats.iter().zip(counts) {
+            p[(f as usize, s)] += x;
+        }
+    }
+    p
 }
 
 /// New-data row → union-axis index: a matched row keeps its training position,
@@ -46,8 +59,11 @@ pub(crate) fn union_remap(
     unseen: &[usize],
     n_train: usize,
 ) -> Vec<Option<usize>> {
-    let _ = (new_to_train, unseen, n_train);
-    todo!("union_remap")
+    let mut out: Vec<Option<usize>> = new_to_train.to_vec();
+    for (i, &row) in unseen.iter().enumerate() {
+        out[row] = Some(n_train + i);
+    }
+    out
 }
 
 /// Per-cell score of the INITIALIZED genes, in the same multinomial-per-count
@@ -75,8 +91,47 @@ pub(crate) fn score_initialized(
     obs: &[Vec<(u32, f32)>],
     null_comp: &[f32],
 ) -> Vec<InitScore> {
-    let _ = (rows, bias, theta, b_cell, obs, null_comp);
-    todo!("score_initialized")
+    let (u, h) = (rows.nrows(), rows.ncols());
+    let floor = f64::from(matrix_util::agreement::PROB_FLOOR);
+    let log_null: Vec<f64> = null_comp
+        .iter()
+        .map(|&q| f64::from(q).max(floor).ln())
+        .collect();
+    (0..theta.nrows())
+        .map(|c| {
+            let count: f32 = obs[c].iter().map(|&(_, x)| x).sum();
+            if count <= 0.0 {
+                return InitScore {
+                    count: 0.0,
+                    llik_per_count: f32::NAN,
+                    null_llik_per_count: f32::NAN,
+                };
+            }
+            // Composition of the model's rates over the initialized genes; the
+            // cell bias is a common factor and cancels.
+            let logits: Vec<f64> = (0..u)
+                .map(|g| {
+                    let s: f32 = (0..h).map(|j| rows[(g, j)] * theta[(c, j)]).sum::<f32>()
+                        + bias[g]
+                        + b_cell[c];
+                    f64::from(s)
+                })
+                .collect();
+            let m = logits.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            let lse = logits.iter().map(|l| (l - m).exp()).sum::<f64>().ln() + m;
+            let (mut ll, mut nl) = (0f64, 0f64);
+            for &(g, x) in &obs[c] {
+                let x = f64::from(x);
+                ll += x * (logits[g as usize] - lse).max(floor.ln());
+                nl += x * log_null[g as usize];
+            }
+            InitScore {
+                count,
+                llik_per_count: (ll / f64::from(count)) as f32,
+                null_llik_per_count: (nl / f64::from(count)) as f32,
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/senna/src/bge/transfer.rs
+++ b/senna/src/bge/transfer.rs
@@ -14,23 +14,6 @@
 
 use crate::embed_common::Mat;
 use nalgebra::DMatrix;
-use std::collections::HashSet;
-
-/// Rows of the NEW data that matched no training gene by name, excluding the
-/// rows deliberately withheld by `--ablate-features` — those are model genes
-/// being tested, not unseen ones. `new_to_train` must be the remap BEFORE the
-/// hide pass zeroed the hidden rows.
-pub(crate) fn unseen_rows(
-    new_to_train: &[Option<usize>],
-    hidden_rows: &HashSet<usize>,
-) -> Vec<usize> {
-    new_to_train
-        .iter()
-        .enumerate()
-        .filter(|(n, t)| t.is_none() && !hidden_rows.contains(n))
-        .map(|(n, _)| n)
-        .collect()
-}
 
 /// Accumulate per-gene count profiles over pseudobulks defined by a cell
 /// clustering into `profiles` (`[n_genes × n_clusters]`):
@@ -90,13 +73,17 @@ pub(crate) fn score_initialized(
     obs: &[Vec<(u32, f32)>],
     null_comp: &[f32],
 ) -> Vec<InitScore> {
-    let (u, h) = (rows.nrows(), rows.ncols());
+    use rayon::prelude::*;
     let floor = f64::from(matrix_util::agreement::PROB_FLOOR);
     let log_null: Vec<f64> = null_comp
         .iter()
         .map(|&q| f64::from(q).max(floor).ln())
         .collect();
+    // One gemm for every cell's logits over the initialized genes; the cell bias
+    // is a common factor and cancels in the composition.
+    let logits = graph_embedding_util::transfer::log_rates(theta, rows, bias, b_cell); // [N × U]
     (0..theta.nrows())
+        .into_par_iter()
         .map(|c| {
             let count: f32 = obs[c].iter().map(|&(_, x)| x).sum();
             if count <= 0.0 {
@@ -106,22 +93,14 @@ pub(crate) fn score_initialized(
                     null_llik_per_count: f32::NAN,
                 };
             }
-            // Composition of the model's rates over the initialized genes; the
-            // cell bias is a common factor and cancels.
-            let logits: Vec<f64> = (0..u)
-                .map(|g| {
-                    let s: f32 = (0..h).map(|j| rows[(g, j)] * theta[(c, j)]).sum::<f32>()
-                        + bias[g]
-                        + b_cell[c];
-                    f64::from(s)
-                })
-                .collect();
-            let m = logits.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-            let lse = logits.iter().map(|l| (l - m).exp()).sum::<f64>().ln() + m;
+            let row = logits.row(c);
+            let m = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let lse =
+                f64::from(row.iter().map(|&l| (l - m).exp()).sum::<f32>()).ln() + f64::from(m);
             let (mut ll, mut nl) = (0f64, 0f64);
             for &(g, x) in &obs[c] {
                 let x = f64::from(x);
-                ll += x * (logits[g as usize] - lse).max(floor.ln());
+                ll += x * (f64::from(row[g as usize]) - lse).max(floor.ln());
                 nl += x * log_null[g as usize];
             }
             InitScore {
@@ -151,76 +130,26 @@ pub(crate) fn write_init_outputs(
     fit: &super::score::BgeFit,
     emit_rates: bool,
 ) -> anyhow::Result<()> {
-    use graph_embedding_util::transfer::GeneStatus;
+    use graph_embedding_util::transfer::{log_rates, write_alignment_table, GeneStatus};
     use log::info;
-    use matrix_util::parquet::{write_named_table, Column};
     use matrix_util::traits::IoOps;
 
     let Some(init) = fit.init.as_ref() else {
         return Ok(());
     };
     let al = &init.alignment;
-    let n_union = al.n_union();
-    let names: Vec<Box<str>> = (0..n_union)
-        .map(|g| match (al.union_to_train[g], al.union_to_new[g]) {
-            (Some(t), _) => model.gene_names[t].clone(),
-            (None, Some(n)) => init.new_gene_names[n].clone(),
-            (None, None) => Box::from("?"),
-        })
-        .collect();
-    let status: Vec<Box<str>> = al
-        .status
-        .iter()
-        .map(|s| {
-            Box::from(match s {
-                GeneStatus::Matched => "matched",
-                GeneStatus::Missing => "missing",
-                GeneStatus::Initialized => "initialized",
-                GeneStatus::Dropped => "dropped",
-            })
-        })
-        .collect();
-    let similarity: Vec<f32> = al
-        .provenance
-        .iter()
-        .map(|p| p.as_ref().map_or(f32::NAN, |p| p.best_similarity))
-        .collect();
-    let diffuse: Vec<i32> = al
-        .provenance
-        .iter()
-        .map(|p| i32::from(p.as_ref().is_some_and(|p| p.diffuse)))
-        .collect();
-    let neighbours: Vec<Box<str>> = al
-        .provenance
-        .iter()
-        .map(|p| {
-            Box::from(
-                p.as_ref()
-                    .map(|p| {
-                        p.neighbours
-                            .iter()
-                            .map(|&t| model.gene_names[t].to_string())
-                            .collect::<Vec<_>>()
-                            .join(",")
-                    })
-                    .unwrap_or_default()
-                    .as_str(),
-            )
+    let new_names = fit.data_vec.row_names()?;
+    let names: Vec<Box<str>> = (0..al.n_union())
+        .map(|g| {
+            if g < al.n_train {
+                model.gene_names[g].clone()
+            } else {
+                new_names[al.union_to_new[g].expect("a new-only union gene")].clone()
+            }
         })
         .collect();
     let path = format!("{out}.gene_alignment.parquet");
-    write_named_table(
-        &path,
-        "gene",
-        &names,
-        &[
-            (Box::from("status"), Column::Str(&status)),
-            (Box::from("best_similarity"), Column::F32(&similarity)),
-            (Box::from("diffuse"), Column::I32(&diffuse)),
-            (Box::from("neighbours"), Column::Str(&neighbours)),
-            (Box::from("bias"), Column::F32(&al.bias)),
-        ],
-    )?;
+    write_alignment_table(&path, &names, &model.gene_names, al)?;
     info!("Wrote {path}");
 
     let cells = fit.data_vec.column_names()?;
@@ -241,14 +170,13 @@ pub(crate) fn write_init_outputs(
             Box::from("init_null_llik_per_count"),
         ]),
     )?;
-    let scored: Vec<&super::transfer::InitScore> =
-        init.scores.iter().filter(|s| s.count > 0.0).collect();
+    let scored: Vec<&InitScore> = init.scores.iter().filter(|s| s.count > 0.0).collect();
     let mean = |f: &dyn Fn(&InitScore) -> f32| {
         scored.iter().map(|s| f(s)).sum::<f32>() / scored.len().max(1) as f32
     };
     info!(
         "Wrote {path}: {} initialized genes over {} pseudobulks{}, {} cells scored, llik/count {:.4} vs query-composition null {:.4} (gain {:+.4})",
-        init.unseen_rows.len(),
+        al.with_status(GeneStatus::Initialized).len(),
         init.n_clusters,
         if init.in_fit { " (observed in pass 2)" } else { "" },
         scored.len(),
@@ -258,21 +186,12 @@ pub(crate) fn write_init_outputs(
     );
 
     if emit_rates {
-        let genes: Vec<usize> = (0..n_union)
+        let genes: Vec<usize> = (0..al.n_union())
             .filter(|&g| matches!(al.status[g], GeneStatus::Missing | GeneStatus::Initialized))
             .collect();
-        let h = al.rows.ncols();
-        let mut rates = Mat::zeros(n, genes.len());
-        for (j, &g) in genes.iter().enumerate() {
-            for c in 0..n {
-                let s: f32 = (0..h)
-                    .map(|k| al.rows[(g, k)] * fit.latent[(c, k)])
-                    .sum::<f32>()
-                    + al.bias[g]
-                    + fit.b_cell[c];
-                rates[(c, j)] = s.exp();
-            }
-        }
+        let rows = al.rows.select_rows(genes.iter());
+        let bias: Vec<f32> = genes.iter().map(|&g| al.bias[g]).collect();
+        let rates = log_rates(&fit.latent, &rows, &bias, &fit.b_cell).map(f32::exp);
         let cols: Vec<Box<str>> = genes.iter().map(|&g| names[g].clone()).collect();
         let path = format!("{out}.gene_rates.parquet");
         rates.to_parquet_with_names(&path, (Some(&cells), Some("cell")), Some(&cols))?;

--- a/senna/src/bge/transfer.rs
+++ b/senna/src/bge/transfer.rs
@@ -32,23 +32,22 @@ pub(crate) fn unseen_rows(
         .collect()
 }
 
-/// Per-gene count profiles over pseudobulks defined by a cell clustering:
-/// `profiles[g, s] = Σ_{c: labels[c] = s} x_cg`, `[n_genes × n_clusters]`.
-/// `cells` yields `(cell, feature rows, counts)` on the NEW data's row axis.
+/// Accumulate per-gene count profiles over pseudobulks defined by a cell
+/// clustering into `profiles` (`[n_genes × n_clusters]`):
+/// `profiles[g, s] += Σ_{c: labels[c] = s} x_cg`. `cells` yields
+/// `(cell, feature rows, counts)` on the NEW data's row axis; call once per
+/// column block.
 pub(crate) fn profiles_by_cluster<'a>(
-    n_genes: usize,
-    n_clusters: usize,
+    profiles: &mut DMatrix<f32>,
     labels: &[usize],
-    cells: impl Iterator<Item = (usize, &'a [u32], &'a [f32])>,
-) -> DMatrix<f32> {
-    let mut p = DMatrix::<f32>::zeros(n_genes, n_clusters);
+    cells: impl Iterator<Item = (usize, &'a [usize], &'a [f32])>,
+) {
     for (c, feats, counts) in cells {
         let s = labels[c];
         for (&f, &x) in feats.iter().zip(counts) {
-            p[(f as usize, s)] += x;
+            profiles[(f, s)] += x;
         }
     }
-    p
 }
 
 /// New-data row → union-axis index: a matched row keeps its training position,
@@ -132,6 +131,154 @@ pub(crate) fn score_initialized(
             }
         })
         .collect()
+}
+
+/// The alignment outputs of a bge `predict`, written only when the query carried
+/// genes the model never saw:
+///
+/// * `{out}.gene_alignment.parquet` — one row per union gene: status, best
+///   profile similarity, whether the diffuse prior was used, the neighbours' names,
+///   and the bias (trained or moment-matched). This is the provenance every reader
+///   of an initialized row is entitled to.
+/// * `{out}.init_genes.parquet` — per cell: counts on the initialized genes and
+///   their multinomial nats per count against the query's own composition, in
+///   their own columns, never mixed into `predictive.parquet`.
+/// * `{out}.gene_rates.parquet` (opt-in) — per cell, the predicted Poisson rate of
+///   every missing and initialized gene, `exp(ρ_g·θ_c + a_g + b_c)`.
+pub(crate) fn write_init_outputs(
+    out: &str,
+    model: &super::score::BgeEmbedding,
+    fit: &super::score::BgeFit,
+    emit_rates: bool,
+) -> anyhow::Result<()> {
+    use graph_embedding_util::transfer::GeneStatus;
+    use log::info;
+    use matrix_util::parquet::{write_named_table, Column};
+    use matrix_util::traits::IoOps;
+
+    let Some(init) = fit.init.as_ref() else {
+        return Ok(());
+    };
+    let al = &init.alignment;
+    let n_union = al.n_union();
+    let names: Vec<Box<str>> = (0..n_union)
+        .map(|g| match (al.union_to_train[g], al.union_to_new[g]) {
+            (Some(t), _) => model.gene_names[t].clone(),
+            (None, Some(n)) => init.new_gene_names[n].clone(),
+            (None, None) => Box::from("?"),
+        })
+        .collect();
+    let status: Vec<Box<str>> = al
+        .status
+        .iter()
+        .map(|s| {
+            Box::from(match s {
+                GeneStatus::Matched => "matched",
+                GeneStatus::Missing => "missing",
+                GeneStatus::Initialized => "initialized",
+                GeneStatus::Dropped => "dropped",
+            })
+        })
+        .collect();
+    let similarity: Vec<f32> = al
+        .provenance
+        .iter()
+        .map(|p| p.as_ref().map_or(f32::NAN, |p| p.best_similarity))
+        .collect();
+    let diffuse: Vec<i32> = al
+        .provenance
+        .iter()
+        .map(|p| i32::from(p.as_ref().is_some_and(|p| p.diffuse)))
+        .collect();
+    let neighbours: Vec<Box<str>> = al
+        .provenance
+        .iter()
+        .map(|p| {
+            Box::from(
+                p.as_ref()
+                    .map(|p| {
+                        p.neighbours
+                            .iter()
+                            .map(|&t| model.gene_names[t].to_string())
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    })
+                    .unwrap_or_default()
+                    .as_str(),
+            )
+        })
+        .collect();
+    let path = format!("{out}.gene_alignment.parquet");
+    write_named_table(
+        &path,
+        "gene",
+        &names,
+        &[
+            (Box::from("status"), Column::Str(&status)),
+            (Box::from("best_similarity"), Column::F32(&similarity)),
+            (Box::from("diffuse"), Column::I32(&diffuse)),
+            (Box::from("neighbours"), Column::Str(&neighbours)),
+            (Box::from("bias"), Column::F32(&al.bias)),
+        ],
+    )?;
+    info!("Wrote {path}");
+
+    let cells = fit.data_vec.column_names()?;
+    let n = init.scores.len();
+    let mut sc = Mat::zeros(n, 3);
+    for (i, s) in init.scores.iter().enumerate() {
+        sc[(i, 0)] = s.count;
+        sc[(i, 1)] = s.llik_per_count;
+        sc[(i, 2)] = s.null_llik_per_count;
+    }
+    let path = format!("{out}.init_genes.parquet");
+    sc.to_parquet_with_names(
+        &path,
+        (Some(&cells), Some("cell")),
+        Some(&[
+            Box::from("init_count"),
+            Box::from("init_llik_per_count"),
+            Box::from("init_null_llik_per_count"),
+        ]),
+    )?;
+    let scored: Vec<&super::transfer::InitScore> =
+        init.scores.iter().filter(|s| s.count > 0.0).collect();
+    let mean = |f: &dyn Fn(&InitScore) -> f32| {
+        scored.iter().map(|s| f(s)).sum::<f32>() / scored.len().max(1) as f32
+    };
+    info!(
+        "Wrote {path}: {} initialized genes over {} pseudobulks{}, {} cells scored, llik/count {:.4} vs query-composition null {:.4} (gain {:+.4})",
+        init.unseen_rows.len(),
+        init.n_clusters,
+        if init.in_fit { " (observed in pass 2)" } else { "" },
+        scored.len(),
+        mean(&|s| s.llik_per_count),
+        mean(&|s| s.null_llik_per_count),
+        mean(&|s| s.llik_per_count - s.null_llik_per_count),
+    );
+
+    if emit_rates {
+        let genes: Vec<usize> = (0..n_union)
+            .filter(|&g| matches!(al.status[g], GeneStatus::Missing | GeneStatus::Initialized))
+            .collect();
+        let h = al.rows.ncols();
+        let mut rates = Mat::zeros(n, genes.len());
+        for (j, &g) in genes.iter().enumerate() {
+            for c in 0..n {
+                let s: f32 = (0..h)
+                    .map(|k| al.rows[(g, k)] * fit.latent[(c, k)])
+                    .sum::<f32>()
+                    + al.bias[g]
+                    + fit.b_cell[c];
+                rates[(c, j)] = s.exp();
+            }
+        }
+        let cols: Vec<Box<str>> = genes.iter().map(|&g| names[g].clone()).collect();
+        let path = format!("{out}.gene_rates.parquet");
+        rates.to_parquet_with_names(&path, (Some(&cells), Some("cell")), Some(&cols))?;
+        info!("Wrote {path} ({} missing + initialized genes)", genes.len());
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/senna/src/bge/transfer/tests.rs
+++ b/senna/src/bge/transfer/tests.rs
@@ -1,17 +1,6 @@
 use super::*;
 
 #[test]
-fn unseen_rows_exclude_matched_and_hidden() {
-    // new rows: 0 matched, 1 unseen, 2 hidden (matched before the hide), 3 unseen, 4 matched
-    let before_hide = vec![Some(3), None, Some(7), None, Some(1)];
-    let hidden: HashSet<usize> = [2usize].into_iter().collect();
-    assert_eq!(unseen_rows(&before_hide, &hidden), vec![1, 3]);
-    // A hidden row that was ALSO unmatched is still not "unseen": it was withheld.
-    let hidden2: HashSet<usize> = [1usize, 2].into_iter().collect();
-    assert_eq!(unseen_rows(&before_hide, &hidden2), vec![3]);
-}
-
-#[test]
 fn profiles_sum_counts_per_cluster() {
     let labels = vec![0usize, 1, 0];
     let f0: Vec<usize> = vec![0, 2];

--- a/senna/src/bge/transfer/tests.rs
+++ b/senna/src/bge/transfer/tests.rs
@@ -14,16 +14,24 @@ fn unseen_rows_exclude_matched_and_hidden() {
 #[test]
 fn profiles_sum_counts_per_cluster() {
     let labels = vec![0usize, 1, 0];
-    let f0: Vec<u32> = vec![0, 2];
+    let f0: Vec<usize> = vec![0, 2];
     let c0: Vec<f32> = vec![1.0, 2.0];
-    let f1: Vec<u32> = vec![1];
+    let f1: Vec<usize> = vec![1];
     let c1: Vec<f32> = vec![5.0];
-    let f2: Vec<u32> = vec![0, 1];
+    let f2: Vec<usize> = vec![0, 1];
     let c2: Vec<f32> = vec![3.0, 4.0];
-    let cells = vec![(0usize, &f0[..], &c0[..]), (1, &f1[..], &c1[..]), (2, &f2[..], &c2[..])];
-    let p = profiles_by_cluster(3, 2, &labels, cells.into_iter());
-    assert_eq!(p.nrows(), 3);
-    assert_eq!(p.ncols(), 2);
+    let mut p = DMatrix::<f32>::zeros(3, 2);
+    // Two blocks, to show accumulation across calls.
+    profiles_by_cluster(
+        &mut p,
+        &labels,
+        vec![(0usize, &f0[..], &c0[..])].into_iter(),
+    );
+    profiles_by_cluster(
+        &mut p,
+        &labels,
+        vec![(1usize, &f1[..], &c1[..]), (2, &f2[..], &c2[..])].into_iter(),
+    );
     assert_eq!(p[(0, 0)], 4.0); // gene 0: cells 0 and 2 → 1 + 3
     assert_eq!(p[(1, 0)], 4.0); // gene 1: cell 2
     assert_eq!(p[(1, 1)], 5.0); // gene 1: cell 1
@@ -57,7 +65,11 @@ fn initialized_score_is_a_multinomial_per_count() {
     let p = [0.25f32, 0.75];
     let want = (1.0 * p[0].ln() + 3.0 * p[1].ln()) / 4.0;
     assert_eq!(s[0].count, 4.0);
-    assert!((s[0].llik_per_count - want).abs() < 1e-6, "{} vs {want}", s[0].llik_per_count);
+    assert!(
+        (s[0].llik_per_count - want).abs() < 1e-6,
+        "{} vs {want}",
+        s[0].llik_per_count
+    );
     assert!((s[0].null_llik_per_count - want).abs() < 1e-6);
     assert_eq!(s[1].count, 0.0);
     assert!(s[1].llik_per_count.is_nan());

--- a/senna/src/bge/transfer/tests.rs
+++ b/senna/src/bge/transfer/tests.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+#[test]
+fn unseen_rows_exclude_matched_and_hidden() {
+    // new rows: 0 matched, 1 unseen, 2 hidden (matched before the hide), 3 unseen, 4 matched
+    let before_hide = vec![Some(3), None, Some(7), None, Some(1)];
+    let hidden: HashSet<usize> = [2usize].into_iter().collect();
+    assert_eq!(unseen_rows(&before_hide, &hidden), vec![1, 3]);
+    // A hidden row that was ALSO unmatched is still not "unseen": it was withheld.
+    let hidden2: HashSet<usize> = [1usize, 2].into_iter().collect();
+    assert_eq!(unseen_rows(&before_hide, &hidden2), vec![3]);
+}
+
+#[test]
+fn profiles_sum_counts_per_cluster() {
+    let labels = vec![0usize, 1, 0];
+    let f0: Vec<u32> = vec![0, 2];
+    let c0: Vec<f32> = vec![1.0, 2.0];
+    let f1: Vec<u32> = vec![1];
+    let c1: Vec<f32> = vec![5.0];
+    let f2: Vec<u32> = vec![0, 1];
+    let c2: Vec<f32> = vec![3.0, 4.0];
+    let cells = vec![(0usize, &f0[..], &c0[..]), (1, &f1[..], &c1[..]), (2, &f2[..], &c2[..])];
+    let p = profiles_by_cluster(3, 2, &labels, cells.into_iter());
+    assert_eq!(p.nrows(), 3);
+    assert_eq!(p.ncols(), 2);
+    assert_eq!(p[(0, 0)], 4.0); // gene 0: cells 0 and 2 → 1 + 3
+    assert_eq!(p[(1, 0)], 4.0); // gene 1: cell 2
+    assert_eq!(p[(1, 1)], 5.0); // gene 1: cell 1
+    assert_eq!(p[(2, 0)], 2.0);
+    assert_eq!(p[(2, 1)], 0.0);
+}
+
+#[test]
+fn union_remap_places_unseen_after_training_genes_and_drops_the_rest() {
+    let new_to_train = vec![Some(3), None, None, None, Some(1)];
+    let unseen = vec![1usize, 3]; // row 2 is hidden/dropped
+    let m = union_remap(&new_to_train, &unseen, 10);
+    assert_eq!(m, vec![Some(3), Some(10), None, Some(11), Some(1)]);
+}
+
+/// Rates equal to the observed composition score the composition's own entropy,
+/// and equal the null when the null is that same composition.
+#[test]
+fn initialized_score_is_a_multinomial_per_count() {
+    let h = 2;
+    // Two initialized genes with rows that make the rates proportional to (1, 3)
+    // for a cell with θ = (0, 0): exp(bias) = (1, 3).
+    let rows = DMatrix::<f32>::zeros(2, h);
+    let bias = [0f32, 3f32.ln()];
+    let theta = Mat::zeros(2, h);
+    let b_cell = [0.7f32, -0.2];
+    // cell 0 observes (1, 3) → composition (0.25, 0.75); cell 1 observes nothing.
+    let obs = vec![vec![(0u32, 1.0f32), (1, 3.0)], vec![]];
+    let null = [0.25f32, 0.75];
+    let s = score_initialized(&rows, &bias, &theta, &b_cell, &obs, &null);
+    let p = [0.25f32, 0.75];
+    let want = (1.0 * p[0].ln() + 3.0 * p[1].ln()) / 4.0;
+    assert_eq!(s[0].count, 4.0);
+    assert!((s[0].llik_per_count - want).abs() < 1e-6, "{} vs {want}", s[0].llik_per_count);
+    assert!((s[0].null_llik_per_count - want).abs() < 1e-6);
+    assert_eq!(s[1].count, 0.0);
+    assert!(s[1].llik_per_count.is_nan());
+    assert!(s[1].null_llik_per_count.is_nan());
+    // The cell bias cancels in the composition: changing it leaves the score.
+    let s2 = score_initialized(&rows, &bias, &theta, &[5.0, 5.0], &obs, &null);
+    assert!((s2[0].llik_per_count - s[0].llik_per_count).abs() < 1e-6);
+    // A latent that favours gene 1 raises its share and lowers the score for
+    // a cell whose counts favour gene 0.
+    let rows2 = DMatrix::<f32>::from_row_slice(2, h, &[0.0, 0.0, 2.0, 0.0]);
+    let theta2 = Mat::from_row_slice(2, h, &[1.0, 0.0, 1.0, 0.0]);
+    let obs2 = vec![vec![(0u32, 3.0f32), (1, 1.0)], vec![]];
+    let s3 = score_initialized(&rows2, &bias, &theta2, &b_cell, &obs2, &null);
+    let s4 = score_initialized(&rows, &bias, &theta, &b_cell, &obs2, &null);
+    assert!(s3[0].llik_per_count < s4[0].llik_per_count);
+}

--- a/senna/src/fne.rs
+++ b/senna/src/fne.rs
@@ -235,6 +235,8 @@ pub fn fit_fne(args: &FneArgs) -> anyhow::Result<()> {
         dictionary_empirical_suffix: None,
         feature_embedding_suffix: Some("feature_embedding.parquet"),
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: None,
         cell_embedding_suffix: None,
         default_colour_by: "cluster",

--- a/senna/src/gem/run.rs
+++ b/senna/src/gem/run.rs
@@ -433,6 +433,8 @@ fn run_gem_genes_bge(
             // the positive competing against its negatives in one distribution
             // separates cell types better than the per-pair logistic SGNS loss).
             nce_objective: args.model.nce_objective.to_ge(),
+            // Learned gene modules are not offered on the β-sharing path yet.
+            gene_modules: None,
             // Per-gene softmax feature gate — the SuSiE variational spike-and-slab
             // single-effect, ALWAYS ON. Gates β_g (identity) AND, independently, δ_g
             // (velocity → velocity_selection); null absorber + categorical + Gaussian
@@ -876,6 +878,8 @@ fn run_gem_genes_bge(
         // on that manifold and goes to `feature_loading` instead.
         feature_embedding_suffix: Some("feature_embedding.parquet"),
         feature_loading_suffix: Some("beta_feature_embedding.parquet"),
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         velocity_suffix: Some("velocity.parquet"),
         velocity_factor_suffix: None,
         delta_feature_embedding_suffix: Some("delta_feature_embedding.parquet"),

--- a/senna/src/gem_encoder/run.rs
+++ b/senna/src/gem_encoder/run.rs
@@ -231,6 +231,8 @@ pub fn run_gem_encoder(args: &GemEncoderArgs) -> anyhow::Result<()> {
         cell_embedding_suffix: Some("cell_embedding.parquet"),
         feature_embedding_suffix: Some("feature_embedding.parquet"),
         feature_loading_suffix: Some("raw_feature_embedding.parquet"),
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         velocity_suffix: Some("velocity.parquet"),
         velocity_factor_suffix: Some("velocity_factor.parquet"),
         delta_feature_embedding_suffix: Some("delta_feature_embedding.parquet"),

--- a/senna/src/impute.rs
+++ b/senna/src/impute.rs
@@ -399,6 +399,13 @@ fn predict_matching_latents(
     info!("Projecting new data through the model (predict → {predict_prefix})");
     let predict_args = PredictArgs {
         ablate_features: None,
+        // impute takes bge's latent from pass 1 on the matched genes; unseen genes are
+        // scored and rate-imputed by predict's own outputs, not through the retrieval.
+        no_init_genes: true,
+        init_neighbours: 10,
+        init_similarity_floor: 0.2,
+        init_genes_in_fit: false,
+        emit_gene_rates: false,
         null_from: None,
         eval_features: None,
         data_files: args.data_files.clone(),

--- a/senna/src/impute.rs
+++ b/senna/src/impute.rs
@@ -405,8 +405,8 @@ fn predict_matching_latents(
         // per-cell rates, which become the model-imputed table below — retrieval
         // cannot reach a gene the reference has no counts for.
         no_init_genes: false,
-        init_neighbours: 10,
-        init_similarity_floor: 0.2,
+        init_neighbours: graph_embedding_util::transfer::DEFAULT_INIT_NEIGHBOURS,
+        init_similarity_floor: graph_embedding_util::transfer::DEFAULT_SIMILARITY_FLOOR,
         init_genes_in_fit: false,
         emit_gene_rates: true,
         null_from: None,
@@ -547,8 +547,10 @@ fn write_model_imputed_genes(args: &ImputeArgs, new_cell_names: &[Box<str>]) -> 
     if !(std::path::Path::new(&al_path).exists() && std::path::Path::new(&rates_path).exists()) {
         return Ok(());
     }
-    let al_genes = matrix_util::parquet::read_parquet_string_column(&al_path, 0)?;
-    let al_status = matrix_util::parquet::read_parquet_string_column(&al_path, 1)?;
+    let mut cols =
+        matrix_util::parquet::read_parquet_string_columns_by_name(&al_path, &["gene", "status"])?;
+    let al_status = cols.pop().expect("status column");
+    let al_genes = cols.pop().expect("gene column");
     let rates = <Mat as IoOps>::from_parquet(&rates_path)?;
     anyhow::ensure!(
         rates.mat.nrows() == new_cell_names.len(),
@@ -590,7 +592,10 @@ pub(crate) fn model_imputed_columns(
     let keep: Vec<(Box<str>, usize)> = alignment_genes
         .iter()
         .zip(alignment_status)
-        .filter(|(_, st)| st.as_ref() == "initialized")
+        .filter(|(_, st)| {
+            graph_embedding_util::transfer::GeneStatus::parse(st)
+                == Some(graph_embedding_util::transfer::GeneStatus::Initialized)
+        })
         .filter_map(|(g, _)| col_of.get(g.as_ref()).map(|&j| (g.clone(), j)))
         .collect();
     let mut out = Mat::zeros(rates.nrows(), keep.len());

--- a/senna/src/impute.rs
+++ b/senna/src/impute.rs
@@ -379,6 +379,7 @@ pub fn impute_model(args: &ImputeArgs) -> anyhow::Result<()> {
         Some(&ref_gene_names),
     )?;
     info!("Wrote imputed {n_new}× {g_ref} matrix to {imputed_path}");
+    write_model_imputed_genes(args, &new_cell_names)?;
 
     Ok(())
 }
@@ -399,13 +400,15 @@ fn predict_matching_latents(
     info!("Projecting new data through the model (predict → {predict_prefix})");
     let predict_args = PredictArgs {
         ablate_features: None,
-        // impute takes bge's latent from pass 1 on the matched genes; unseen genes are
-        // scored and rate-imputed by predict's own outputs, not through the retrieval.
-        no_init_genes: true,
+        // bge: the latent comes from pass 1 on the matched genes (unchanged), and
+        // predict also initializes the genes the model never saw and writes their
+        // per-cell rates, which become the model-imputed table below — retrieval
+        // cannot reach a gene the reference has no counts for.
+        no_init_genes: false,
         init_neighbours: 10,
         init_similarity_floor: 0.2,
         init_genes_in_fit: false,
-        emit_gene_rates: false,
+        emit_gene_rates: true,
         null_from: None,
         eval_features: None,
         data_files: args.data_files.clone(),
@@ -532,6 +535,41 @@ fn svd_matching_latents(
     Ok((new_cell_names, theta_new, theta_ref))
 }
 
+/// The genes the model never saw, imputed by the MODEL rather than retrieved:
+/// read back predict's alignment and rate tables (written under the
+/// `predict_tmp` prefix when the query carried unseen genes), keep the
+/// initialized columns, and write `{out}.imputed_model_genes.parquet`. Absent
+/// tables — a plain run, or no unseen gene — write nothing.
+fn write_model_imputed_genes(args: &ImputeArgs, new_cell_names: &[Box<str>]) -> anyhow::Result<()> {
+    let prefix = format!("{}.predict_tmp", args.out);
+    let al_path = format!("{prefix}.gene_alignment.parquet");
+    let rates_path = format!("{prefix}.gene_rates.parquet");
+    if !(std::path::Path::new(&al_path).exists() && std::path::Path::new(&rates_path).exists()) {
+        return Ok(());
+    }
+    let al_genes = matrix_util::parquet::read_parquet_string_column(&al_path, 0)?;
+    let al_status = matrix_util::parquet::read_parquet_string_column(&al_path, 1)?;
+    let rates = <Mat as IoOps>::from_parquet(&rates_path)?;
+    anyhow::ensure!(
+        rates.mat.nrows() == new_cell_names.len(),
+        "{rates_path}: {} rows for {} query cells",
+        rates.mat.nrows(),
+        new_cell_names.len()
+    );
+    let (names, m) = model_imputed_columns(&al_genes, &al_status, &rates.cols, &rates.mat);
+    if names.is_empty() {
+        return Ok(());
+    }
+    let path = format!("{}.imputed_model_genes.parquet", args.out);
+    m.to_parquet_with_names(&path, (Some(new_cell_names), Some("cell")), Some(&names))?;
+    info!(
+        "Wrote {path}: {} genes the model never saw, imputed from their initialized rows \
+         (provenance in {al_path}); they are NOT in the retrieved matrix",
+        names.len()
+    );
+    Ok(())
+}
+
 /// The model-imputed columns for the genes the model never saw: from predict's
 /// `gene_alignment` (status per union gene) and `gene_rates` (per-cell rates of
 /// the missing and initialized genes), keep exactly the `initialized` columns, in
@@ -544,8 +582,22 @@ pub(crate) fn model_imputed_columns(
     rate_genes: &[Box<str>],
     rates: &Mat,
 ) -> (Vec<Box<str>>, Mat) {
-    let _ = (alignment_genes, alignment_status, rate_genes, rates);
-    todo!("model_imputed_columns")
+    let col_of: std::collections::HashMap<&str, usize> = rate_genes
+        .iter()
+        .enumerate()
+        .map(|(j, g)| (g.as_ref(), j))
+        .collect();
+    let keep: Vec<(Box<str>, usize)> = alignment_genes
+        .iter()
+        .zip(alignment_status)
+        .filter(|(_, st)| st.as_ref() == "initialized")
+        .filter_map(|(g, _)| col_of.get(g.as_ref()).map(|&j| (g.clone(), j)))
+        .collect();
+    let mut out = Mat::zeros(rates.nrows(), keep.len());
+    for (k, (_, j)) in keep.iter().enumerate() {
+        out.set_column(k, &rates.column(*j));
+    }
+    (keep.into_iter().map(|(g, _)| g).collect(), out)
 }
 
 #[cfg(test)]

--- a/senna/src/impute.rs
+++ b/senna/src/impute.rs
@@ -532,6 +532,22 @@ fn svd_matching_latents(
     Ok((new_cell_names, theta_new, theta_ref))
 }
 
+/// The model-imputed columns for the genes the model never saw: from predict's
+/// `gene_alignment` (status per union gene) and `gene_rates` (per-cell rates of
+/// the missing and initialized genes), keep exactly the `initialized` columns, in
+/// the alignment's order. Retrieval cannot impute these genes — the reference has
+/// no counts for them — so they are written as their own table with their own
+/// provenance rather than mixed into the retrieved matrix.
+pub(crate) fn model_imputed_columns(
+    alignment_genes: &[Box<str>],
+    alignment_status: &[Box<str>],
+    rate_genes: &[Box<str>],
+    rates: &Mat,
+) -> (Vec<Box<str>>, Mat) {
+    let _ = (alignment_genes, alignment_status, rate_genes, rates);
+    todo!("model_imputed_columns")
+}
+
 #[cfg(test)]
 #[path = "impute/tests.rs"]
 mod tests;

--- a/senna/src/impute/tests.rs
+++ b/senna/src/impute/tests.rs
@@ -237,3 +237,36 @@ fn svd_projection_refuses_a_query_sharing_no_gene() -> anyhow::Result<()> {
     .is_err());
     Ok(())
 }
+
+/// Only the `initialized` genes come through, in the alignment's order, and the
+/// column is looked up by NAME in the rates table (whose order is the writer's).
+#[test]
+fn model_imputed_columns_keep_only_initialized_genes_by_name() {
+    let al_genes: Vec<Box<str>> = ["A", "B", "U1", "U2"].iter().map(|s| (*s).into()).collect();
+    let al_status: Vec<Box<str>> = ["matched", "missing", "initialized", "initialized"]
+        .iter()
+        .map(|s| (*s).into())
+        .collect();
+    // rates hold missing + initialized, in a different order than the alignment.
+    let rate_genes: Vec<Box<str>> = ["U2", "B", "U1"].iter().map(|s| (*s).into()).collect();
+    let rates = Mat::from_row_slice(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let (names, m) = model_imputed_columns(&al_genes, &al_status, &rate_genes, &rates);
+    assert_eq!(names, vec![Box::<str>::from("U1"), Box::<str>::from("U2")]);
+    assert_eq!(m.nrows(), 2);
+    assert_eq!(m.ncols(), 2);
+    assert_eq!(m[(0, 0)], 3.0); // U1, cell 0
+    assert_eq!(m[(0, 1)], 1.0); // U2, cell 0
+    assert_eq!(m[(1, 0)], 6.0);
+    assert_eq!(m[(1, 1)], 4.0);
+}
+
+/// No initialized gene → an empty table, not an error.
+#[test]
+fn model_imputed_columns_are_empty_without_initialized_genes() {
+    let al_genes: Vec<Box<str>> = ["A"].iter().map(|s| (*s).into()).collect();
+    let al_status: Vec<Box<str>> = ["matched"].iter().map(|s| (*s).into()).collect();
+    let (names, m) = model_imputed_columns(&al_genes, &al_status, &[], &Mat::zeros(2, 0));
+    assert!(names.is_empty());
+    assert_eq!(m.nrows(), 2);
+    assert_eq!(m.ncols(), 0);
+}

--- a/senna/src/joint_topic.rs
+++ b/senna/src/joint_topic.rs
@@ -507,6 +507,8 @@ pub fn fit_joint_topic_model(args: &JointTopicArgs) -> anyhow::Result<()> {
         dictionary_empirical_suffix: None,
         feature_embedding_suffix: None,
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: Some("dictionary.parquet"),
         cell_embedding_suffix: None,
         default_colour_by: "cluster",

--- a/senna/src/main.rs
+++ b/senna/src/main.rs
@@ -674,7 +674,9 @@ enum Commands {
                       \n\
                       Families: topic, masked-topic, masked-sbp, masked-vae, vae.\n\
                       For svd this re-fits on the union — there are no weights to\n\
-                      warm-start. bge is unsupported: it saves no checkpoint."
+                      warm-start. bge carries its learned gene modules (membership and\n\
+                      module dictionary) as the warm start; genes new to the union\n\
+                      axis are initialized through them."
     )]
     Update(UpdateArgs),
 

--- a/senna/src/masked_topic.rs
+++ b/senna/src/masked_topic.rs
@@ -1474,6 +1474,8 @@ pub(crate) fn fit_masked_model(args: &MaskedTopicArgs, head: LatentHead) -> anyh
         dictionary_empirical_suffix: Some("dictionary_empirical.parquet"),
         feature_embedding_suffix: Some("feature_embedding.parquet"),
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: Some("dictionary.parquet"),
         cell_embedding_suffix: None,
         default_colour_by: "cluster",

--- a/senna/src/predict.rs
+++ b/senna/src/predict.rs
@@ -270,6 +270,47 @@ pub struct PredictArgs {
     )]
     pub(crate) ablate_features: Option<Box<str>>,
 
+    /// bge only. Genes in the query that the model never saw are placed through the
+    /// learned modules (their membership is the similarity-weighted mean of the k
+    /// most similar matched genes' memberships, their bias is moment-matched to the
+    /// pass-1 latents) instead of being dropped. `--no-init-genes` restores the drop.
+    #[arg(
+        long,
+        help = "bge: drop genes the model never saw instead of initializing them through the modules"
+    )]
+    pub(crate) no_init_genes: bool,
+
+    #[arg(
+        long,
+        default_value_t = 10,
+        value_name = "K",
+        help = "bge: matched genes whose memberships are averaged to initialize an unseen gene"
+    )]
+    pub(crate) init_neighbours: usize,
+
+    #[arg(
+        long,
+        default_value_t = 0.2,
+        value_name = "S",
+        help = "bge: below this best profile similarity an unseen gene takes the diffuse prior"
+    )]
+    pub(crate) init_similarity_floor: f32,
+
+    #[arg(
+        long,
+        help = "bge: re-project every cell with the initialized genes as observations (pass 2)",
+        long_help = "bge: after initialization, run a second projection in which the initialized\n\
+                     genes' counts are observed. Off, they are scored from the pass-1 latent and\n\
+                     never move it. The comparable score still normalizes over the model's genes."
+    )]
+    pub(crate) init_genes_in_fit: bool,
+
+    #[arg(
+        long,
+        help = "bge: write {out}.gene_rates.parquet, per-cell predicted rates of the missing and initialized genes"
+    )]
+    pub(crate) emit_gene_rates: bool,
+
     /// Training data, read once to build the null every arm is scored against.
     ///
     /// The floor is the count-weighted gene composition of this data — what a
@@ -449,11 +490,17 @@ fn predict_bge(args: &PredictArgs) -> anyhow::Result<()> {
 
     let model = crate::bge::score::BgeEmbedding::open(&args.model)?;
     let qopts = args.query_name_opts()?;
-    let fit = model.score(
+    let fit = model.score_with_init(
         &args.data_files,
         args.preload_data,
         args.minibatch_size,
         &qopts,
+        crate::bge::score::InitOpts {
+            enabled: !args.no_init_genes,
+            k: args.init_neighbours,
+            similarity_floor: args.init_similarity_floor,
+            in_fit: args.init_genes_in_fit,
+        },
         &args.resolve_device()?,
     )?;
 
@@ -479,6 +526,7 @@ fn predict_bge(args: &PredictArgs) -> anyhow::Result<()> {
         &fit.total,
         agreement.as_ref(),
     )?;
+    crate::bge::transfer::write_init_outputs(&args.out, &model, &fit, args.emit_gene_rates)?;
 
     Ok(())
 }

--- a/senna/src/predict.rs
+++ b/senna/src/predict.rs
@@ -282,7 +282,7 @@ pub struct PredictArgs {
 
     #[arg(
         long,
-        default_value_t = 10,
+        default_value_t = graph_embedding_util::transfer::DEFAULT_INIT_NEIGHBOURS,
         value_name = "K",
         help = "bge: matched genes whose memberships are averaged to initialize an unseen gene"
     )]
@@ -290,7 +290,7 @@ pub struct PredictArgs {
 
     #[arg(
         long,
-        default_value_t = 0.2,
+        default_value_t = graph_embedding_util::transfer::DEFAULT_SIMILARITY_FLOOR,
         value_name = "S",
         help = "bge: below this best profile similarity an unseen gene takes the diffuse prior"
     )]
@@ -496,9 +496,10 @@ fn predict_bge(args: &PredictArgs) -> anyhow::Result<()> {
         args.minibatch_size,
         &qopts,
         crate::bge::score::InitOpts {
-            enabled: !args.no_init_genes,
-            k: args.init_neighbours,
-            similarity_floor: args.init_similarity_floor,
+            align: (!args.no_init_genes).then_some(graph_embedding_util::transfer::AlignKnobs {
+                k: args.init_neighbours,
+                similarity_floor: args.init_similarity_floor,
+            }),
             in_fit: args.init_genes_in_fit,
         },
         &args.resolve_device()?,

--- a/senna/src/resolve_embedding_space.rs
+++ b/senna/src/resolve_embedding_space.rs
@@ -458,6 +458,8 @@ pub fn resolve_embedding_space(args: &RestArgs) -> anyhow::Result<()> {
         dictionary_empirical_suffix: None,
         feature_embedding_suffix: Some("feature_embedding.parquet"),
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: None,
         cell_embedding_suffix: Some("cell_embedding.parquet"),
         default_colour_by: "cluster",

--- a/senna/src/run_manifest.rs
+++ b/senna/src/run_manifest.rs
@@ -585,6 +585,16 @@ pub struct RunOutputs {
     /// consumers such as `senna deconvolve` had to demand `--skip-etm`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feature_loading: Option<String>,
+    /// `{out}.module_membership.parquet`: gene × M learned-module membership
+    /// (rows on the simplex with exact zeros). Present only for a run trained with
+    /// gene modules; `feature_loading` still holds the composed row, so a reader
+    /// that ignores this slot loses nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module_membership: Option<String>,
+    /// `{out}.module_dictionary.parquet`: M × H module vectors, the `μ` in
+    /// `ρ_g = Σ_m π_gm μ_m + r_g`. Paired with `module_membership`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module_dictionary: Option<String>,
     /// `{out}.cell_embedding.parquet` — N × H per-cell embedding Z in the
     /// SAME H-space as `feature_embedding` ρ.
     ///
@@ -1153,6 +1163,10 @@ pub struct RunDescription<'a> {
     /// [`RunOutputs::feature_loading`] for why this is separate from
     /// `feature_embedding_suffix`.
     pub feature_loading_suffix: Option<&'a str>,
+    /// e.g. `"module_membership.parquet"` for a gene-module run; `None` to omit.
+    pub module_membership_suffix: Option<&'a str>,
+    /// e.g. `"module_dictionary.parquet"`; paired with the membership.
+    pub module_dictionary_suffix: Option<&'a str>,
     /// Suffix after `{basename}.` for the log-simplex topic dictionary β, e.g.
     /// `"dictionary.parquet"`. Set by kinds whose dictionary IS a
     /// `log_softmax`-over-genes simplex; `None` for signed loadings, which stay
@@ -1244,6 +1258,12 @@ pub fn write_run_manifest(desc: &RunDescription<'_>) -> anyhow::Result<()> {
     }
     if let Some(suf) = desc.feature_loading_suffix {
         m.outputs.feature_loading = Some(format!("{basename}.{suf}"));
+    }
+    if let Some(suf) = desc.module_membership_suffix {
+        m.outputs.module_membership = Some(format!("{basename}.{suf}"));
+    }
+    if let Some(suf) = desc.module_dictionary_suffix {
+        m.outputs.module_dictionary = Some(format!("{basename}.{suf}"));
     }
     if let Some(suf) = desc.softmax_dictionary_suffix {
         m.outputs.softmax_dictionary = Some(format!("{basename}.{suf}"));

--- a/senna/src/svd/fit.rs
+++ b/senna/src/svd/fit.rs
@@ -346,6 +346,8 @@ pub fn fit_svd(args: &SvdArgs) -> anyhow::Result<()> {
         dictionary_empirical_suffix: None,
         feature_embedding_suffix: None,
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: None,
         cell_embedding_suffix: None,
         // SVD produces no topic / cluster labels on its own; users

--- a/senna/src/svd/fit_joint.rs
+++ b/senna/src/svd/fit_joint.rs
@@ -244,6 +244,8 @@ pub fn fit_joint_svd(args: &JointSvdArgs) -> anyhow::Result<()> {
         dictionary_empirical_suffix: None,
         feature_embedding_suffix: None,
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: None,
         cell_embedding_suffix: None,
         default_colour_by: "cluster",

--- a/senna/src/topic/cmd.rs
+++ b/senna/src/topic/cmd.rs
@@ -777,6 +777,8 @@ fn write_topic_manifest(
         dictionary_empirical_suffix: Some("dictionary_empirical.parquet"),
         feature_embedding_suffix: None,
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: Some("dictionary.parquet"),
         cell_embedding_suffix: None,
         default_colour_by: "cluster",

--- a/senna/src/vae.rs
+++ b/senna/src/vae.rs
@@ -469,6 +469,8 @@ pub fn fit_vae_model(args: &VaeArgs) -> anyhow::Result<()> {
         dictionary_empirical_suffix: None,
         feature_embedding_suffix: None,
         feature_loading_suffix: None,
+        module_membership_suffix: None,
+        module_dictionary_suffix: None,
         softmax_dictionary_suffix: None,
         cell_embedding_suffix: None,
         default_colour_by: "cluster",


### PR DESCRIPTION
## Summary

Gene modules in geu embeddings, gene-axis initialization of unseen genes, and a fix to the multi-batch collapse that every pooled batch correction depends on.

**Gene modules (geu, `senna bge` default on, `pinto cage` opt-in).** Each gene row is a sparsemax-mixed sum of module vectors plus a residual, trained by an exact cell-module softmax term (detached target) with within-module negatives and gene dropout at pooling time. Held-out ablation on the bone-marrow reference: the base bge scored below the training marginal, modules bring it level; gene rows become lineage-coherent.

**Initialization of unseen genes (`senna predict`, `senna impute`, `senna update`, `pinto cage --gene-init-mode membership`, `pinto predict`).** Genes absent from a fitted model are placed by similarity-weighted module membership of their nearest matched genes (`graph-embedding-util::transfer::align_gene_axis`), scored separately, and carried into the update warm start. `data-beans subset-rows --exact-names` added (prefix matching was always on).

**Collapse fix (data-beans-alg).** The pooled multi-batch fit had a fixed point at `mu_adjusted = counterfactual`, placing each batch's pseudobulks in the other batches' frame. The model is now one batch-free rate with both the observed and the counterfactual side Poisson at that rate; delta is identified by the counterfactual's per-batch source mass (new statistic `matched_bs`) and pinned per gene to geometric mean one over the frame batches (anchors when present). Planted tests document the old defect and the new contract.

**Phase 2 (geu).** Cells divide their counts by the batch-level fold before the Poisson-MAP projection; the per-pseudobulk `mu_residual` divide is removed. `senna bge` writes `{out}.batch_gene_fold.parquet` and the phase-1 pseudobulk embeddings with their batches.

## Behaviour changes to know about

- Every default `senna bge` run now trains modules (`--no-gene-modules` opts out).
- `senna update` on an older bge manifest re-fits with modules on.
- Every consumer of the pooled multi-batch collapse sees different `mu_adjusted`, `mu_residual` and `delta`; senna topic and svd were re-measured and improve on cross-study data, masked-topic and the gem encoder were not.
- A Ctrl+C'd bge run writes no `feature_loading.parquet` (pre-existing).

## Test plan

- [x] geu, data-beans-alg, data-beans, auxiliary-data, senna and pinto test suites pass; clippy clean on all six with `--all-targets`; `cargo fmt --check` clean.
- [x] Simulated topics, the bone-marrow reference (single study, two-study pair, five-study joint and incremental update chain), and a Visium section were used to validate modules, initialization, and the batch fixes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nz9pZdsjj8vN5PUM3DBHyV
